### PR TITLE
fix: preserve bond price precision (4 decimal places)

### DIFF
--- a/apps/frontend/src/lib/format-amount.test.ts
+++ b/apps/frontend/src/lib/format-amount.test.ts
@@ -1,0 +1,28 @@
+import { formatAmount } from "@wealthfolio/ui";
+import { describe, expect, it } from "vitest";
+
+describe("formatAmount", () => {
+  it("formats integer with default 2 decimals", () => {
+    expect(formatAmount(1234, "USD")).toBe("$1,234.00");
+  });
+
+  it("rounds to 2 decimals by default", () => {
+    expect(formatAmount(1234.5678, "USD")).toBe("$1,234.57");
+  });
+
+  it("shows exactly 4 decimals when precision=4", () => {
+    expect(formatAmount(0.9192, "USD", false, 4)).toBe("0.9192");
+  });
+
+  it("pads trailing zeros when precision=4 (columns align)", () => {
+    expect(formatAmount(0.92, "USD", false, 4)).toBe("0.9200");
+  });
+
+  it("pads with zeros for a 3-decimal value at precision=4", () => {
+    expect(formatAmount(0.918, "USD", false, 4)).toBe("0.9180");
+  });
+
+  it("returns - for null", () => {
+    expect(formatAmount(null, "USD")).toBe("-");
+  });
+});

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -253,6 +253,31 @@ const DECIMAL_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
 
 const decimalFormatter = new Intl.NumberFormat("en-US", DECIMAL_FORMAT_OPTIONS);
 const currencyFormatterCache = new Map<string, Intl.NumberFormat>();
+const precisionFormatterCache = new Map<string, Intl.NumberFormat>();
+
+const getPrecisionFormatter = (
+  precision: number,
+  currency?: string,
+  displayCurrency?: boolean,
+): Intl.NumberFormat => {
+  const key = `${currency ?? ""}|${displayCurrency}|${precision}`;
+  if (precisionFormatterCache.has(key)) return precisionFormatterCache.get(key)!;
+  const opts: Intl.NumberFormatOptions = {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  };
+  let formatter: Intl.NumberFormat;
+  try {
+    formatter =
+      displayCurrency && currency
+        ? new Intl.NumberFormat("en-US", { style: "currency", currency, ...opts })
+        : new Intl.NumberFormat("en-US", opts);
+  } catch {
+    formatter = new Intl.NumberFormat("en-US", opts);
+  }
+  precisionFormatterCache.set(key, formatter);
+  return formatter;
+};
 
 const getCurrencyFormatter = (currency: string) => {
   const normalizedCurrency = currency?.toUpperCase?.() ?? "USD";
@@ -304,6 +329,7 @@ export function formatAmount(
   amount: number | string | null | undefined,
   currency: string,
   displayCurrency = true,
+  precision?: number,
 ) {
   if (amount == null) return "-";
   const numericAmount = typeof amount === "string" ? Number(amount) : amount;
@@ -311,6 +337,13 @@ export function formatAmount(
   const displayAmount = Math.abs(numericAmount) < 0.005 ? 0 : numericAmount;
   const rawCurrency = currency ?? "USD";
   const isPenceCurrency = rawCurrency === "GBp" || rawCurrency === "GBX";
+
+  if (precision != null && precision !== DISPLAY_DECIMAL_PRECISION) {
+    const showCcy = displayCurrency && !isPenceCurrency;
+    const formatter = getPrecisionFormatter(precision, showCcy ? rawCurrency : undefined, showCcy);
+    const result = formatter.format(numericAmount);
+    return isPenceCurrency && displayCurrency ? `${result}p` : result;
+  }
 
   if (isPenceCurrency) {
     const formattedNumber = decimalFormatter.format(displayAmount);

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -1020,7 +1020,7 @@ export function AssetEditSheet({
                                 latestQuote.close,
                                 latestQuote.currency,
                                 true,
-                                asset?.kind === "BOND" ? 4 : undefined,
+                                asset?.instrumentType === "BOND" ? 4 : undefined,
                               )}
                             </p>
                             <p className="text-muted-foreground text-xs">Latest price</p>

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -1016,7 +1016,12 @@ export function AssetEditSheet({
                         <div className="grid grid-cols-3 gap-4 text-center">
                           <div>
                             <p className="text-xl font-semibold">
-                              {formatAmount(latestQuote.close, latestQuote.currency)}
+                              {formatAmount(
+                                latestQuote.close,
+                                latestQuote.currency,
+                                true,
+                                asset?.kind === "BOND" ? 4 : undefined,
+                              )}
                             </p>
                             <p className="text-muted-foreground text-xs">Latest price</p>
                           </div>

--- a/apps/frontend/src/pages/asset/asset-lots-table.tsx
+++ b/apps/frontend/src/pages/asset/asset-lots-table.tsx
@@ -6,7 +6,7 @@ import {
   TableHeader,
   TableRow,
 } from "@wealthfolio/ui/components/ui/table";
-import { AssetKind, Lot } from "@/lib/types";
+import { Lot } from "@/lib/types";
 import { formatAmount } from "@wealthfolio/ui";
 import { formatDate, formatQuantity } from "@/lib/utils";
 import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
@@ -17,10 +17,15 @@ interface AssetLotsTableProps {
   lots: Lot[];
   currency: string;
   marketPrice: number;
-  assetKind?: AssetKind | null;
+  instrumentType?: string | null;
 }
 
-export const AssetLotsTable = ({ lots, currency, marketPrice, assetKind }: AssetLotsTableProps) => {
+export const AssetLotsTable = ({
+  lots,
+  currency,
+  marketPrice,
+  instrumentType,
+}: AssetLotsTableProps) => {
   if (!lots || lots.length === 0) {
     return null;
   }
@@ -61,7 +66,7 @@ export const AssetLotsTable = ({ lots, currency, marketPrice, assetKind }: Asset
                         lot.acquisitionPrice,
                         currency,
                         true,
-                        assetKind === "BOND" ? 4 : undefined,
+                        instrumentType === "BOND" ? 4 : undefined,
                       )}
                     </TableCell>
                     <TableCell className="text-right">

--- a/apps/frontend/src/pages/asset/asset-lots-table.tsx
+++ b/apps/frontend/src/pages/asset/asset-lots-table.tsx
@@ -6,7 +6,7 @@ import {
   TableHeader,
   TableRow,
 } from "@wealthfolio/ui/components/ui/table";
-import { Lot } from "@/lib/types";
+import { AssetKind, Lot } from "@/lib/types";
 import { formatAmount } from "@wealthfolio/ui";
 import { formatDate, formatQuantity } from "@/lib/utils";
 import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
@@ -17,9 +17,10 @@ interface AssetLotsTableProps {
   lots: Lot[];
   currency: string;
   marketPrice: number;
+  assetKind?: AssetKind | null;
 }
 
-export const AssetLotsTable = ({ lots, currency, marketPrice }: AssetLotsTableProps) => {
+export const AssetLotsTable = ({ lots, currency, marketPrice, assetKind }: AssetLotsTableProps) => {
   if (!lots || lots.length === 0) {
     return null;
   }
@@ -56,7 +57,12 @@ export const AssetLotsTable = ({ lots, currency, marketPrice }: AssetLotsTablePr
                     <TableCell className="font-medium">{formatDate(lot.acquisitionDate)}</TableCell>
                     <TableCell className="text-right">{formatQuantity(lot.quantity)}</TableCell>
                     <TableCell className="text-right">
-                      {formatAmount(lot.acquisitionPrice, currency)}
+                      {formatAmount(
+                        lot.acquisitionPrice,
+                        currency,
+                        true,
+                        assetKind === "BOND" ? 4 : undefined,
+                      )}
                     </TableCell>
                     <TableCell className="text-right">
                       {formatAmount(lot.acquisitionFees, currency)}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -631,7 +631,7 @@ export const AssetProfilePage = () => {
             lots={holding.lots}
             currency={symbolHolding?.currency ?? profile.currency ?? baseCurrency}
             marketPrice={Number(holding.price ?? profile.marketPrice)}
-            assetKind={assetProfile?.kind}
+            instrumentType={assetProfile?.instrumentType}
           />
         ),
       });
@@ -656,6 +656,7 @@ export const AssetProfilePage = () => {
           assetId={assetId}
           currency={quote?.currency ?? profile?.currency ?? baseCurrency}
           assetKind={assetProfile?.kind}
+          instrumentType={assetProfile?.instrumentType}
           isManualDataSource={isManualPricingMode}
           onSaveQuote={(quote: Quote) => saveQuoteMutation.mutate(quote)}
           onDeleteQuote={(id: string) => deleteQuoteMutation.mutate(id)}
@@ -824,6 +825,7 @@ export const AssetProfilePage = () => {
               assetId={assetId}
               currency={profile?.currency ?? baseCurrency}
               assetKind={assetProfile?.kind}
+              instrumentType={assetProfile?.instrumentType}
               isManualDataSource={isManualPricingMode}
               onSaveQuote={(quote: Quote) => saveQuoteMutation.mutate(quote)}
               onDeleteQuote={(id: string) => deleteQuoteMutation.mutate(id)}
@@ -1253,7 +1255,7 @@ export const AssetProfilePage = () => {
                   lots={holding.lots}
                   currency={symbolHolding?.currency ?? profile.currency ?? baseCurrency}
                   marketPrice={Number(holding.price ?? profile.marketPrice)}
-                  assetKind={assetProfile?.kind}
+                  instrumentType={assetProfile?.instrumentType}
                 />
               </TabsContent>
             )}
@@ -1276,6 +1278,7 @@ export const AssetProfilePage = () => {
                   assetId={assetId}
                   currency={quote?.currency ?? profile?.currency ?? baseCurrency}
                   assetKind={assetProfile?.kind}
+                  instrumentType={assetProfile?.instrumentType}
                   isManualDataSource={isManualPricingMode}
                   onSaveQuote={(quote: Quote) => saveQuoteMutation.mutate(quote)}
                   onDeleteQuote={(id: string) => deleteQuoteMutation.mutate(id)}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -631,6 +631,7 @@ export const AssetProfilePage = () => {
             lots={holding.lots}
             currency={symbolHolding?.currency ?? profile.currency ?? baseCurrency}
             marketPrice={Number(holding.price ?? profile.marketPrice)}
+            assetKind={assetProfile?.kind}
           />
         ),
       });
@@ -1252,6 +1253,7 @@ export const AssetProfilePage = () => {
                   lots={holding.lots}
                   currency={symbolHolding?.currency ?? profile.currency ?? baseCurrency}
                   marketPrice={Number(holding.price ?? profile.marketPrice)}
+                  assetKind={assetProfile?.kind}
                 />
               </TabsContent>
             )}

--- a/apps/frontend/src/pages/asset/assets-table-mobile.tsx
+++ b/apps/frontend/src/pages/asset/assets-table-mobile.tsx
@@ -252,6 +252,8 @@ export function AssetsTableMobile({
                         {formatAmount(
                           latestQuotes[asset.id].quote.close,
                           latestQuotes[asset.id].quote.currency ?? asset.quoteCcy ?? baseCurrency,
+                          true,
+                          asset.kind === "BOND" ? 4 : undefined,
                         )}
                         {isStaleQuote(latestQuotes[asset.id], asset) ? (
                           <Tooltip>

--- a/apps/frontend/src/pages/asset/assets-table-mobile.tsx
+++ b/apps/frontend/src/pages/asset/assets-table-mobile.tsx
@@ -253,7 +253,7 @@ export function AssetsTableMobile({
                           latestQuotes[asset.id].quote.close,
                           latestQuotes[asset.id].quote.currency ?? asset.quoteCcy ?? baseCurrency,
                           true,
-                          asset.kind === "BOND" ? 4 : undefined,
+                          asset.instrumentType === "BOND" ? 4 : undefined,
                         )}
                         {isStaleQuote(latestQuotes[asset.id], asset) ? (
                           <Tooltip>

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -232,7 +232,12 @@ export function AssetsTable({
                   </Tooltip>
                 ) : null}
                 <span className="font-semibold tabular-nums">
-                  {formatAmount(quote.close, quote.currency ?? asset.quoteCcy ?? baseCurrency)}
+                  {formatAmount(
+                    quote.close,
+                    quote.currency ?? asset.quoteCcy ?? baseCurrency,
+                    true,
+                    asset.kind === "BOND" ? 4 : undefined,
+                  )}
                 </span>
               </div>
               <div className="text-muted-foreground text-[11px]">{formatDate(quote.timestamp)}</div>

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -236,7 +236,7 @@ export function AssetsTable({
                     quote.close,
                     quote.currency ?? asset.quoteCcy ?? baseCurrency,
                     true,
-                    asset.kind === "BOND" ? 4 : undefined,
+                    asset.instrumentType === "BOND" ? 4 : undefined,
                   )}
                 </span>
               </div>

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
@@ -26,7 +26,7 @@ const getDecimalPrecision = (assetKind?: AssetKind | null): number => {
     case "FX":
       return 6; // FX rates need high precision
     default:
-      return 2; // Standard precision for stocks, ETFs, etc.
+      return 4; // Standard precision for stocks, ETFs, bonds, etc.
   }
 };
 

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
@@ -20,16 +20,14 @@ const normalizeDate = (value: Date | string): Date => {
   return new Date(value);
 };
 
-// Get decimal precision based on asset kind
-const getDecimalPrecision = (assetKind?: AssetKind | null): number => {
-  switch (assetKind) {
-    case "FX":
-      return 6;
-    case "BOND":
-      return 4;
-    default:
-      return 2;
-  }
+// Get decimal precision based on asset kind and instrument type
+const getDecimalPrecision = (
+  assetKind?: AssetKind | null,
+  instrumentType?: string | null,
+): number => {
+  if (assetKind === "FX") return 6;
+  if (instrumentType === "BOND") return 4;
+  return 2;
 };
 
 // Round number to specified decimal places
@@ -62,6 +60,8 @@ interface QuoteHistoryDataGridProps {
   currency: string;
   /** Asset kind for decimal precision */
   assetKind?: AssetKind | null;
+  /** Instrument type for decimal precision (e.g. "BOND") */
+  instrumentType?: string | null;
   /** Whether manual tracking is enabled */
   isManualDataSource?: boolean;
   /** Callback to save a quote */
@@ -128,14 +128,14 @@ export function QuoteHistoryDataGrid({
   assetId,
   currency,
   assetKind,
+  instrumentType,
   isManualDataSource = false,
   onSaveQuote,
   onDeleteQuote,
   onChangeDataSource,
 }: QuoteHistoryDataGridProps) {
   const isMobile = useIsMobileViewport();
-  // Get decimal precision based on asset kind
-  const decimalPrecision = getDecimalPrecision(assetKind);
+  const decimalPrecision = getDecimalPrecision(assetKind, instrumentType);
 
   // Convert quotes to local entries with rounding
   const initialEntries = useMemo(

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
@@ -24,9 +24,11 @@ const normalizeDate = (value: Date | string): Date => {
 const getDecimalPrecision = (assetKind?: AssetKind | null): number => {
   switch (assetKind) {
     case "FX":
-      return 6; // FX rates need high precision
+      return 6;
+    case "BOND":
+      return 4;
     default:
-      return 4; // Standard precision for stocks, ETFs, bonds, etc.
+      return 2;
   }
 };
 

--- a/apps/frontend/src/pages/asset/quote-history-table.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-table.tsx
@@ -1,4 +1,4 @@
-import { Quote } from "@/lib/types";
+import { AssetKind, Quote } from "@/lib/types";
 import { format } from "date-fns";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
@@ -54,11 +54,23 @@ import {
 
 interface QuoteHistoryTableProps {
   data: Quote[];
+  assetKind?: AssetKind | null;
   isManualDataSource?: boolean;
   onSaveQuote?: (quote: Quote) => void;
   onDeleteQuote?: (quoteId: string) => void;
   onChangeDataSource?: (isManual: boolean) => void;
 }
+
+const getDecimalPrecision = (assetKind?: AssetKind | null): number => {
+  switch (assetKind) {
+    case "FX":
+      return 6;
+    case "BOND":
+      return 4;
+    default:
+      return 2;
+  }
+};
 
 const ITEMS_PER_PAGE = 10;
 
@@ -74,11 +86,13 @@ const emptyQuote: Partial<Quote> = {
 
 export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
   data,
+  assetKind,
   isManualDataSource = false,
   onSaveQuote,
   onDeleteQuote,
   onChangeDataSource,
 }) => {
+  const decimalPrecision = getDecimalPrecision(assetKind);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editedValues, setEditedValues] = useState<Partial<Quote>>({});
   const [isAddingQuote, setIsAddingQuote] = useState(false);
@@ -197,7 +211,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               onChange={(e) => handleInputChange("open", e.target.value)}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatAmount(value, info.row.original.currency, false, decimalPrecision)
           );
         },
         enableSorting: false,
@@ -215,7 +229,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               autoFocus={true}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatAmount(value, info.row.original.currency, false, decimalPrecision)
           );
         },
         enableSorting: false,
@@ -232,7 +246,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               onChange={(e) => handleInputChange("low", e.target.value)}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatAmount(value, info.row.original.currency, false, decimalPrecision)
           );
         },
         enableSorting: false,
@@ -249,7 +263,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               onChange={(e) => handleInputChange("close", e.target.value)}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatAmount(value, info.row.original.currency, false, decimalPrecision)
           );
         },
         enableSorting: false,

--- a/apps/frontend/src/pages/asset/quote-history-table.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-table.tsx
@@ -55,21 +55,20 @@ import {
 interface QuoteHistoryTableProps {
   data: Quote[];
   assetKind?: AssetKind | null;
+  instrumentType?: string | null;
   isManualDataSource?: boolean;
   onSaveQuote?: (quote: Quote) => void;
   onDeleteQuote?: (quoteId: string) => void;
   onChangeDataSource?: (isManual: boolean) => void;
 }
 
-const getDecimalPrecision = (assetKind?: AssetKind | null): number => {
-  switch (assetKind) {
-    case "FX":
-      return 6;
-    case "BOND":
-      return 4;
-    default:
-      return 2;
-  }
+const getDecimalPrecision = (
+  assetKind?: AssetKind | null,
+  instrumentType?: string | null,
+): number => {
+  if (assetKind === "FX") return 6;
+  if (instrumentType === "BOND") return 4;
+  return 2;
 };
 
 const ITEMS_PER_PAGE = 10;
@@ -87,12 +86,13 @@ const emptyQuote: Partial<Quote> = {
 export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
   data,
   assetKind,
+  instrumentType,
   isManualDataSource = false,
   onSaveQuote,
   onDeleteQuote,
   onChangeDataSource,
 }) => {
-  const decimalPrecision = getDecimalPrecision(assetKind);
+  const decimalPrecision = getDecimalPrecision(assetKind, instrumentType);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editedValues, setEditedValues] = useState<Partial<Quote>>({});
   const [isAddingQuote, setIsAddingQuote] = useState(false);

--- a/crates/market-data/src/provider/boerse_frankfurt/mod.rs
+++ b/crates/market-data/src/provider/boerse_frankfurt/mod.rs
@@ -354,24 +354,23 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
                 message: "No lastPrice in response".to_string(),
             })?;
 
-        let price = if body.traded_in_percent {
-            raw_price / 100.0
+        let close = Decimal::try_from(raw_price).map_err(|_| MarketDataError::ValidationFailed {
+            message: format!("Failed to convert price {} to decimal", raw_price),
+        })?;
+        let close = if body.traded_in_percent {
+            close / Decimal::from(100)
         } else {
-            raw_price
+            close
         };
 
-        let close = Decimal::try_from(price).map_err(|_| MarketDataError::ValidationFailed {
-            message: format!("Failed to convert price {} to decimal", price),
-        })?;
-
         let high = body.day_high.and_then(|v| {
-            let v = if body.traded_in_percent { v / 100.0 } else { v };
-            Decimal::try_from(v).ok()
+            let d = Decimal::try_from(v).ok()?;
+            Some(if body.traded_in_percent { d / Decimal::from(100) } else { d })
         });
 
         let low = body.day_low.and_then(|v| {
-            let v = if body.traded_in_percent { v / 100.0 } else { v };
-            Decimal::try_from(v).ok()
+            let d = Decimal::try_from(v).ok()?;
+            Some(if body.traded_in_percent { d / Decimal::from(100) } else { d })
         });
 
         let currency = body
@@ -454,25 +453,28 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
             let ts = body.t[i];
             let timestamp = DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now);
 
-            let divisor = if bond { 100.0 } else { 1.0 };
+            let divisor = if bond { Decimal::from(100) } else { Decimal::ONE };
 
-            let close = Decimal::try_from(body.c.get(i).copied().unwrap_or(0.0) / divisor)
+            let close = Decimal::try_from(body.c.get(i).copied().unwrap_or(0.0))
                 .map_err(|_| MarketDataError::ValidationFailed {
                     message: format!("Failed to convert close to decimal at index {}", i),
-                })?;
+                })? / divisor;
 
             let open = body
                 .o
                 .get(i)
-                .and_then(|&v| Decimal::try_from(v / divisor).ok());
+                .and_then(|&v| Decimal::try_from(v).ok())
+                .map(|d| d / divisor);
             let high = body
                 .h
                 .get(i)
-                .and_then(|&v| Decimal::try_from(v / divisor).ok());
+                .and_then(|&v| Decimal::try_from(v).ok())
+                .map(|d| d / divisor);
             let low = body
                 .l
                 .get(i)
-                .and_then(|&v| Decimal::try_from(v / divisor).ok());
+                .and_then(|&v| Decimal::try_from(v).ok())
+                .map(|d| d / divisor);
             let volume = body.v.get(i).and_then(|&v| Decimal::try_from(v).ok());
 
             quotes.push(Quote {
@@ -755,8 +757,7 @@ mod tests {
 
         // Verify /100 conversion
         let raw = resp.last_price.unwrap();
-        let converted = raw / 100.0;
-        let dec = Decimal::try_from(converted).unwrap();
+        let dec = Decimal::try_from(raw).unwrap() / Decimal::from(100);
         assert_eq!(dec.to_string(), "0.97025");
     }
 

--- a/crates/market-data/src/provider/boerse_frankfurt/mod.rs
+++ b/crates/market-data/src/provider/boerse_frankfurt/mod.rs
@@ -354,9 +354,10 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
                 message: "No lastPrice in response".to_string(),
             })?;
 
-        let close = Decimal::try_from(raw_price).map_err(|_| MarketDataError::ValidationFailed {
-            message: format!("Failed to convert price {} to decimal", raw_price),
-        })?;
+        let close =
+            Decimal::try_from(raw_price).map_err(|_| MarketDataError::ValidationFailed {
+                message: format!("Failed to convert price {} to decimal", raw_price),
+            })?;
         let close = if body.traded_in_percent {
             close / Decimal::from(100)
         } else {
@@ -365,12 +366,20 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
 
         let high = body.day_high.and_then(|v| {
             let d = Decimal::try_from(v).ok()?;
-            Some(if body.traded_in_percent { d / Decimal::from(100) } else { d })
+            Some(if body.traded_in_percent {
+                d / Decimal::from(100)
+            } else {
+                d
+            })
         });
 
         let low = body.day_low.and_then(|v| {
             let d = Decimal::try_from(v).ok()?;
-            Some(if body.traded_in_percent { d / Decimal::from(100) } else { d })
+            Some(if body.traded_in_percent {
+                d / Decimal::from(100)
+            } else {
+                d
+            })
         });
 
         let currency = body
@@ -453,12 +462,17 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
             let ts = body.t[i];
             let timestamp = DateTime::from_timestamp(ts, 0).unwrap_or_else(Utc::now);
 
-            let divisor = if bond { Decimal::from(100) } else { Decimal::ONE };
+            let divisor = if bond {
+                Decimal::from(100)
+            } else {
+                Decimal::ONE
+            };
 
-            let close = Decimal::try_from(body.c.get(i).copied().unwrap_or(0.0))
-                .map_err(|_| MarketDataError::ValidationFailed {
+            let close = Decimal::try_from(body.c.get(i).copied().unwrap_or(0.0)).map_err(|_| {
+                MarketDataError::ValidationFailed {
                     message: format!("Failed to convert close to decimal at index {}", i),
-                })? / divisor;
+                }
+            })? / divisor;
 
             let open = body
                 .o
@@ -759,6 +773,14 @@ mod tests {
         let raw = resp.last_price.unwrap();
         let dec = Decimal::try_from(raw).unwrap() / Decimal::from(100);
         assert_eq!(dec.to_string(), "0.97025");
+    }
+
+    #[test]
+    fn historical_bond_close_preserves_precision() {
+        let raw = 91.92_f64;
+        let divisor = Decimal::from(100);
+        let d = Decimal::try_from(raw).unwrap() / divisor;
+        assert_eq!(d.to_string(), "0.9192");
     }
 
     #[test]

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -11,7 +11,7 @@ export function cn(...inputs: ClassValue[]) {
  */
 const DECIMAL_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   minimumFractionDigits: DISPLAY_DECIMAL_PRECISION,
-  maximumFractionDigits: DISPLAY_DECIMAL_PRECISION,
+  maximumFractionDigits: 4,
 };
 
 const decimalFormatter = new Intl.NumberFormat("en-US", DECIMAL_FORMAT_OPTIONS);

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -11,7 +11,7 @@ export function cn(...inputs: ClassValue[]) {
  */
 const DECIMAL_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   minimumFractionDigits: DISPLAY_DECIMAL_PRECISION,
-  maximumFractionDigits: 4,
+  maximumFractionDigits: DISPLAY_DECIMAL_PRECISION,
 };
 
 const decimalFormatter = new Intl.NumberFormat("en-US", DECIMAL_FORMAT_OPTIONS);
@@ -65,10 +65,38 @@ const getCompactCurrencyFormatter = (currency: string, maximumFractionDigits: nu
   return formatter;
 };
 
+const precisionFormatterCache = new Map<string, Intl.NumberFormat>();
+
+const getPrecisionFormatter = (
+  precision: number,
+  currency?: string,
+  displayCurrency?: boolean,
+): Intl.NumberFormat => {
+  const key = `${currency ?? ""}|${displayCurrency}|${precision}`;
+  if (precisionFormatterCache.has(key)) return precisionFormatterCache.get(key)!;
+
+  const opts: Intl.NumberFormatOptions = {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  };
+  let formatter: Intl.NumberFormat;
+  try {
+    formatter =
+      displayCurrency && currency
+        ? new Intl.NumberFormat("en-US", { style: "currency", currency, ...opts })
+        : new Intl.NumberFormat("en-US", opts);
+  } catch {
+    formatter = new Intl.NumberFormat("en-US", opts);
+  }
+  precisionFormatterCache.set(key, formatter);
+  return formatter;
+};
+
 export function formatAmount(
   amount: number | string | null | undefined,
   currency: string,
   displayCurrency = true,
+  precision?: number,
 ) {
   if (amount == null) return "-";
   const numericAmount = typeof amount === "string" ? Number(amount) : amount;
@@ -76,6 +104,13 @@ export function formatAmount(
   const displayAmount = Math.abs(numericAmount) < 0.005 ? 0 : numericAmount;
   const rawCurrency = currency ?? "USD";
   const isPenceCurrency = rawCurrency === "GBp" || rawCurrency === "GBX";
+
+  if (precision != null && precision !== DISPLAY_DECIMAL_PRECISION) {
+    const showCcy = displayCurrency && !isPenceCurrency;
+    const formatter = getPrecisionFormatter(precision, showCcy ? rawCurrency : undefined, showCcy);
+    const result = formatter.format(numericAmount);
+    return isPenceCurrency && displayCurrency ? `${result}p` : result;
+  }
 
   if (isPenceCurrency) {
     const formattedNumber = decimalFormatter.format(displayAmount);


### PR DESCRIPTION
Fixes #821

- boerse_frankfurt: convert f64 to Decimal before dividing by 100, matching the pattern in metal_price_api (Decimal-space arithmetic)
- quote-history-data-grid: increase default precision from 2 to 4 so bond prices like 0.9192 are not rounded to 0.92 on save
- formatAmount: set maximumFractionDigits to 4 (min stays 2) so trailing zeros are trimmed automatically via Intl.NumberFormat

## Summary

Bonds from Boerse Frankfurt are quoted as % of face value (e.g. 91.92%), normalized to a decimal fraction (0.9192). Two issues caused precision loss:

- **Frontend rounded to 2 decimals**: `0.9192` was displayed and could be saved back as `0.92`, destroying precision
- **f64-space division in provider**: the `/100` normalization happened before `Decimal` conversion, inconsistent with the pattern in `metal_price_api`

## Changes

**`crates/market-data/src/provider/boerse_frankfurt/mod.rs`**
- Convert `f64` → `Decimal` first, then divide by `Decimal::from(100)` for `traded_in_percent` bonds (latest + historical quotes)

**`apps/frontend/src/pages/asset/quote-history-data-grid.tsx`**
- Default precision: `2` → `4` so bond prices like `0.9192` are preserved on display and save

**`packages/ui/src/lib/utils.ts`**
- `maximumFractionDigits`: `2` → `4` in `formatAmount()` — propagates to all price displays. `Intl.NumberFormat` trims trailing zeros automatically (`0.9200` → `0.92`, `0.9192` → `0.9192`)

## Test plan

- [x] `cargo test -p wealthfolio-market-data` — 232 tests pass
- [x] `pnpm type-check` — no errors
- [x] Manual: bond asset from Boerse Frankfurt shows 4 decimal places
- [x] Manual: stocks/ETFs still show 2 decimals

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
