### PR TITLE
fix(accounts): clean up snapshots and valuations on account deletion

### DIFF
--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -182,6 +182,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
     let app_sync_repository = Arc::new(AppSyncRepository::new(pool.clone(), writer.clone()));
     let quote_sync_state_repository =
         Arc::new(QuoteSyncStateRepository::new(pool.clone(), writer.clone()));
+    let valuation_repository = Arc::new(ValuationRepository::new(pool.clone(), writer.clone()));
 
     let account_service = Arc::new(AccountService::new(
         account_repo.clone(),
@@ -190,6 +191,8 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         domain_event_sink.clone(),
         asset_repository.clone(),
         quote_sync_state_repository.clone(),
+        snapshot_repository.clone(),
+        valuation_repository.clone(),
     ));
     let custom_provider_repository = Arc::new(
         wealthfolio_storage_sqlite::custom_provider::CustomProviderSqliteRepository::new(
@@ -241,7 +244,6 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         .with_event_sink(domain_event_sink.clone()),
     );
 
-    let valuation_repository = Arc::new(ValuationRepository::new(pool.clone(), writer.clone()));
     let valuation_service = Arc::new(ValuationService::new(
         base_currency.clone(),
         valuation_repository.clone(),

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -164,6 +164,8 @@ pub async fn initialize_context(
         domain_event_sink.clone(),
         asset_repository.clone(),
         quote_sync_state_repository.clone(),
+        snapshot_repository.clone(),
+        valuation_repository.clone(),
     ));
 
     // Import run repository for tracking CSV imports

--- a/crates/core/src/accounts/accounts_service.rs
+++ b/crates/core/src/accounts/accounts_service.rs
@@ -9,6 +9,8 @@ use crate::assets::AssetRepositoryTrait;
 use crate::errors::Result;
 use crate::events::{CurrencyChange, DomainEvent, DomainEventSink};
 use crate::fx::FxServiceTrait;
+use crate::portfolio::snapshot::SnapshotRepositoryTrait;
+use crate::portfolio::valuation::ValuationRepositoryTrait;
 use crate::quotes::sync_state::SyncStateStore;
 
 /// Service for managing accounts.
@@ -19,10 +21,13 @@ pub struct AccountService {
     event_sink: Arc<dyn DomainEventSink>,
     asset_repository: Arc<dyn AssetRepositoryTrait>,
     sync_state_store: Arc<dyn SyncStateStore>,
+    snapshot_repository: Arc<dyn SnapshotRepositoryTrait>,
+    valuation_repository: Arc<dyn ValuationRepositoryTrait>,
 }
 
 impl AccountService {
     /// Creates a new AccountService instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         repository: Arc<dyn AccountRepositoryTrait>,
         fx_service: Arc<dyn FxServiceTrait>,
@@ -30,6 +35,8 @@ impl AccountService {
         event_sink: Arc<dyn DomainEventSink>,
         asset_repository: Arc<dyn AssetRepositoryTrait>,
         sync_state_store: Arc<dyn SyncStateStore>,
+        snapshot_repository: Arc<dyn SnapshotRepositoryTrait>,
+        valuation_repository: Arc<dyn ValuationRepositoryTrait>,
     ) -> Self {
         Self {
             repository,
@@ -38,6 +45,8 @@ impl AccountService {
             event_sink,
             asset_repository,
             sync_state_store,
+            snapshot_repository,
+            valuation_repository,
         }
     }
 }
@@ -178,6 +187,28 @@ impl AccountServiceTrait for AccountService {
     /// Deletes an account by its ID.
     async fn delete_account(&self, account_id: &str) -> Result<()> {
         self.repository.delete(account_id).await?;
+
+        // Clean up snapshots and valuations (no FK CASCADE on these tables)
+        if let Err(e) = self
+            .snapshot_repository
+            .delete_snapshots_by_account_ids(&[account_id.to_string()])
+            .await
+        {
+            warn!(
+                "Failed to delete snapshots for account {}: {}",
+                account_id, e
+            );
+        }
+        if let Err(e) = self
+            .valuation_repository
+            .delete_valuations_for_account(account_id, None)
+            .await
+        {
+            warn!(
+                "Failed to delete valuations for account {}: {}",
+                account_id, e
+            );
+        }
 
         // Clean up orphaned assets (activities are already CASCADE-deleted)
         match self


### PR DESCRIPTION
## Summary

- `holdings_snapshots` and `daily_account_valuation` have no FK CASCADE
  on `account_id`, so deleting an account left orphaned rows in these
  tables.
- Add explicit deletes for both tables in `delete_account` before the
  account row is removed.
- This also enables a faster wipe-and-reimport workflow: delete the
  account (instant CASCADE of activities + lots + snapshots +
  valuations) then recreate and reimport, instead of deleting activities
  one-by-one.

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass
- [x] Verified `holdings_snapshots` and `daily_account_valuation` have
  no FK constraint on `account_id` (confirmed via `sqlite_master` schema)
- [x] Both `delete_snapshots_by_account_ids` and
  `delete_valuations_for_account` are existing repository methods with
  their own test coverage