### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,10 @@ environment variables.
 
 You can either pull the official Docker image or build it yourself locally.
 
+> **Prefer not to self-host?** [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/wealthfolio)
+>
+> One-click managed Wealthfolio: storage, backups, email and a free subdomain included. A share of every subscription goes back to Wealthfolio.
+
 ### Using the Pre-built Image
 
 The latest server build is published to Docker Hub.


### PR DESCRIPTION
## Description

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Wealthfolio to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Docker (self-hosting) section (links to https://zenith.hosting/host/wealthfolio).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

docs-only change (one badge in the README). tests/build N/A. no LLM used.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
