### PR TITLE
fix(spending): Create Event dialog breaks out of its box with long transaction names

### DIFF
--- a/apps/frontend/src/features/spending/components/event-form-dialog.tsx
+++ b/apps/frontend/src/features/spending/components/event-form-dialog.tsx
@@ -644,7 +644,7 @@ function SuggestedTransactions({
   }
 
   return (
-    <div className="border-input rounded-md border">
+    <div className="border-input overflow-hidden rounded-md border">
       <div className="flex items-center justify-between border-b px-3 py-2">
         <div className="min-w-0">
           <p className="text-foreground text-xs font-semibold">
@@ -692,8 +692,8 @@ function SuggestedTransactions({
                   onChange={(e) => onToggle(c.id, e.target.checked)}
                 />
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-foreground truncate text-xs">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span className="text-foreground min-w-0 truncate text-xs">
                       {c.notes || c.activityType}
                     </span>
                     {c.eventId && checked && (

--- a/apps/frontend/src/features/spending/components/event-form-dialog.tsx
+++ b/apps/frontend/src/features/spending/components/event-form-dialog.tsx
@@ -323,7 +323,7 @@ export function EventFormDialog({
           </DialogDescription>
         </DialogHeader>
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="min-w-0 space-y-4">
             <FormField
               control={form.control}
               name="name"


### PR DESCRIPTION
## What was broken

On the Spending Insight page, opening **Create Event** and looking at the "Tag transactions in this range" list — if any transaction had a long, unbroken description (common with bank references, SEPA transfers, long merchant strings, etc.) — the popup would stretch way past its normal size. Fields and the Cancel/Create buttons would end up rendered outside the visible dialog box, over the dimmed background, instead of staying inside a normal-sized popup.

<img width="1295" height="816" alt="imagen" src="https://github.com/user-attachments/assets/6e635f49-d34a-414a-a206-640ac0cf22ed" />
<img width="1288" height="782" alt="imagen" src="https://github.com/user-attachments/assets/e8afe327-d513-4bd5-8c6f-bb7fd5510321" />


## Why it happened

Two small CSS issues combined:
1. The long transaction text was supposed to truncate with "…" but a missing style meant it never actually shrank — it just kept pushing everything wider.
2. The dialog's form itself had no upper limit on how wide it was allowed to grow, so once the text pushed things wide enough, the whole popup grew with it instead of staying capped at its normal size.

## The fix

Two one-line CSS tweaks in `event-form-dialog.tsx` so the text properly truncates and the dialog can no longer grow past its intended width, no matter how long a transaction's description is.

## Testing

Reproduced the bug locally with a synthetic long transaction description, confirmed it broke the dialog exactly as described, applied the fix, and confirmed the dialog now stays a normal size with the long text properly truncated. No other files touched.