### PR TITLE
feat(logo-asset): custom per-asset logo overrides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Database
-diesel = { version = "2.2", features = ["sqlite", "chrono", "r2d2", "numeric", "returning_clauses_for_sqlite_3_35"] }
+diesel = { version = "2.2", features = ["sqlite", "chrono", "r2d2", "numeric", "returning_clauses_for_sqlite_3_35", "64-column-tables"] }
 diesel_migrations = { version = "2.2", features = ["sqlite"] }
 rusqlite = { version = "0.34", features = ["bundled"] }
 r2d2 = "0.8"

--- a/apps/frontend/src/adapters/tauri/asset-logo.ts
+++ b/apps/frontend/src/adapters/tauri/asset-logo.ts
@@ -9,13 +9,17 @@ interface AssetLogoPayload {
   contentType: string;
 }
 
+export const getAssetLogoDataUrl = async (assetId: string): Promise<string | null> => {
+  const payload = await invoke<AssetLogoPayload | null>("get_asset_logo", { assetId });
+  if (!payload) return null;
+  return `data:${payload.contentType};base64,${payload.contentBase64}`;
+};
+
 export const getAssetLogoUrl = async (
   asset: { id: string; customLogoFilename?: string | null } | undefined,
 ): Promise<string | null> => {
   if (!asset?.customLogoFilename) return null;
-  const payload = await invoke<AssetLogoPayload | null>("get_asset_logo", { assetId: asset.id });
-  if (!payload) return null;
-  return `data:${payload.contentType};base64,${payload.contentBase64}`;
+  return getAssetLogoDataUrl(asset.id);
 };
 
 /** Opens a native file picker; `_file` is unused here (web-only parameter) but

--- a/apps/frontend/src/adapters/tauri/asset-logo.ts
+++ b/apps/frontend/src/adapters/tauri/asset-logo.ts
@@ -1,0 +1,29 @@
+// Custom asset logo overrides - Tauri adapter.
+// Bytes cross the IPC boundary as base64 (no local HTTP server involved);
+// the result is turned into a data URL for <img src>.
+
+import { invoke } from "./core";
+
+interface AssetLogoPayload {
+  contentBase64: string;
+  contentType: string;
+}
+
+export const getAssetLogoUrl = async (
+  asset: { id: string; customLogoFilename?: string | null } | undefined,
+): Promise<string | null> => {
+  if (!asset?.customLogoFilename) return null;
+  const payload = await invoke<AssetLogoPayload | null>("get_asset_logo", { assetId: asset.id });
+  if (!payload) return null;
+  return `data:${payload.contentType};base64,${payload.contentBase64}`;
+};
+
+/** Opens a native file picker; `_file` is unused here (web-only parameter) but
+ * kept so callers can share one signature across runtimes. */
+export const uploadAssetLogo = async (assetId: string, _file?: File): Promise<boolean> => {
+  return invoke<boolean>("pick_and_upload_asset_logo", { assetId });
+};
+
+export const removeAssetLogo = async (assetId: string): Promise<void> => {
+  await invoke<void>("remove_asset_logo", { assetId });
+};

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -268,3 +268,6 @@ export {
   runRetirementSorr,
   runRetirementStressTests,
 } from "./fire-planner";
+
+// Custom asset logo overrides
+export { getAssetLogoUrl, removeAssetLogo, uploadAssetLogo } from "./asset-logo";

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -270,4 +270,9 @@ export {
 } from "./fire-planner";
 
 // Custom asset logo overrides
-export { getAssetLogoUrl, removeAssetLogo, uploadAssetLogo } from "./asset-logo";
+export {
+  getAssetLogoDataUrl,
+  getAssetLogoUrl,
+  removeAssetLogo,
+  uploadAssetLogo,
+} from "./asset-logo";

--- a/apps/frontend/src/adapters/web/asset-logo.ts
+++ b/apps/frontend/src/adapters/web/asset-logo.ts
@@ -1,0 +1,37 @@
+// Custom asset logo overrides - web adapter.
+// The image is served directly by the backend at a stable URL, so no
+// client-side caching/decoding step is needed the way Tauri requires.
+
+const logoPath = (assetId: string): string => `/api/v1/assets/${encodeURIComponent(assetId)}/logo`;
+
+export const getAssetLogoUrl = async (
+  asset: { id: string; customLogoFilename?: string | null } | undefined,
+): Promise<string | null> => {
+  if (!asset?.customLogoFilename) return null;
+  return logoPath(asset.id);
+};
+
+export const uploadAssetLogo = async (assetId: string, file?: File): Promise<boolean> => {
+  if (!file) throw new Error("A file is required to upload a logo");
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await fetch(logoPath(assetId), {
+    method: "POST",
+    body: formData,
+    credentials: "same-origin",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to upload logo (${res.status})`);
+  }
+  return true;
+};
+
+export const removeAssetLogo = async (assetId: string): Promise<void> => {
+  const res = await fetch(logoPath(assetId), {
+    method: "DELETE",
+    credentials: "same-origin",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to remove logo (${res.status})`);
+  }
+};

--- a/apps/frontend/src/adapters/web/asset-logo.ts
+++ b/apps/frontend/src/adapters/web/asset-logo.ts
@@ -11,6 +11,25 @@ export const getAssetLogoUrl = async (
   return logoPath(asset.id);
 };
 
+/**
+ * Fetches the logo bytes and returns a self-contained `data:` URL rather
+ * than the relative path `getAssetLogoUrl` returns — needed by callers
+ * (e.g. sandboxed addon iframes) that can't rely on sharing the app's own
+ * origin for a plain relative fetch.
+ */
+export const getAssetLogoDataUrl = async (assetId: string): Promise<string | null> => {
+  const res = await fetch(logoPath(assetId), { credentials: "same-origin" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to fetch logo (${res.status})`);
+  const blob = await res.blob();
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read logo blob"));
+    reader.readAsDataURL(blob);
+  });
+};
+
 export const uploadAssetLogo = async (assetId: string, file?: File): Promise<boolean> => {
   if (!file) throw new Error("A file is required to upload a logo");
   const formData = new FormData();

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -500,4 +500,9 @@ export {
 } from "./crypto";
 
 // Custom asset logo overrides
-export { getAssetLogoUrl, removeAssetLogo, uploadAssetLogo } from "./asset-logo";
+export {
+  getAssetLogoDataUrl,
+  getAssetLogoUrl,
+  removeAssetLogo,
+  uploadAssetLogo,
+} from "./asset-logo";

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -498,3 +498,6 @@ export {
   syncHashPairingCode,
   syncHmacSha256,
 } from "./crypto";
+
+// Custom asset logo overrides
+export { getAssetLogoUrl, removeAssetLogo, uploadAssetLogo } from "./asset-logo";

--- a/apps/frontend/src/addons/addons-runtime-context.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.ts
@@ -37,6 +37,7 @@ import {
 } from "@/adapters";
 import {
   fetchDividends,
+  getAssetLogoDataUrl,
   getAssetProfile,
   getMarketDataProviders,
   getQuoteHistory,
@@ -471,6 +472,7 @@ export function createAddonHostAPI(
       getAssetProfile,
       updateAssetProfile,
       updateQuoteMode,
+      getAssetLogoDataUrl,
       updateQuote,
       syncMarketData,
       getQuoteHistory,

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -307,6 +307,7 @@ const ALLOWED_API_METHODS = new Set([
   "assets.getProfile",
   "assets.updateProfile",
   "assets.updateQuoteMode",
+  "assets.getLogoDataUrl",
   "quotes.update",
   "quotes.getHistory",
   "performance.calculateHistory",

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -98,6 +98,7 @@ export interface InternalHostAPI {
   getAssetProfile(assetId: string): Promise<Asset>;
   updateAssetProfile(payload: UpdateAssetProfile): Promise<Asset>;
   updateQuoteMode(assetId: string, quoteMode: string): Promise<Asset>;
+  getAssetLogoDataUrl(assetId: string): Promise<string | null>;
   updateQuote(symbol: string, quote: Quote): Promise<void>;
   syncMarketData(
     assetIds: string[],
@@ -455,6 +456,7 @@ export function createSDKHostAPIBridge(
       getProfile: internalAPI.getAssetProfile,
       updateProfile: internalAPI.updateAssetProfile,
       updateQuoteMode: internalAPI.updateQuoteMode,
+      getLogoDataUrl: internalAPI.getAssetLogoDataUrl,
     },
     "assets",
     guard,

--- a/apps/frontend/src/components/classification/classification-sheet.tsx
+++ b/apps/frontend/src/components/classification/classification-sheet.tsx
@@ -11,13 +11,15 @@ import {
 import { useTaxonomies } from "@/hooks/use-taxonomies";
 import { SingleSelectTaxonomy } from "./single-select-taxonomy";
 import { MultiSelectTaxonomy } from "./multi-select-taxonomy";
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import type { Taxonomy } from "@/lib/types";
 
 interface ClassificationSheetProps {
   assetId: string;
   assetName?: string;
   assetSymbol?: string;
+  /** User-uploaded logo override filename, if one has been set on the asset */
+  assetCustomLogoFilename?: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -34,6 +36,7 @@ export function ClassificationSheet({
   assetId,
   assetName,
   assetSymbol,
+  assetCustomLogoFilename,
   open,
   onOpenChange,
 }: ClassificationSheetProps) {
@@ -70,7 +73,13 @@ export function ClassificationSheet({
       <SheetContent side="right" className="flex h-full w-full flex-col sm:max-w-lg">
         <SheetHeader className="shrink-0 pb-4">
           <div className="flex items-center gap-3">
-            {assetSymbol && <TickerAvatar symbol={assetSymbol} className="size-10" />}
+            {assetSymbol && (
+              <AssetTickerAvatar
+                asset={{ id: assetId, customLogoFilename: assetCustomLogoFilename }}
+                symbol={assetSymbol}
+                className="size-10"
+              />
+            )}
             <div className="min-w-0 flex-1">
               <SheetTitle className="truncate text-lg">
                 {assetSymbol || t("asset:classification.classifyAsset")}

--- a/apps/frontend/src/components/ticker-avatar.test.tsx
+++ b/apps/frontend/src/components/ticker-avatar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { TickerAvatar } from "./ticker-avatar";
+import { getTickerLogoImageClassName, TickerAvatar } from "./ticker-avatar";
 
 describe("TickerAvatar", () => {
   it("renders cash symbols with a painted avatar background", () => {
@@ -30,5 +30,17 @@ describe("TickerAvatar", () => {
     render(<TickerAvatar symbol="ABCDE" />);
 
     expect(screen.getByTitle("ABCDE")).toHaveTextContent("ABCD");
+  });
+});
+
+describe("getTickerLogoImageClassName", () => {
+  it("renders a custom logo edge-to-edge, with no padding", () => {
+    expect(getTickerLogoImageClassName(true, "p-1")).toBe("object-contain");
+    expect(getTickerLogoImageClassName(true, "p-2")).toBe("object-contain");
+  });
+
+  it("keeps the caller-specific padding for the bundled ticker-logo fallback", () => {
+    expect(getTickerLogoImageClassName(false, "p-1")).toBe("object-contain p-1");
+    expect(getTickerLogoImageClassName(false, "p-2")).toBe("object-contain p-2");
   });
 });

--- a/apps/frontend/src/components/ticker-avatar.tsx
+++ b/apps/frontend/src/components/ticker-avatar.tsx
@@ -2,12 +2,16 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { parseOccSymbol } from "@/lib/occ-symbol";
+import { useAssetLogoUrl } from "@/hooks/use-asset-logo-url";
+import type { Asset } from "@/lib/types";
 import { Avatar, AvatarFallback, AvatarImage } from "@wealthfolio/ui";
 
 interface TickerAvatarProps {
   symbol: string;
   className?: string;
   imageClassName?: string;
+  /** Resolved user-uploaded logo override URL (data URL or server path), if any. */
+  customLogoUrl?: string | null;
 }
 
 const CASH_AVATAR_LABELS: Record<string, string> = {
@@ -34,7 +38,8 @@ const getFallbackAvatarLabel = (symbol: string): string => symbol.slice(0, 4);
 export const TickerAvatar = ({
   symbol,
   className = "size-8",
-  imageClassName = "object-contain p-2",
+  imageClassName,
+  customLogoUrl,
 }: TickerAvatarProps) => {
   // For OCC option symbols (e.g. "AAPL250321C00150000"), use the underlying ticker for logo
   const parsed = symbol ? parseOccSymbol(symbol) : null;
@@ -44,12 +49,25 @@ export const TickerAvatar = ({
   const baseSymbol = logoSymbol ? logoSymbol.split(/[.:-]/)[0].toUpperCase() : "";
   const fullSymbol = logoSymbol ? logoSymbol.toUpperCase() : "";
 
-  // Try full symbol first, then fallback to base symbol
-  const primaryLogoUrl = fullSymbol ? `/ticker-logos/${fullSymbol}.png` : "";
-  const fallbackLogoUrl = baseSymbol ? `/ticker-logos/${baseSymbol}.png` : "";
+  // A user-uploaded override always wins; only fall back to the bundled
+  // ticker-logos resolution (full symbol, then base symbol) when unset.
+  const primaryLogoUrl = customLogoUrl || (fullSymbol ? `/ticker-logos/${fullSymbol}.png` : "");
+  const fallbackLogoUrl = customLogoUrl
+    ? ""
+    : baseSymbol
+      ? `/ticker-logos/${baseSymbol}.png`
+      : "";
   const cashAvatarLabel = getCashAvatarLabel(fullSymbol);
   const fallbackAvatarLabel = baseSymbol ? getFallbackAvatarLabel(baseSymbol) : "•";
   const [logoUrl, setLogoUrl] = useState(primaryLogoUrl);
+
+  // object-contain never distorts the source image: a landscape logo scales
+  // to the circle's full width (letterboxed top/bottom), a portrait logo
+  // scales to the circle's full height (letterboxed left/right) — either
+  // way the aspect ratio is preserved, unlike `object-cover` (which crops)
+  // or leaving `object-fit` unset (which stretches to fill).
+  const resolvedImageClassName =
+    imageClassName ?? (customLogoUrl ? "object-contain" : "object-contain p-2");
 
   useEffect(() => {
     setLogoUrl(primaryLogoUrl);
@@ -74,7 +92,7 @@ export const TickerAvatar = ({
       <AvatarImage
         src={logoUrl}
         alt={fullSymbol}
-        className={imageClassName}
+        className={resolvedImageClassName}
         onLoadingStatusChange={(status) => {
           if (
             status === "error" &&
@@ -97,5 +115,66 @@ export const TickerAvatar = ({
         </span>
       </AvatarFallback>
     </Avatar>
+  );
+};
+
+interface AssetTickerAvatarProps extends Omit<TickerAvatarProps, "customLogoUrl"> {
+  /** The full asset row/profile this avatar represents (needed to resolve a logo override). */
+  asset: Pick<Asset, "id" | "customLogoFilename"> | undefined;
+}
+
+/**
+ * Convenience wrapper for call sites that already have a full `Asset` object
+ * (as opposed to the slimmer `Instrument` DTO some holdings/activity views
+ * use) — resolves the logo override automatically instead of requiring each
+ * caller to call `useAssetLogoUrl` itself.
+ */
+export const AssetTickerAvatar = ({ asset, ...props }: AssetTickerAvatarProps) => {
+  const { data: customLogoUrl } = useAssetLogoUrl(asset);
+  return <TickerAvatar {...props} customLogoUrl={customLogoUrl} />;
+};
+
+interface AssetLogoWatermarkProps {
+  /** The full asset/instrument this row represents (needed to resolve a logo override). */
+  asset: Pick<Asset, "id" | "customLogoFilename"> | undefined;
+  className?: string;
+}
+
+/**
+ * Large, unboxed, low-opacity background rendering of a custom logo,
+ * intended for full-width list rows (e.g. a holdings row). Renders nothing
+ * when the asset has no custom logo override. The containing row must be
+ * `relative` (and ideally `isolate overflow-hidden`) for this to lay out
+ * correctly behind the row's foreground content.
+ */
+export const AssetLogoWatermark = ({ asset, className }: AssetLogoWatermarkProps) => {
+  const { data: customLogoUrl } = useAssetLogoUrl(asset);
+  if (!customLogoUrl) return null;
+
+  // A background-image div anchored directly to its own container's edges
+  // (top-0 bottom-0), rather than an <img> sized via `h-full`/`inset-y-0` —
+  // percentage heights on a positioned element only resolve if every
+  // ancestor in the chain has a *definite* height, which table cells and
+  // flex rows sized by their own content don't reliably provide. Anchoring
+  // to edges works regardless of how the container's height was computed.
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute left-0 top-0 bottom-0 -z-10 w-48 opacity-10",
+        "[mask-image:linear-gradient(to_right,black,transparent_85%)]",
+        className,
+      )}
+      style={{
+        backgroundImage: `url(${customLogoUrl})`,
+        // Bounded to a fixed-width box (not the full row): `cover` scales to
+        // fill both dimensions of *that* box, giving a bigger, more zoomed-in
+        // result than fitting to height alone, and leaves room past the
+        // image's own edge for the mask fade to actually be visible against.
+        backgroundSize: "cover",
+        backgroundPosition: "left center",
+        backgroundRepeat: "no-repeat",
+      }}
+    />
   );
 };

--- a/apps/frontend/src/components/ticker-avatar.tsx
+++ b/apps/frontend/src/components/ticker-avatar.tsx
@@ -35,6 +35,18 @@ const getCashAvatarLabel = (symbol: string): string | null => {
 
 const getFallbackAvatarLabel = (symbol: string): string => symbol.slice(0, 4);
 
+/**
+ * A user-uploaded logo is already tightly cropped, so it should render
+ * edge-to-edge (`object-contain` only). The bundled ticker-logos fallback has
+ * more surrounding whitespace baked into the source images and needs padding
+ * to avoid looking oversized in the circle. Call sites that pass their own
+ * `imageClassName` must derive it from this so the two cases don't diverge.
+ */
+export const getTickerLogoImageClassName = (
+  hasCustomLogo: boolean,
+  fallbackPadding: string,
+): string => (hasCustomLogo ? "object-contain" : `object-contain ${fallbackPadding}`);
+
 export const TickerAvatar = ({
   symbol,
   className = "size-8",
@@ -67,7 +79,7 @@ export const TickerAvatar = ({
   // way the aspect ratio is preserved, unlike `object-cover` (which crops)
   // or leaving `object-fit` unset (which stretches to fill).
   const resolvedImageClassName =
-    imageClassName ?? (customLogoUrl ? "object-contain" : "object-contain p-2");
+    imageClassName ?? getTickerLogoImageClassName(!!customLogoUrl, "p-2");
 
   useEffect(() => {
     setLogoUrl(primaryLogoUrl);

--- a/apps/frontend/src/hooks/use-asset-logo-url.ts
+++ b/apps/frontend/src/hooks/use-asset-logo-url.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAssetLogoUrl } from "@/adapters";
+import { QueryKeys } from "@/lib/query-keys";
+import type { Asset } from "@/lib/types";
+
+export function useAssetLogoUrl(asset: Pick<Asset, "id" | "customLogoFilename"> | undefined) {
+  return useQuery<string | null, Error>({
+    queryKey: [QueryKeys.ASSET_DATA, asset?.id, "logo", asset?.customLogoFilename],
+    queryFn: () => getAssetLogoUrl(asset),
+    enabled: !!asset?.customLogoFilename,
+  });
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -243,6 +243,8 @@ export interface ActivityDetails {
   counterpartCurrency?: string | null;
   counterpartFxRate?: string | null;
   subRows?: ActivityDetails[];
+  /** User-uploaded logo override filename for the activity's asset, if one has been set */
+  customLogoFilename?: string | null;
 }
 
 export interface ActivitySearchResponse {
@@ -752,6 +754,8 @@ export interface HoldingSummary {
   marketValue: number; // Base currency value
   currency: string;
   weightInCategory: number; // Percentage weight within the category (0-100)
+  /** User-uploaded logo override filename, if one has been set on the asset */
+  customLogoFilename?: string | null;
 }
 
 /**
@@ -2662,6 +2666,8 @@ export interface DriftHoldingRow {
   driftBps?: number | null;
   isUnknownCategory: boolean;
   isCash: boolean;
+  /** User-uploaded logo override filename, if one has been set on the asset */
+  customLogoFilename?: string | null;
 }
 
 export interface DriftHoldingsReport {

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -625,6 +625,9 @@ export interface Instrument {
 
   // Taxonomy-based classifications
   classifications?: AssetClassifications | null;
+
+  // User-uploaded logo override filename, if one has been set
+  customLogoFilename?: string | null;
 }
 
 export interface MonetaryValue {
@@ -803,6 +806,9 @@ export interface Asset {
 
   // Derived
   exchangeName?: string | null; // Friendly exchange name (e.g., "NASDAQ")
+
+  // User-uploaded logo override filename, if one has been set
+  customLogoFilename?: string | null;
 
   // Audit
   createdAt: string; // ISO date string

--- a/apps/frontend/src/pages/activity/components/activity-date-list.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-date-list.tsx
@@ -1,4 +1,4 @@
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import {
   calculateActivityCashImpact,
   calculateActivityValue,
@@ -200,7 +200,11 @@ function ActivityDateListItem({
   const content = (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+        <AssetTickerAvatar
+          asset={{ id: activity.assetId, customLogoFilename: activity.customLogoFilename }}
+          symbol={avatarSymbol}
+          className="h-10 w-10 flex-shrink-0"
+        />
         <div className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] gap-x-3">
           <p className="truncate text-base font-semibold leading-5">{displaySymbol}</p>
           {activity.activityType !== ActivityType.SPLIT ? (

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -1,4 +1,4 @@
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import {
   calculateActivityValue,
@@ -134,7 +134,11 @@ export const ActivityTableMobile = ({
                 {(() => {
                   const inner = (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+                      <AssetTickerAvatar
+                        asset={{ id: activity.assetId, customLogoFilename: activity.customLogoFilename }}
+                        symbol={avatarSymbol}
+                        className="h-10 w-10 flex-shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-baseline justify-between gap-2">
                           <p className="truncate font-semibold">{displaySymbol}</p>
@@ -203,7 +207,11 @@ export const ActivityTableMobile = ({
                 {(() => {
                   const inner = (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10" />
+                      <AssetTickerAvatar
+                        asset={{ id: activity.assetId, customLogoFilename: activity.customLogoFilename }}
+                        symbol={avatarSymbol}
+                        className="h-10 w-10"
+                      />
                       <div>
                         <p className="font-semibold">{displaySymbol}</p>
                         <p className="text-muted-foreground text-xs">

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import { DataTableColumnHeader } from "@wealthfolio/ui/components/ui/data-table/data-table-column-header";
 import {
@@ -226,7 +226,11 @@ export const ActivityTable = ({
 
           const content = (
             <div className="flex max-w-[220px] items-center gap-2">
-              <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
+              <AssetTickerAvatar
+                asset={{ id: assetId, customLogoFilename: row.original.customLogoFilename }}
+                symbol={avatarSymbol}
+                className="h-8 w-8 shrink-0"
+              />
               <div className="flex min-w-0 flex-col">
                 <span className="flex items-center gap-1 truncate font-medium">
                   <span className="truncate">{displaySymbol}</span>

--- a/apps/frontend/src/pages/allocation-targets/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/holdings-table.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@wealthfolio/ui";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar, getTickerLogoImageClassName } from "@/components/ticker-avatar";
 import { cn, formatAmount } from "@/lib/utils";
 import { useAccounts } from "@/hooks/use-accounts";
 import type { DriftHoldingRow, DriftReport } from "@/lib/types";
@@ -32,10 +32,14 @@ function cashSymbol(currency: string): string {
 function HoldingAvatar({
   isCash,
   symbol,
+  assetId,
+  customLogoFilename,
   className = "size-6",
 }: {
   isCash: boolean;
   symbol: string;
+  assetId: string;
+  customLogoFilename?: string | null;
   className?: string;
 }) {
   if (isCash) {
@@ -52,10 +56,11 @@ function HoldingAvatar({
   }
 
   return (
-    <TickerAvatar
+    <AssetTickerAvatar
+      asset={{ id: assetId, customLogoFilename }}
       symbol={symbol === "-" ? "?" : symbol}
       className={cn("shrink-0", className)}
-      imageClassName="object-contain p-1"
+      imageClassName={getTickerLogoImageClassName(!!customLogoFilename, "p-1")}
     />
   );
 }
@@ -149,7 +154,13 @@ export function HoldingsTable({ report }: HoldingsTableProps) {
               >
                 <div className="grid grid-cols-[1.75rem_minmax(0,1fr)_auto] gap-x-3 gap-y-1">
                   <div className="row-span-2 flex items-center">
-                    <HoldingAvatar isCash={row.isCash} symbol={row.symbol} className="size-7" />
+                    <HoldingAvatar
+                      isCash={row.isCash}
+                      symbol={row.symbol}
+                      assetId={row.assetId}
+                      customLogoFilename={row.customLogoFilename}
+                      className="size-7"
+                    />
                   </div>
 
                   <div className="flex min-w-0 items-baseline gap-1.5">
@@ -238,7 +249,12 @@ export function HoldingsTable({ report }: HoldingsTableProps) {
                   >
                     <td className="pl-6 pr-3">
                       <div className="flex min-w-[280px] items-center gap-2">
-                        <HoldingAvatar isCash={row.isCash} symbol={row.symbol} />
+                        <HoldingAvatar
+                          isCash={row.isCash}
+                          symbol={row.symbol}
+                          assetId={row.assetId}
+                          customLogoFilename={row.customLogoFilename}
+                        />
                         <div className="flex min-w-0 items-baseline gap-2">
                           <span className="text-foreground shrink-0 text-[12px] font-semibold">
                             {row.symbol}

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -1,7 +1,7 @@
 import { getExchanges, resolveSymbolQuote } from "@/adapters";
 import { MultiSelectTaxonomy } from "@/components/classification/multi-select-taxonomy";
 import { SingleSelectTaxonomy } from "@/components/classification/single-select-taxonomy";
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { useCustomProviders } from "@/hooks/use-custom-providers";
 import { useMarketDataProviders } from "@/hooks/use-market-data-providers";
 import { useTaxonomies } from "@/hooks/use-taxonomies";
@@ -655,7 +655,7 @@ export function AssetEditSheet({
       <SheetContent side="right" className="pb-safe flex h-full w-full flex-col sm:max-w-2xl">
         <SheetHeader className="shrink-0 pb-4">
           <div className="flex items-center gap-3">
-            <TickerAvatar symbol={asset.displayCode ?? ""} className="size-10" />
+            <AssetTickerAvatar asset={asset} symbol={asset.displayCode ?? ""} className="size-10" />
             <div className="min-w-0 flex-1">
               <SheetTitle className="truncate text-lg">
                 {asset.displayCode ?? asset.name ?? t("asset:editSheet.unknown")}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -33,7 +33,7 @@ import {
   AlertDialogTitle,
 } from "@wealthfolio/ui/components/ui/alert-dialog";
 import { Tabs, TabsContent } from "@wealthfolio/ui/components/ui/tabs";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
@@ -51,6 +51,8 @@ import ActivityTableMobile from "@/pages/activity/components/activity-table/acti
 import { MobileActivityForm } from "@/pages/activity/components/mobile-forms/mobile-activity-form";
 import { useActivityActionDialogs } from "@/pages/activity/hooks/use-activity-action-dialogs";
 import { useAssetProfile } from "./hooks/use-asset-profile";
+import { useAssetLogoUrl } from "@/hooks/use-asset-logo-url";
+import { isDesktop } from "@/adapters";
 import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
 import { RefreshQuotesConfirmDialog } from "./refresh-quotes-confirm-dialog";
 import { useQuoteMutations } from "./hooks/use-quote-mutations";
@@ -304,6 +306,9 @@ export const AssetProfilePage = () => {
     isError: isAssetProfileError,
   } = useAssetProfile(assetId);
 
+  const { data: customLogoUrl } = useAssetLogoUrl(assetProfile ?? undefined);
+  const logoFileInputRef = useRef<HTMLInputElement>(null);
+
   const {
     holdings: allHoldings,
     isLoading: isHoldingLoading,
@@ -334,7 +339,8 @@ export const AssetProfilePage = () => {
   // Taxonomy data for category badges - use same approach as edit sheet
   const { data: assignments = [], isLoading: isAssignmentsLoading } =
     useAssetTaxonomyAssignments(assetId);
-  const { updateQuoteModeMutation } = useAssetProfileMutations();
+  const { updateQuoteModeMutation, uploadAssetLogoMutation, removeAssetLogoMutation } =
+    useAssetProfileMutations();
 
   // Fetch taxonomy details for taxonomies with assignments
   // We need the categories to get name and color
@@ -1359,6 +1365,30 @@ export const AssetProfilePage = () => {
                             label: t("asset:profile.edit"),
                             onClick: () => setEditSheetOpen(true),
                           },
+                          {
+                            icon: Icons.FileImage,
+                            label: assetProfile?.customLogoFilename
+                              ? t("asset:profile.change_logo", { defaultValue: "Change logo" })
+                              : t("asset:profile.upload_logo", { defaultValue: "Upload logo" }),
+                            onClick: () => {
+                              if (isDesktop) {
+                                uploadAssetLogoMutation.mutate({ assetId });
+                              } else {
+                                logoFileInputRef.current?.click();
+                              }
+                            },
+                          },
+                          ...(assetProfile?.customLogoFilename
+                            ? [
+                                {
+                                  icon: Icons.Trash,
+                                  label: t("asset:profile.remove_logo", {
+                                    defaultValue: "Remove logo",
+                                  }),
+                                  onClick: () => removeAssetLogoMutation.mutate(assetId),
+                                },
+                              ]
+                            : []),
                         ],
                       },
                     ] satisfies ActionPaletteGroup[])
@@ -1368,6 +1398,17 @@ export const AssetProfilePage = () => {
                   <Icons.DotsThreeVertical className="h-5 w-5" weight="fill" />
                 </Button>
               }
+            />
+            <input
+              ref={logoFileInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                e.target.value = "";
+                if (file) uploadAssetLogoMutation.mutate({ assetId, file });
+              }}
             />
           </div>
         }
@@ -1387,6 +1428,7 @@ export const AssetProfilePage = () => {
                   assetId
                 }
                 className="size-9"
+                customLogoUrl={customLogoUrl}
               />
             )
           )}

--- a/apps/frontend/src/pages/asset/assets-table-mobile.tsx
+++ b/apps/frontend/src/pages/asset/assets-table-mobile.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 
 import { Badge, Card, formatPrice, Input } from "@wealthfolio/ui";
 
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { ASSET_KIND_DISPLAY_NAMES, LatestQuoteSnapshot } from "@/lib/types";
 import { parseOccSymbol } from "@/lib/occ-symbol";
@@ -226,7 +226,11 @@ export function AssetsTableMobile({
                   const avatarSymbol = parsedOption ? parsedOption.underlying : rawSymbol;
                   return (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+                      <AssetTickerAvatar
+                        asset={asset}
+                        symbol={avatarSymbol}
+                        className="h-10 w-10 flex-shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
                           <p className="truncate font-semibold">{displaySymbol}</p>

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { Badge } from "@wealthfolio/ui";
 import { DataTable } from "@wealthfolio/ui/components/ui/data-table";
 import { DataTableColumnHeader } from "@wealthfolio/ui/components/ui/data-table/data-table-column-header";
@@ -107,7 +107,7 @@ export function AssetsTable({
               onClick={() => navigate(`/holdings/${encodeURIComponent(asset.id)}`)}
               className="hover:bg-muted/60 focus-visible:ring-ring group flex w-full items-center gap-2.5 rounded-md py-1 text-left transition"
             >
-              <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
+              <AssetTickerAvatar asset={asset} symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
               <div className="min-w-0 flex-1">
                 <div className="group-hover:text-primary flex items-center gap-1.5 font-semibold leading-tight transition-colors">
                   {displaySymbol}

--- a/apps/frontend/src/pages/asset/hooks/use-asset-profile-mutations.ts
+++ b/apps/frontend/src/pages/asset/hooks/use-asset-profile-mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updateAssetProfile, updateQuoteMode, logger } from "@/adapters";
+import { updateAssetProfile, updateQuoteMode, uploadAssetLogo, removeAssetLogo, logger } from "@/adapters";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { QueryKeys } from "@/lib/query-keys";
 
@@ -48,8 +48,33 @@ export const useAssetProfileMutations = () => {
     },
   });
 
+  const uploadAssetLogoMutation = useMutation({
+    mutationFn: ({ assetId, file }: { assetId: string; file?: File }) =>
+      uploadAssetLogo(assetId, file),
+    onSuccess: (_result, variables) => {
+      handleSuccess("Logo updated successfully.", variables.assetId);
+    },
+    onError: (error) => {
+      logger.error(`Error uploading asset logo: ${error}`);
+      handleError("uploading the logo");
+    },
+  });
+
+  const removeAssetLogoMutation = useMutation({
+    mutationFn: (assetId: string) => removeAssetLogo(assetId),
+    onSuccess: (_result, assetId) => {
+      handleSuccess("Logo removed.", assetId);
+    },
+    onError: (error) => {
+      logger.error(`Error removing asset logo: ${error}`);
+      handleError("removing the logo");
+    },
+  });
+
   return {
     updateAssetProfileMutation,
     updateQuoteModeMutation,
+    uploadAssetLogoMutation,
+    removeAssetLogoMutation,
   };
 };

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -1,6 +1,6 @@
 import { DashboardCard } from "@/components/dashboard-card";
 import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { HoldingType, isAlternativeAssetKind } from "@/lib/constants";
 import { getBaseHoldingPerformancePercentForMode } from "@/lib/holding-performance";
@@ -73,7 +73,11 @@ function HoldingRow({
       onKeyDown={(e) => e.key === "Enter" && onClick?.()}
     >
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        <TickerAvatar symbol={avatarSymbol} className="size-9 shrink-0" />
+        <AssetTickerAvatar
+          asset={holding.instrument ?? undefined}
+          symbol={avatarSymbol}
+          className="size-9 shrink-0"
+        />
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-sm font-semibold">{title}</span>
           <span className="text-muted-foreground text-xs">{subtitle}</span>
@@ -134,7 +138,11 @@ function StackedAvatars({ holdings, totalRemaining, onClick }: StackedAvatarsPro
               className={cn("relative", index > 0 && "-ml-2")}
               style={{ zIndex: displayedHoldings.length - index }}
             >
-              <TickerAvatar symbol={avatarSym} className="ring-background size-8 ring-2" />
+              <AssetTickerAvatar
+                asset={holding.instrument ?? undefined}
+                symbol={avatarSym}
+                className="ring-background size-8 ring-2"
+              />
             </div>
           );
         })}

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { getHoldingsByAllocation } from "@/adapters";
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { HoldingType } from "@/lib/constants";
 import type {
   AccountScope,
@@ -408,7 +408,11 @@ export function AllocationDetailSheet({
                         )}
                         onClick={() => handleHoldingClick(holding)}
                       >
-                        <TickerAvatar symbol={avatarSymbol} className="h-9 w-9" />
+                        <AssetTickerAvatar
+                          asset={{ id: holding.id, customLogoFilename: holding.customLogoFilename }}
+                          symbol={avatarSymbol}
+                          className="h-9 w-9"
+                        />
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-semibold">{primaryLabel}</p>
                           <p className="text-muted-foreground truncate text-xs">{secondaryLabel}</p>

--- a/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
@@ -20,7 +20,7 @@ import { ScrollArea } from "@wealthfolio/ui/components/ui/scroll-area";
 import { toast } from "sonner";
 import { format, parseISO } from "date-fns";
 
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar, TickerAvatar } from "@/components/ticker-avatar";
 import TickerSearchInput from "@/components/ticker-search";
 import {
   saveManualHoldings,
@@ -57,6 +57,8 @@ interface EditableHolding {
   /** Provider-native symbol/code selected by search/import. */
   providerSymbol?: string;
   isNew?: boolean;
+  /** User-uploaded logo override filename, if one has been set on the asset */
+  customLogoFilename?: string | null;
 }
 
 interface EditableCashBalance {
@@ -130,6 +132,7 @@ export const HoldingsEditMode = ({
           averageCost,
           currency: h.localCurrency,
           isNew: false,
+          customLogoFilename: h.instrument?.customLogoFilename,
         };
       });
   }, []);
@@ -463,7 +466,11 @@ export const HoldingsEditMode = ({
                         {/* Symbol */}
                         <div className="col-span-5">
                           <div className="flex items-center gap-2">
-                            <TickerAvatar symbol={holding.symbol} className="h-7 w-7 shrink-0" />
+                            <AssetTickerAvatar
+                              asset={{ id: holding.assetId, customLogoFilename: holding.customLogoFilename }}
+                              symbol={holding.symbol}
+                              className="h-7 w-7 shrink-0"
+                            />
                             <div className="min-w-0">
                               <div className="truncate text-sm font-medium">{holding.symbol}</div>
                               {holding.name && (

--- a/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
@@ -8,7 +8,7 @@ import {
 } from "@wealthfolio/ui/components/ui/collapsible";
 import { AmountDisplay, QuantityDisplay } from "@wealthfolio/ui";
 import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetTickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { Holding, HOLDING_GROUP_ORDER } from "@/lib/types";
 import { AccountType, AssetKind, HoldingType } from "@/lib/constants";
@@ -268,7 +268,11 @@ function HoldingRow({
       >
         {/* Symbol/Name Column */}
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 flex-shrink-0" />
+          <AssetTickerAvatar
+            asset={holding.instrument ?? undefined}
+            symbol={avatarSymbol}
+            className="h-8 w-8 flex-shrink-0"
+          />
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex items-center gap-2">
               <span className="truncate font-medium">{symbol}</span>

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -1,4 +1,4 @@
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetLogoWatermark, AssetTickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
 import { parseOccSymbol } from "@/lib/occ-symbol";
@@ -187,14 +187,19 @@ export const HoldingsTableMobile = ({
               <Card
                 key={holding.id}
                 className={cn(
-                  "p-3",
+                  "relative isolate overflow-hidden p-3",
                   isNavigable && "hover:bg-muted/50 cursor-pointer transition-colors",
                 )}
                 onClick={() => isNavigable && handleNavigate(holding)}
               >
+                <AssetLogoWatermark asset={holding.instrument ?? undefined} />
                 <div className="flex items-center justify-between">
                   <div className="flex flex-1 items-center gap-3 overflow-hidden">
-                    <TickerAvatar symbol={avatarSymbol} className="h-10 w-10" />
+                    <AssetTickerAvatar
+                      asset={holding.instrument ?? undefined}
+                      symbol={avatarSymbol}
+                      className="h-10 w-10"
+                    />
                     <div className="flex-1 overflow-hidden">
                       <div className="flex items-center gap-1.5">
                         <p className="truncate font-semibold">{displaySymbol}</p>

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -13,7 +13,7 @@ import {
 } from "@wealthfolio/ui/components/ui/dropdown-menu";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 
-import { TickerAvatar } from "@/components/ticker-avatar";
+import { AssetLogoWatermark, AssetTickerAvatar } from "@/components/ticker-avatar";
 import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
@@ -228,8 +228,13 @@ const getColumns = (
 
       const isManual = holding.instrument?.quoteMode === "MANUAL";
       const content = (
-        <div className="flex items-center">
-          <TickerAvatar symbol={avatarSymbol} className="mr-2 h-8 w-8" />
+        <div className="relative isolate -m-4 flex items-center overflow-hidden p-4">
+          <AssetLogoWatermark asset={holding.instrument ?? undefined} />
+          <AssetTickerAvatar
+            asset={holding.instrument ?? undefined}
+            symbol={avatarSymbol}
+            className="mr-2 h-8 w-8"
+          />
           <div className="flex flex-col">
             <div className="flex items-center gap-1.5">
               <span className="font-medium">{displaySymbol}</span>

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -115,6 +115,7 @@ export const HoldingsPage = () => {
     id: string;
     symbol: string;
     name?: string;
+    customLogoFilename?: string | null;
   } | null>(null);
 
   // Edit mode state for HOLDINGS-mode accounts
@@ -446,6 +447,7 @@ export const HoldingsPage = () => {
                   id: holding.instrument?.id ?? holding.id,
                   symbol: holding.instrument?.symbol ?? holding.id,
                   name: holding.instrument?.name ?? undefined,
+                  customLogoFilename: holding.instrument?.customLogoFilename,
                 })
               }
             />
@@ -760,6 +762,7 @@ export const HoldingsPage = () => {
         assetId={classifyAsset?.id ?? ""}
         assetSymbol={classifyAsset?.symbol}
         assetName={classifyAsset?.name}
+        assetCustomLogoFilename={classifyAsset?.customLogoFilename}
       />
     </>
   );

--- a/apps/server/src/api/assets.rs
+++ b/apps/server/src/api/assets.rs
@@ -2,12 +2,17 @@ use std::sync::Arc;
 
 use crate::{error::ApiResult, main_lib::AppState};
 use axum::{
-    extract::{Path, Query, State},
-    http::StatusCode,
+    body::Body,
+    extract::{Multipart, Path, Query, State},
+    http::{header, StatusCode},
+    response::Response,
     routing::{delete, get, put},
     Json, Router,
 };
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use wealthfolio_core::assets::{Asset as CoreAsset, AssetProfile, NewAsset, UpdateAssetProfile};
+
+use crate::error::ApiError;
 
 #[derive(serde::Deserialize)]
 struct AssetQuery {
@@ -74,11 +79,84 @@ async fn delete_asset(
     Ok(StatusCode::NO_CONTENT)
 }
 
+async fn upload_asset_logo(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    mut multipart: Multipart,
+) -> ApiResult<StatusCode> {
+    let mut file_bytes: Option<Vec<u8>> = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| ApiError::BadRequest(format!("Failed to read multipart field: {}", e)))?
+    {
+        if field.name() == Some("file") {
+            file_bytes = Some(
+                field
+                    .bytes()
+                    .await
+                    .map_err(|e| ApiError::BadRequest(format!("Failed to read file: {}", e)))?
+                    .to_vec(),
+            );
+        }
+    }
+
+    let bytes = file_bytes
+        .ok_or_else(|| ApiError::BadRequest("Missing file in multipart request".to_string()))?;
+
+    let asset_service: Arc<dyn wealthfolio_core::assets::AssetServiceTrait> =
+        state.asset_service.clone();
+    state.asset_logo_store.store(&asset_service, &id, &bytes).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn get_asset_logo(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Response> {
+    let asset_service: Arc<dyn wealthfolio_core::assets::AssetServiceTrait> =
+        state.asset_service.clone();
+    match state.asset_logo_store.read(&asset_service, &id)? {
+        Some((bytes, content_type)) => Ok(Response::builder()
+            .header(header::CONTENT_TYPE, content_type)
+            .header(header::CACHE_CONTROL, "no-cache")
+            .body(Body::from(bytes))
+            .map_err(|e| ApiError::Internal(e.to_string()))?),
+        None => Err(ApiError::NotFound),
+    }
+}
+
+async fn remove_asset_logo(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<StatusCode> {
+    let asset_service: Arc<dyn wealthfolio_core::assets::AssetServiceTrait> =
+        state.asset_service.clone();
+    state.asset_logo_store.remove(&asset_service, &id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 pub fn router() -> Router<Arc<AppState>> {
+    // Rate limit logo uploads: 5 per 60 seconds per peer IP, to bound
+    // disk-fill abuse from a compromised or malicious authenticated session.
+    let upload_logo_governor = GovernorConfigBuilder::default()
+        .per_second(12)
+        .burst_size(5)
+        .finish()
+        .expect("valid governor config");
+
     Router::new()
         .route("/assets", get(list_assets).post(create_asset))
         .route("/assets/{id}", delete(delete_asset))
         .route("/assets/profile", get(get_asset_profile))
         .route("/assets/profile/{id}", put(update_asset_profile))
         .route("/assets/pricing-mode/{id}", put(update_quote_mode))
+        .route("/assets/{id}/logo", get(get_asset_logo))
+        .route("/assets/{id}/logo", delete(remove_asset_logo))
+        .route(
+            "/assets/{id}/logo",
+            axum::routing::post(upload_asset_logo)
+                .layer(GovernorLayer::new(upload_logo_governor)),
+        )
 }

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -20,7 +20,7 @@ use wealthfolio_core::{
     activities::{ActivityService as CoreActivityService, ActivityServiceTrait},
     assets::{
         AlternativeAssetRepositoryTrait, AlternativeAssetService, AlternativeAssetServiceTrait,
-        AssetClassificationService, AssetService, AssetServiceTrait,
+        AssetClassificationService, AssetLogoStore, AssetService, AssetServiceTrait,
     },
     events::DomainEventSink,
     fx::{FxService, FxServiceTrait},
@@ -94,6 +94,7 @@ pub struct AppState {
     pub fx_service: Arc<dyn FxServiceTrait + Send + Sync>,
     pub activity_service: Arc<dyn ActivityServiceTrait + Send + Sync>,
     pub asset_service: Arc<dyn AssetServiceTrait + Send + Sync>,
+    pub asset_logo_store: Arc<AssetLogoStore>,
     pub taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
     pub net_worth_service: Arc<dyn NetWorthServiceTrait + Send + Sync>,
     pub alternative_asset_service: Arc<dyn AlternativeAssetServiceTrait + Send + Sync>,
@@ -829,6 +830,10 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         None => None,
     };
 
+    let asset_logo_store = Arc::new(AssetLogoStore::new(
+        std::path::Path::new(&data_root).join("asset-logos"),
+    ));
+
     let state = Arc::new(AppState {
         domain_event_sink,
         account_service,
@@ -849,6 +854,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         fx_service: fx_service.clone(),
         activity_service,
         asset_service,
+        asset_logo_store,
         taxonomy_service,
         net_worth_service,
         alternative_asset_service,

--- a/apps/tauri/src/commands/asset.rs
+++ b/apps/tauri/src/commands/asset.rs
@@ -1,8 +1,18 @@
 use std::sync::Arc;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use crate::context::ServiceContext;
-use tauri::State;
+use serde::Serialize;
+use tauri::{AppHandle, State};
+use tauri_plugin_dialog::DialogExt;
 use wealthfolio_core::assets::{Asset, AssetProfile, NewAsset, UpdateAssetProfile};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetLogoPayload {
+    content_base64: String,
+    content_type: &'static str,
+}
 
 #[tauri::command]
 pub async fn get_asset_profile(
@@ -67,6 +77,79 @@ pub async fn delete_asset(id: String, state: State<'_, Arc<ServiceContext>>) -> 
     state
         .asset_service()
         .delete_asset(&id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_asset_logo(
+    asset_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Option<AssetLogoPayload>, String> {
+    let store = state.asset_logo_store();
+    let asset_service = state.asset_service();
+    let result = tauri::async_runtime::spawn_blocking(move || store.read(&asset_service, &asset_id))
+        .await
+        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())?;
+
+    Ok(result.map(|(bytes, content_type)| AssetLogoPayload {
+        content_base64: BASE64_STANDARD.encode(bytes),
+        content_type,
+    }))
+}
+
+/// Opens a native file picker restricted to image files and, if the user
+/// selects one, uploads it as the custom logo for `asset_id`.
+/// Returns `false` if the user cancelled the dialog.
+#[tauri::command]
+pub async fn pick_and_upload_asset_logo(
+    asset_id: String,
+    app_handle: AppHandle,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<bool, String> {
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    {
+        let _ = (&asset_id, &app_handle, &state);
+        return Err("Logo upload is only supported on desktop".to_string());
+    }
+
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    {
+        let Some(picked) = app_handle
+            .dialog()
+            .file()
+            .add_filter("Image", &["png", "jpg", "jpeg", "webp"])
+            .blocking_pick_file()
+        else {
+            return Ok(false);
+        };
+
+        let path = picked
+            .into_path()
+            .map_err(|e| format!("Failed to resolve selected file path: {}", e))?;
+
+        let bytes = std::fs::read(&path)
+            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+        state
+            .asset_logo_store()
+            .store(&state.asset_service(), &asset_id, &bytes)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(true)
+    }
+}
+
+#[tauri::command]
+pub async fn remove_asset_logo(
+    asset_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<(), String> {
+    state
+        .asset_logo_store()
+        .remove(&state.asset_service(), &asset_id)
         .await
         .map_err(|e| e.to_string())
 }

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -1698,6 +1698,7 @@ pub async fn get_snapshot_by_date(
             preferred_provider: asset.preferred_provider(),
             exchange_mic: asset.instrument_exchange_mic.clone(),
             classifications: None,
+            custom_logo_filename: asset.custom_logo_filename.clone(),
         };
 
         let holding = Holding {

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -596,6 +596,10 @@ pub async fn initialize_context(
         warn!("Failed to prune local sync outbox: {}", err);
     }
 
+    let asset_logo_store = Arc::new(wealthfolio_core::assets::AssetLogoStore::new(
+        std::path::Path::new(app_data_dir).join("asset-logos"),
+    ));
+
     Ok(ContextInitResult {
         context: ServiceContext {
             base_currency,
@@ -606,6 +610,7 @@ pub async fn initialize_context(
             account_service,
             activity_service,
             asset_service,
+            asset_logo_store,
             goal_service,
             quote_service,
             limits_service,

--- a/apps/tauri/src/context/registry.rs
+++ b/apps/tauri/src/context/registry.rs
@@ -46,6 +46,7 @@ pub struct ServiceContext {
     pub account_service: Arc<dyn accounts::AccountServiceTrait>,
     pub goal_service: Arc<dyn goals::GoalServiceTrait>,
     pub asset_service: Arc<dyn assets::AssetServiceTrait>,
+    pub asset_logo_store: Arc<assets::AssetLogoStore>,
     pub quote_service: Arc<dyn quotes::QuoteServiceTrait>,
     pub limits_service: Arc<dyn limits::ContributionLimitServiceTrait>,
     pub fx_service: Arc<dyn fx::FxServiceTrait>,
@@ -147,6 +148,10 @@ impl ServiceContext {
 
     pub fn asset_service(&self) -> Arc<dyn assets::AssetServiceTrait> {
         Arc::clone(&self.asset_service)
+    }
+
+    pub fn asset_logo_store(&self) -> Arc<assets::AssetLogoStore> {
+        Arc::clone(&self.asset_logo_store)
     }
 
     pub fn goal_service(&self) -> Arc<dyn goals::GoalServiceTrait> {

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -606,6 +606,9 @@ pub fn run() {
             commands::asset::update_quote_mode,
             commands::asset::delete_asset,
             commands::asset::create_asset,
+            commands::asset::get_asset_logo,
+            commands::asset::pick_and_upload_asset_logo,
+            commands::asset::remove_asset_logo,
             // Alternative asset commands
             commands::alternative_assets::create_alternative_asset,
             commands::alternative_assets::update_alternative_asset_valuation,

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -816,6 +816,8 @@ pub struct ActivityDetails {
     pub import_run_id: Option<String>,
     pub is_user_modified: bool,
     pub metadata: Option<Value>,
+    // User-uploaded logo override filename, if one has been set on the asset
+    pub custom_logo_filename: Option<String>,
 }
 
 impl ActivityDetails {

--- a/crates/core/src/assets/alternative_assets_service.rs
+++ b/crates/core/src/assets/alternative_assets_service.rs
@@ -965,6 +965,14 @@ mod tests {
             unimplemented!("not used in this test")
         }
 
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> Result<crate::assets::assets_model::Asset> {
+            unimplemented!("not used in this test")
+        }
+
         fn get_by_id(&self, asset_id: &str) -> Result<crate::assets::assets_model::Asset> {
             self.assets
                 .iter()

--- a/crates/core/src/assets/asset_logo_store.rs
+++ b/crates/core/src/assets/asset_logo_store.rs
@@ -1,0 +1,437 @@
+//! Local storage for user-uploaded per-asset logo overrides.
+//!
+//! Bytes are validated by file-signature (not by trusting the caller's
+//! declared extension or MIME type) before ever touching disk, and the
+//! on-disk filename is always derived from the asset id, never from
+//! caller-supplied input, so this cannot be used for path traversal.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::assets_traits::AssetServiceTrait;
+use crate::errors::{Error, Result, ValidationError};
+
+/// Hard cap on uploaded logo size. Generous for a small square icon, small
+/// enough to make disk-fill abuse impractical.
+const MAX_LOGO_BYTES: usize = 2 * 1024 * 1024;
+
+/// Supported image formats, matched by file-signature ("magic bytes"), not
+/// by trusting the extension or `Content-Type` the caller sent.
+const SIGNATURES: &[(&str, &str, &[u8])] = &[
+    ("png", "image/png", &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+    ("jpg", "image/jpeg", &[0xFF, 0xD8, 0xFF]),
+    ("webp", "image/webp", b"RIFF"), // followed by size (4 bytes) then "WEBP"; checked below
+];
+
+fn detect_image_type(bytes: &[u8]) -> Result<(&'static str, &'static str)> {
+    if bytes.len() > MAX_LOGO_BYTES {
+        return Err(Error::Validation(ValidationError::InvalidInput(
+            "Image exceeds the 2MB size limit".to_string(),
+        )));
+    }
+
+    for (ext, content_type, magic) in SIGNATURES {
+        if *ext == "webp" {
+            if bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+                return Ok((ext, content_type));
+            }
+            continue;
+        }
+        if bytes.starts_with(magic) {
+            return Ok((ext, content_type));
+        }
+    }
+
+    Err(Error::Validation(ValidationError::InvalidInput(
+        "Unsupported or unrecognized image format; only PNG, JPEG, and WEBP are allowed"
+            .to_string(),
+    )))
+}
+
+/// An asset id must already be a validated identifier (UUID) coming from the
+/// database, but we never trust that assumption when building filesystem
+/// paths — reject anything that isn't a plain alphanumeric/dash token.
+fn sanitize_asset_id(asset_id: &str) -> Result<()> {
+    let valid = !asset_id.is_empty()
+        && asset_id.len() <= 128
+        && asset_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '$');
+    if valid {
+        Ok(())
+    } else {
+        Err(Error::Validation(ValidationError::InvalidInput(
+            "Invalid asset id".to_string(),
+        )))
+    }
+}
+
+pub struct AssetLogoStore {
+    base_dir: PathBuf,
+}
+
+impl AssetLogoStore {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+
+    fn path_for(&self, filename: &str) -> PathBuf {
+        self.base_dir.join(filename)
+    }
+
+    /// Validates, stores, and records a new logo override for `asset_id`,
+    /// replacing any previous override.
+    pub async fn store(
+        &self,
+        service: &Arc<dyn AssetServiceTrait>,
+        asset_id: &str,
+        bytes: &[u8],
+    ) -> Result<()> {
+        sanitize_asset_id(asset_id)?;
+        let (ext, _content_type) = detect_image_type(bytes)?;
+
+        // Verify the asset exists before writing anything to disk.
+        let existing = service.get_asset_by_id(asset_id)?;
+
+        std::fs::create_dir_all(&self.base_dir)
+            .map_err(|e| Error::Asset(format!("Failed to create logo directory: {e}")))?;
+
+        // Clean up a prior override that may have used a different extension.
+        if let Some(old) = existing.custom_logo_filename.as_deref() {
+            let _ = std::fs::remove_file(self.path_for(old));
+        }
+
+        let filename = format!("{asset_id}.{ext}");
+        let path = self.path_for(&filename);
+        std::fs::write(&path, bytes)
+            .map_err(|e| Error::Asset(format!("Failed to write logo file: {e}")))?;
+
+        if let Err(e) = service
+            .update_custom_logo_filename(asset_id, Some(&filename))
+            .await
+        {
+            let _ = std::fs::remove_file(&path);
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    /// Reads the stored override bytes for `asset_id`, if one exists.
+    pub fn read(
+        &self,
+        service: &Arc<dyn AssetServiceTrait>,
+        asset_id: &str,
+    ) -> Result<Option<(Vec<u8>, &'static str)>> {
+        sanitize_asset_id(asset_id)?;
+        let asset = service.get_asset_by_id(asset_id)?;
+        let Some(filename) = asset.custom_logo_filename else {
+            return Ok(None);
+        };
+
+        // Defense in depth: the filename must be exactly what `store` would
+        // have produced for this asset id, never a value that could escape
+        // `base_dir` even if the DB row were somehow corrupted.
+        let Some(ext) = filename.strip_prefix(&format!("{asset_id}.")) else {
+            return Ok(None);
+        };
+        let content_type = match ext {
+            "png" => "image/png",
+            "jpg" => "image/jpeg",
+            "webp" => "image/webp",
+            _ => return Ok(None),
+        };
+
+        let path = self.path_for(&filename);
+        match std::fs::read(&path) {
+            Ok(bytes) => Ok(Some((bytes, content_type))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(Error::Asset(format!("Failed to read logo file: {e}"))),
+        }
+    }
+
+    /// Removes any stored logo override for `asset_id`, restoring the
+    /// default logo resolution.
+    pub async fn remove(
+        &self,
+        service: &Arc<dyn AssetServiceTrait>,
+        asset_id: &str,
+    ) -> Result<()> {
+        sanitize_asset_id(asset_id)?;
+        let asset = service.get_asset_by_id(asset_id)?;
+        if let Some(filename) = asset.custom_logo_filename.as_deref() {
+            let _ = std::fs::remove_file(self.path_for(filename));
+        }
+        service.update_custom_logo_filename(asset_id, None).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assets::assets_model::{Asset, AssetKind, NewAsset, QuoteMode, UpdateAssetProfile};
+    use crate::errors::{DatabaseError, Error};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    const PNG_MAGIC: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    struct FakeAssetService {
+        assets: Mutex<HashMap<String, Asset>>,
+    }
+
+    impl FakeAssetService {
+        fn with_asset(id: &str) -> Self {
+            let mut assets = HashMap::new();
+            assets.insert(
+                id.to_string(),
+                Asset {
+                    id: id.to_string(),
+                    kind: AssetKind::Investment,
+                    quote_mode: QuoteMode::Market,
+                    quote_ccy: "USD".to_string(),
+                    ..Default::default()
+                },
+            );
+            Self {
+                assets: Mutex::new(assets),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AssetServiceTrait for FakeAssetService {
+        fn get_assets(&self) -> Result<Vec<Asset>> {
+            Ok(self.assets.lock().unwrap().values().cloned().collect())
+        }
+
+        fn get_asset_by_id(&self, asset_id: &str) -> Result<Asset> {
+            self.assets
+                .lock()
+                .unwrap()
+                .get(asset_id)
+                .cloned()
+                .ok_or_else(|| Error::Database(DatabaseError::NotFound("not found".to_string())))
+        }
+
+        async fn delete_asset(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn update_asset_profile(
+            &self,
+            _asset_id: &str,
+            _payload: UpdateAssetProfile,
+        ) -> Result<Asset> {
+            unimplemented!()
+        }
+
+        async fn create_asset(&self, _new_asset: NewAsset) -> Result<Asset> {
+            unimplemented!()
+        }
+
+        async fn get_or_create_minimal_asset(
+            &self,
+            _asset_id: &str,
+            _context_currency: Option<String>,
+            _metadata: Option<crate::assets::assets_model::AssetMetadata>,
+            _quote_mode: Option<String>,
+        ) -> Result<Asset> {
+            unimplemented!()
+        }
+
+        async fn update_quote_mode(&self, _asset_id: &str, _quote_mode: &str) -> Result<Asset> {
+            unimplemented!()
+        }
+
+        async fn update_custom_logo_filename(
+            &self,
+            asset_id: &str,
+            filename: Option<&str>,
+        ) -> Result<Asset> {
+            let mut assets = self.assets.lock().unwrap();
+            let asset = assets
+                .get_mut(asset_id)
+                .ok_or_else(|| Error::Database(DatabaseError::NotFound("not found".to_string())))?;
+            asset.custom_logo_filename = filename.map(|f| f.to_string());
+            Ok(asset.clone())
+        }
+
+        async fn get_assets_by_asset_ids(&self, _asset_ids: &[String]) -> Result<Vec<Asset>> {
+            unimplemented!()
+        }
+
+        async fn enrich_asset_profile(&self, _asset_id: &str) -> Result<Asset> {
+            unimplemented!()
+        }
+
+        async fn enrich_assets(&self, _asset_ids: Vec<String>) -> Result<(usize, usize, usize)> {
+            unimplemented!()
+        }
+
+        async fn cleanup_legacy_metadata(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!()
+        }
+
+        async fn merge_unknown_asset(
+            &self,
+            _resolved_asset_id: &str,
+            _unknown_asset_id: &str,
+            _activity_repository: &dyn crate::activities::ActivityRepositoryTrait,
+        ) -> Result<u32> {
+            unimplemented!()
+        }
+
+        async fn ensure_assets(
+            &self,
+            _specs: Vec<crate::assets::assets_model::AssetSpec>,
+            _activity_repository: &dyn crate::activities::ActivityRepositoryTrait,
+        ) -> Result<crate::assets::assets_model::EnsureAssetsResult> {
+            unimplemented!()
+        }
+
+        async fn resolve_import_asset_inputs(
+            &self,
+            _inputs: Vec<crate::assets::AssetResolutionInput>,
+        ) -> Result<Vec<crate::assets::AssetResolutionOutput>> {
+            unimplemented!()
+        }
+    }
+
+    fn service_with_asset(id: &str) -> Arc<dyn AssetServiceTrait> {
+        Arc::new(FakeAssetService::with_asset(id))
+    }
+
+    #[tokio::test]
+    async fn store_rejects_oversized_upload() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        let mut bytes = PNG_MAGIC.to_vec();
+        bytes.extend(vec![0u8; MAX_LOGO_BYTES + 1]);
+
+        let err = store.store(&service, "asset-1", &bytes).await.unwrap_err();
+        assert!(matches!(err, Error::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn store_rejects_content_that_is_not_a_recognized_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        let err = store
+            .store(&service, "asset-1", b"not-an-image, just text")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn store_rejects_extension_spoofing_via_content_sniffing() {
+        // A file merely named "logo.png" but containing non-image bytes must
+        // still be rejected: detection is by magic bytes, never by trusting
+        // a caller-supplied name or content-type.
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        let fake_png = b"<script>alert(1)</script>".to_vec();
+        let err = store.store(&service, "asset-1", &fake_png).await.unwrap_err();
+        assert!(matches!(err, Error::Validation(_)));
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn store_rejects_path_traversal_asset_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        for malicious_id in ["../../etc/passwd", "..\\windows\\system32", "a/b", "a\0b", ""] {
+            let err = store
+                .store(&service, malicious_id, PNG_MAGIC)
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, Error::Validation(_)),
+                "expected rejection for id {malicious_id:?}, got {err:?}"
+            );
+        }
+        // Nothing was ever written to disk, even transiently.
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn store_rejects_unknown_asset_without_writing_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        let err = store
+            .store(&service, "does-not-exist", PNG_MAGIC)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::Database(_)));
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn store_then_read_then_remove_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        store.store(&service, "asset-1", PNG_MAGIC).await.unwrap();
+
+        let (bytes, content_type) = store.read(&service, "asset-1").unwrap().unwrap();
+        assert_eq!(bytes, PNG_MAGIC);
+        assert_eq!(content_type, "image/png");
+
+        let on_disk = std::fs::read_dir(dir.path()).unwrap().count();
+        assert_eq!(on_disk, 1);
+
+        store.remove(&service, "asset-1").await.unwrap();
+        assert!(store.read(&service, "asset-1").unwrap().is_none());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn store_replacing_an_existing_logo_removes_the_old_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        store.store(&service, "asset-1", PNG_MAGIC).await.unwrap();
+        // JPEG magic bytes: different extension than the first upload.
+        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0];
+        store.store(&service, "asset-1", &jpeg).await.unwrap();
+
+        // Only the newest file should remain (the .png from the first
+        // upload must have been cleaned up).
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+        let (bytes, content_type) = store.read(&service, "asset-1").unwrap().unwrap();
+        assert_eq!(bytes, jpeg);
+        assert_eq!(content_type, "image/jpeg");
+    }
+
+    #[tokio::test]
+    async fn read_defends_against_a_corrupted_filename_escaping_base_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AssetLogoStore::new(dir.path());
+        let service = service_with_asset("asset-1");
+
+        // Simulate a corrupted DB row pointing outside the expected
+        // "{asset_id}.{ext}" shape.
+        service
+            .update_custom_logo_filename("asset-1", Some("../../../etc/passwd"))
+            .await
+            .unwrap();
+
+        assert!(store.read(&service, "asset-1").unwrap().is_none());
+    }
+}

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -268,6 +268,11 @@ pub struct Asset {
 
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+
+    // User-uploaded logo override filename (read-only here; written only via
+    // the dedicated asset-logo service, never through profile updates)
+    #[serde(skip_deserializing)]
+    pub custom_logo_filename: Option<String>,
 }
 
 fn default_is_active() -> bool {

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -580,6 +580,7 @@ mod tests {
             exchange_name: None,
             created_at: NaiveDateTime::default(),
             updated_at: NaiveDateTime::default(),
+            custom_logo_filename: None,
         }
     }
 }

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -1993,6 +1993,16 @@ impl AssetServiceTrait for AssetService {
         Ok(asset)
     }
 
+    async fn update_custom_logo_filename(
+        &self,
+        asset_id: &str,
+        filename: Option<&str>,
+    ) -> Result<Asset> {
+        self.asset_repository
+            .update_custom_logo_filename(asset_id, filename)
+            .await
+    }
+
     async fn get_assets_by_asset_ids(&self, asset_ids: &[String]) -> Result<Vec<Asset>> {
         self.asset_repository.list_by_asset_ids(asset_ids)
     }
@@ -2702,6 +2712,14 @@ mod tests {
         }
 
         async fn update_quote_mode(&self, _asset_id: &str, _quote_mode: &str) -> Result<Asset> {
+            unimplemented!()
+        }
+
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> Result<Asset> {
             unimplemented!()
         }
 

--- a/crates/core/src/assets/assets_traits.rs
+++ b/crates/core/src/assets/assets_traits.rs
@@ -46,6 +46,17 @@ pub trait AssetServiceTrait: Send + Sync {
     async fn update_quote_mode_silent(&self, asset_id: &str, quote_mode: &str) -> Result<Asset> {
         self.update_quote_mode(asset_id, quote_mode).await
     }
+    /// Sets or clears the stored custom logo filename for an asset.
+    /// Default is unsupported; only the concrete `AssetService` overrides this.
+    async fn update_custom_logo_filename(
+        &self,
+        _asset_id: &str,
+        _filename: Option<&str>,
+    ) -> Result<Asset> {
+        Err(crate::errors::Error::Asset(
+            "Custom logo overrides are not supported by this asset service".to_string(),
+        ))
+    }
     async fn get_assets_by_asset_ids(&self, asset_ids: &[String]) -> Result<Vec<Asset>>;
     /// Enriches an existing asset's profile with data from market data provider.
     /// Updates the profile JSON (sectors, countries, website) and notes fields.
@@ -181,6 +192,13 @@ pub trait AssetRepositoryTrait: Send + Sync {
     async fn create_batch(&self, new_assets: Vec<NewAsset>) -> Result<Vec<Asset>>;
     async fn update_profile(&self, asset_id: &str, payload: UpdateAssetProfile) -> Result<Asset>;
     async fn update_quote_mode(&self, asset_id: &str, quote_mode: &str) -> Result<Asset>;
+    /// Sets or clears the stored custom logo filename for an asset.
+    /// `filename` is `None` to clear the override back to the default logo.
+    async fn update_custom_logo_filename(
+        &self,
+        asset_id: &str,
+        filename: Option<&str>,
+    ) -> Result<Asset>;
     fn get_by_id(&self, asset_id: &str) -> Result<Asset>;
     fn list(&self) -> Result<Vec<Asset>>;
     fn list_by_asset_ids(&self, asset_ids: &[String]) -> Result<Vec<Asset>>;

--- a/crates/core/src/assets/mod.rs
+++ b/crates/core/src/assets/mod.rs
@@ -4,6 +4,7 @@ mod alternative_assets_model;
 mod alternative_assets_service;
 mod alternative_assets_traits;
 mod asset_id;
+mod asset_logo_store;
 mod asset_resolution;
 mod assets_constants;
 mod assets_model;
@@ -29,6 +30,7 @@ pub use asset_id::{
     parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix, symbol_resolution_candidates,
     unknown_dotted_suffix_fallback,
 };
+pub use asset_logo_store::AssetLogoStore;
 pub(crate) use asset_resolution::asset_provider_alias_symbols;
 pub use asset_resolution::{AssetResolutionInput, AssetResolutionOutput};
 pub use assets_model::{

--- a/crates/core/src/exports.rs
+++ b/crates/core/src/exports.rs
@@ -459,6 +459,7 @@ mod tests {
                 isin: Some("US0378331005".to_string()),
                 exchange_mic: Some("XNAS".to_string()),
                 classifications: None,
+                custom_logo_filename: None,
             }),
             asset_kind: Some(AssetKind::Investment),
             quantity: dec!(10),

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -2301,6 +2301,7 @@ mod tests {
             exchange_name: None,
             created_at: now.naive_utc(),
             updated_at: now.naive_utc(),
+            custom_logo_filename: None,
         }
     }
 

--- a/crates/core/src/portfolio/allocation/allocation_model.rs
+++ b/crates/core/src/portfolio/allocation/allocation_model.rs
@@ -133,6 +133,8 @@ pub struct HoldingAllocationContribution {
     pub category_color: String,
     /// Weighted market value in base currency.
     pub value: Decimal,
+    /// User-uploaded logo override filename, if one has been set on the asset
+    pub custom_logo_filename: Option<String>,
 }
 
 /// Holding-level category contributions for one taxonomy.

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -1540,6 +1540,7 @@ mod tests {
                 preferred_provider: None,
                 exchange_mic: None,
                 classifications: None,
+                custom_logo_filename: None,
             }),
             asset_kind: None,
             quantity: dec!(1),

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -180,6 +180,9 @@ impl AllocationService {
                 if existing_summary.unit_price.is_none() {
                     existing_summary.unit_price = summary.unit_price;
                 }
+                if existing_summary.custom_logo_filename.is_none() {
+                    existing_summary.custom_logo_filename = summary.custom_logo_filename;
+                }
                 *existing_value += value;
             } else {
                 non_cash_index_by_id.insert(summary.id.clone(), merged.len());
@@ -258,12 +261,16 @@ impl AllocationService {
             .unwrap_or_else(|| (category_id.to_string(), fallback_color.to_string()))
     }
 
-    fn holding_display(holding: &Holding) -> (String, String, String) {
+    fn holding_display(holding: &Holding) -> (String, String, String, Option<String>) {
         let asset_id = holding
             .instrument
             .as_ref()
             .map(|instrument| instrument.id.clone())
             .unwrap_or_else(|| holding.id.clone());
+        let custom_logo_filename = holding
+            .instrument
+            .as_ref()
+            .and_then(|instrument| instrument.custom_logo_filename.clone());
 
         if holding.holding_type == HoldingType::Cash {
             let symbol = holding.local_currency.clone();
@@ -271,6 +278,7 @@ impl AllocationService {
                 asset_id,
                 symbol.clone(),
                 format!("Cash ({})", holding.local_currency),
+                custom_logo_filename,
             );
         }
 
@@ -285,7 +293,7 @@ impl AllocationService {
             .and_then(|instrument| instrument.name.clone())
             .unwrap_or_else(|| symbol.clone());
 
-        (asset_id, symbol, name)
+        (asset_id, symbol, name, custom_logo_filename)
     }
 
     fn contribution_shares_for_holding(
@@ -880,7 +888,7 @@ impl AllocationService {
                 &assignments_by_asset,
                 cash_overrides,
             );
-            let (asset_id, symbol, name) = Self::holding_display(holding);
+            let (asset_id, symbol, name, custom_logo_filename) = Self::holding_display(holding);
             let mut value_by_category: BTreeMap<String, Decimal> = BTreeMap::new();
             for share in shares {
                 *value_by_category.entry(share.category_id).or_default() +=
@@ -908,6 +916,7 @@ impl AllocationService {
                     category_name,
                     category_color,
                     value,
+                    custom_logo_filename: custom_logo_filename.clone(),
                 });
             }
         }
@@ -1016,7 +1025,7 @@ impl AllocationService {
             }
 
             let matched_value = holding.market_value.base * matched_share;
-            let (asset_id, symbol, name) = Self::holding_display(holding);
+            let (asset_id, symbol, name, custom_logo_filename) = Self::holding_display(holding);
             matched_values.push((
                 HoldingSummary {
                     id: asset_id,
@@ -1029,6 +1038,7 @@ impl AllocationService {
                     currency: base_currency.to_string(),
                     weight_in_category: Decimal::ZERO,
                     unit_price: holding.price,
+                    custom_logo_filename,
                 },
                 matched_value,
             ));

--- a/crates/core/src/portfolio/allocation_targets/cash.rs
+++ b/crates/core/src/portfolio/allocation_targets/cash.rs
@@ -92,6 +92,7 @@ mod tests {
             category_name: category_id.to_string(),
             category_color: "#000000".to_string(),
             value,
+            custom_logo_filename: None,
         }
     }
 

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -333,6 +333,7 @@ impl DriftService {
                     drift_bps,
                     is_unknown_category: contribution.category_id == "__UNKNOWN__",
                     is_cash: contribution.holding_type == HoldingType::Cash,
+                    custom_logo_filename: contribution.custom_logo_filename.clone(),
                 }
             })
             .collect();
@@ -588,6 +589,7 @@ mod tests {
             category_name: category_id.to_string(),
             category_color: "#111111".to_string(),
             value,
+            custom_logo_filename: None,
         }
     }
 
@@ -687,6 +689,7 @@ mod tests {
                 category_name: category.category_name,
                 category_color: category.color,
                 value: category.value,
+                custom_logo_filename: None,
             })
             .collect();
 
@@ -1155,6 +1158,7 @@ mod tests {
                         category_name: "Equity".to_string(),
                         category_color: "#111111".to_string(),
                         value: dec!(7000),
+                        custom_logo_filename: None,
                     },
                     HoldingAllocationContribution {
                         id: "bnd:BONDS:0".to_string(),
@@ -1170,6 +1174,7 @@ mod tests {
                         category_name: "Bonds".to_string(),
                         category_color: "#222222".to_string(),
                         value: dec!(3000),
+                        custom_logo_filename: None,
                     },
                 ],
             },

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -281,6 +281,8 @@ pub struct DriftHoldingRow {
     pub drift_bps: Option<i32>,
     pub is_unknown_category: bool,
     pub is_cash: bool,
+    /// User-uploaded logo override filename, if one has been set on the asset
+    pub custom_logo_filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -713,6 +713,7 @@ mod tests {
                 preferred_provider: None,
                 exchange_mic: None,
                 classifications: None,
+                custom_logo_filename: None,
             }),
             asset_kind: None,
             quantity,

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -823,6 +823,10 @@ mod tests {
             category_name: category_id.to_string(),
             category_color: "#aaa".to_string(),
             value,
+            custom_logo_filename: holding
+                .instrument
+                .as_ref()
+                .and_then(|i| i.custom_logo_filename.clone()),
         }
     }
 

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -33,6 +33,9 @@ pub struct Instrument {
 
     // Taxonomy-based classifications
     pub classifications: Option<AssetClassifications>,
+
+    // User-uploaded logo override filename, if one has been set
+    pub custom_logo_filename: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -158,6 +161,8 @@ pub struct HoldingListInstrument {
     pub exchange_mic: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classifications: Option<AssetClassifications>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_logo_filename: Option<String>,
 }
 
 /// List-oriented holding payload for app tables and dashboards.
@@ -222,6 +227,7 @@ impl From<Holding> for HoldingListItem {
                 isin,
                 exchange_mic: instrument.exchange_mic,
                 classifications,
+                custom_logo_filename: instrument.custom_logo_filename,
             }
         });
 

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -73,6 +73,8 @@ pub struct HoldingSummary {
     /// Use this for trade sizing instead of market_value/quantity,
     /// which gives a wrong result when market_value is weighted across categories.
     pub unit_price: Option<Decimal>,
+    /// User-uploaded logo override filename, if one has been set on the asset
+    pub custom_logo_filename: Option<String>,
 }
 
 /// Position view model for frontend display with daily and total performance

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -273,6 +273,7 @@ impl HoldingsService {
                             preferred_provider: asset.preferred_provider(),
                             exchange_mic: asset.instrument_exchange_mic.clone(),
                             classifications: None,
+                            custom_logo_filename: asset.custom_logo_filename.clone(),
                         };
 
                         let asset_info = AssetInfo {
@@ -393,6 +394,7 @@ impl HoldingsService {
                 preferred_provider: None,
                 exchange_mic: None,
                 classifications: None,
+                custom_logo_filename: None,
             };
 
             let holding_view = Holding {
@@ -1536,6 +1538,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 preferred_provider: asset.preferred_provider(),
                 exchange_mic: asset.instrument_exchange_mic.clone(),
                 classifications: None,
+                custom_logo_filename: asset.custom_logo_filename.clone(),
             };
 
             let holding = Holding {
@@ -3598,6 +3601,7 @@ mod tests {
                 preferred_provider: None,
                 exchange_mic: None,
                 classifications: None,
+                custom_logo_filename: None,
             }),
             asset_kind: None,
             quantity: dec!(1),

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -493,6 +493,7 @@ mod tests {
                 preferred_provider: None,
                 exchange_mic: None,
                 classifications: None,
+                custom_logo_filename: None,
             })
         } else {
             None

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -111,6 +111,14 @@ impl AssetRepositoryTrait for MockAssetRepository {
         unimplemented!()
     }
 
+    async fn update_custom_logo_filename(
+        &self,
+        _asset_id: &str,
+        _filename: Option<&str>,
+    ) -> Result<Asset> {
+        unimplemented!()
+    }
+
     fn find_by_instrument_key(&self, _instrument_key: &str) -> Result<Option<Asset>> {
         Ok(None)
     }
@@ -893,6 +901,7 @@ fn create_test_asset(id: &str, kind: AssetKind, currency: &str) -> Asset {
         provider_config: None,
         is_active: true,
         metadata: None,
+        custom_logo_filename: None,
     }
 }
 

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -5722,6 +5722,17 @@ mod tests {
             ))
         }
 
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> Result<Asset> {
+            Err(errors::Error::Unexpected(
+                "TestAssetRepository::update_custom_logo_filename should not be called"
+                    .to_string(),
+            ))
+        }
+
         fn get_by_id(&self, asset_id: &str) -> Result<Asset> {
             if asset_id == "AAPL" {
                 Ok(Asset {

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -131,6 +131,14 @@ mod tests {
             unimplemented!("Not needed for tests")
         }
 
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> Result<Asset> {
+            unimplemented!("Not needed for tests")
+        }
+
         fn find_by_instrument_key(&self, _instrument_key: &str) -> Result<Option<Asset>> {
             Ok(None)
         }

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -217,6 +217,14 @@ mod tests {
             unimplemented!("update_quote_mode not implemented for MockAssetRepository")
         }
 
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> AppResult<Asset> {
+            unimplemented!("update_custom_logo_filename not implemented for MockAssetRepository")
+        }
+
         fn find_by_instrument_key(&self, _instrument_key: &str) -> AppResult<Option<Asset>> {
             Ok(None)
         }

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -3038,6 +3038,14 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> Result<Asset> {
+            unimplemented!("unused in this test")
+        }
+
         fn get_by_id(&self, _asset_id: &str) -> Result<Asset> {
             unimplemented!("unused in this test")
         }
@@ -3108,6 +3116,14 @@ mod tests {
         }
 
         async fn update_quote_mode(&self, _asset_id: &str, _quote_mode: &str) -> Result<Asset> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn update_custom_logo_filename(
+            &self,
+            _asset_id: &str,
+            _filename: Option<&str>,
+        ) -> Result<Asset> {
             unimplemented!("unused in this test")
         }
 

--- a/crates/storage-sqlite/migrations/2026-07-15-000001_asset_custom_logo/down.sql
+++ b/crates/storage-sqlite/migrations/2026-07-15-000001_asset_custom_logo/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assets DROP COLUMN custom_logo_filename;

--- a/crates/storage-sqlite/migrations/2026-07-15-000001_asset_custom_logo/up.sql
+++ b/crates/storage-sqlite/migrations/2026-07-15-000001_asset_custom_logo/up.sql
@@ -1,0 +1,3 @@
+-- User-uploaded logo override for an asset. Filename only; bytes live under
+-- the app's data directory, resolved and served by the asset logo service.
+ALTER TABLE assets ADD COLUMN custom_logo_filename TEXT;

--- a/crates/storage-sqlite/src/activities/model.rs
+++ b/crates/storage-sqlite/src/activities/model.rs
@@ -201,6 +201,8 @@ pub struct ActivityDetailsDB {
     pub instrument_type: Option<String>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     pub metadata: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    pub custom_logo_filename: Option<String>,
 }
 
 impl ActivityDetailsDB {
@@ -356,6 +358,7 @@ impl From<ActivityDetailsDB> for wealthfolio_core::activities::ActivityDetails {
             import_run_id: db.import_run_id,
             is_user_modified: db.is_user_modified != 0,
             metadata: db.metadata.and_then(|s| serde_json::from_str(&s).ok()),
+            custom_logo_filename: db.custom_logo_filename,
         }
     }
 }

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -574,6 +574,7 @@ impl ActivityRepository {
                 assets::quote_mode.nullable(),
                 assets::instrument_type.nullable(),
                 activities::metadata,
+                assets::custom_logo_filename.nullable(),
             ))
             .limit(page_size)
             .offset(offset)

--- a/crates/storage-sqlite/src/assets/model.rs
+++ b/crates/storage-sqlite/src/assets/model.rs
@@ -67,9 +67,14 @@ pub struct AssetDB {
     pub provider_config: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    pub custom_logo_filename: Option<String>,
 }
 
 /// Database write model for assets (excludes generated columns).
+///
+/// `custom_logo_filename` is intentionally excluded here — it is written via a
+/// dedicated narrow update (see `update_custom_logo_filename`), the same
+/// pattern as `quote_mode`, so a full profile update never clobbers it.
 #[derive(Insertable, AsChangeset, Debug, Clone)]
 #[diesel(table_name = crate::schema::assets)]
 pub struct InsertableAssetDB {
@@ -132,6 +137,7 @@ impl From<AssetDB> for Asset {
             exchange_name: None, // Computed by Asset::enrich()
             created_at: text_to_datetime(&db.created_at),
             updated_at: text_to_datetime(&db.updated_at),
+            custom_logo_filename: db.custom_logo_filename,
         }
     }
 }

--- a/crates/storage-sqlite/src/assets/repository.rs
+++ b/crates/storage-sqlite/src/assets/repository.rs
@@ -298,6 +298,27 @@ impl AssetRepositoryTrait for AssetRepository {
             .await
     }
 
+    /// Sets or clears the stored custom logo filename for an asset.
+    async fn update_custom_logo_filename(
+        &self,
+        asset_id: &str,
+        filename: Option<&str>,
+    ) -> Result<Asset> {
+        let asset_id_owned = asset_id.to_string();
+        let filename_owned = filename.map(|f| f.to_string());
+        self.writer
+            .exec_tx(move |tx| -> Result<Asset> {
+                let result_db = diesel::update(assets::table.filter(assets::id.eq(asset_id_owned)))
+                    .set(assets::custom_logo_filename.eq(filename_owned))
+                    .get_result::<AssetDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+                let payload_db = result_db.clone();
+                tx.update(&payload_db)?;
+                Ok(result_db.into())
+            })
+            .await
+    }
+
     /// Retrieves an asset by its ID
     fn get_by_id(&self, asset_id: &str) -> Result<Asset> {
         self.get_by_id_impl(asset_id)

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -148,6 +148,7 @@ diesel::table! {
         provider_config -> Nullable<Text>,
         created_at -> Text,
         updated_at -> Text,
+        custom_logo_filename -> Nullable<Text>,
     }
 }
 

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -490,6 +490,9 @@ export interface Instrument {
   quoteMode: QuoteMode;
   preferredProvider?: string | null;
   classifications?: AssetClassifications | null;
+
+  // User-uploaded logo override filename, if one has been set
+  customLogoFilename?: string | null;
 }
 
 export interface AssetClassifications {
@@ -626,6 +629,9 @@ export interface Asset {
 
   // Derived
   exchangeName?: string | null; // Friendly exchange name (e.g., "NASDAQ")
+
+  // User-uploaded logo override filename, if one has been set
+  customLogoFilename?: string | null;
 
   // Audit
   createdAt: string;

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -295,6 +295,13 @@ export interface AssetsAPI {
    * @returns Promise resolving to updated asset
    */
   updateQuoteMode(assetId: string, quoteMode: string): Promise<Asset>;
+
+  /**
+   * Get the user-uploaded custom logo override for an asset, if one is set.
+   * @param assetId Asset identifier
+   * @returns Promise resolving to a ready-to-use `data:` URL, or `null` if no custom logo is set
+   */
+  getLogoDataUrl(assetId: string): Promise<string | null>;
 }
 
 /**

--- a/packages/addon-sdk/src/permissions.ts
+++ b/packages/addon-sdk/src/permissions.ts
@@ -103,7 +103,7 @@ export const PERMISSION_CATEGORIES: PermissionCategory[] = [
     id: 'assets',
     name: 'Asset Management',
     description: 'Access to asset profiles and data sources',
-    functions: ['getProfile', 'updateProfile', 'updateQuoteMode'],
+    functions: ['getProfile', 'updateProfile', 'updateQuoteMode', 'getLogoDataUrl'],
     riskLevel: 'medium',
   },
   {

--- a/packages/ui/src/components/ui/data-table/index.tsx
+++ b/packages/ui/src/components/ui/data-table/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "@tanstack/react-table";
 import * as React from "react";
 
+import { cn } from "../../../lib/utils";
 import { Icons } from "../icons";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../table";
 import { usePersistentState } from "../../../hooks/use-persistent-state";
@@ -37,6 +38,8 @@ interface DataTableProps<TData, TValue> {
   scrollable?: boolean;
   showColumnToggle?: boolean;
   toolbarActions?: React.ReactNode;
+  /** Extra className applied to each body row (e.g. to host a per-row background decoration). */
+  rowClassName?: string | ((row: TData) => string);
 }
 
 export function DataTable<TData, TValue>({
@@ -52,6 +55,7 @@ export function DataTable<TData, TValue>({
   scrollable = false,
   showColumnToggle = false,
   toolbarActions,
+  rowClassName,
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = React.useState({});
   const [storedColumnVisibility, setColumnVisibility] = storageKey
@@ -127,7 +131,13 @@ export function DataTable<TData, TValue>({
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  className={cn(
+                    typeof rowClassName === "function" ? rowClassName(row.original) : rowClassName,
+                  )}
+                >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
                   ))}


### PR DESCRIPTION
## Description

Lets users upload a local image to override the ticker logo shown for a specific asset, with fallback to the existing bundled ticker-logos resolution when unset. Works in both the Tauri desktop app and the self-hosted web server, and is also exposed to addons via `assets.getLogoDataUrl`.

- Custom logo upload/remove UI on the asset profile page, validated by file signature (not extension), 2MB cap.
- Shared core storage logic (`AssetLogoStore`) with new unit tests covering size limits, non-image rejection, extension spoofing, and path traversal.
- New `GET/POST/DELETE /assets/{id}/logo` route (web), rate-limited on upload; matching Tauri IPC commands using a native file picker.
- Logo override now shows in holdings tables and the dashboard, not just the asset page.
- New `assets.getLogoDataUrl(assetId)` addon API method, mirroring the existing `getProfile`/`updateQuoteMode` permission pattern.
-bonus coolification pass with background watermark logo on the holding row

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

## Preview

<img width="476" height="290" alt="image" src="https://github.com/user-attachments/assets/745d42e5-4822-406c-bd23-e76cac6b1a32" />
<img width="265" height="530" alt="image" src="https://github.com/user-attachments/assets/fa5bbd2b-fb90-42f8-a4e5-1add8be6a45b" />
<img width="390" height="135" alt="image" src="https://github.com/user-attachments/assets/26386ade-a410-4825-b7de-d2847ce35639" />

## Follow-up: consistent logo rendering everywhere

The original PR only wired the logo override into holdings tables and the dashboard. This commit spreads it to the remaining surfaces that already had the asset data in scope but weren't using it:

- Activities (table, mobile table, date list) — required adding `custom_logo_filename` to the `ActivityDetails` model/query, not just the frontend.
- Asset classification sheet, holdings edit mode (manual bulk-edit table).
- Allocation detail sheet (category drill-down) and the allocation-targets drift/rebalance table.
- Fixed a padding bug on the drift table where a hardcoded class made uploaded logos render tiny — extracted a shared, tested helper so custom logos always render edge-to-edge regardless of call site.

**Test plan**
- `cargo check --workspace --tests` clean
- 1654 core lib tests + 28 activities-repository tests pass
- `tsc --noEmit` clean
- Full frontend suite passes (1109 tests)
