### PR TITLE
feat(addons): allow per-request timeout override for addon network broker

### DIFF
--- a/apps/frontend/src/adapters/types.ts
+++ b/apps/frontend/src/adapters/types.ts
@@ -107,6 +107,11 @@ export interface AddonNetworkRequest {
   headers?: Record<string, string>;
   body?: string;
   auth?: AddonNetworkAuth;
+  /**
+   * Per-request timeout override, in seconds. Defaults to 10s when omitted.
+   * Clamped server-side to a 120s maximum.
+   */
+  timeoutSecs?: number;
 }
 
 export interface AddonNetworkResponse {

--- a/crates/core/src/addons/network.rs
+++ b/crates/core/src/addons/network.rs
@@ -18,6 +18,7 @@ use crate::secrets::{addon_secret_service_id, legacy_addon_secret_service_id, Se
 const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
+const MAX_REQUEST_TIMEOUT_SECS: u64 = 120;
 
 fn validate_addon_runtime_id(addon_id: &str) -> Result<(), String> {
     validate_addon_id(&addon_id.to_ascii_lowercase())
@@ -39,6 +40,9 @@ pub struct AddonNetworkRequest {
     pub headers: Option<BTreeMap<String, String>>,
     pub body: Option<String>,
     pub auth: Option<AddonNetworkAuth>,
+    /// Per-request timeout override in seconds. Clamped server-side to
+    /// `MAX_REQUEST_TIMEOUT_SECS`; falls back to `REQUEST_TIMEOUT_SECS` when unset.
+    pub timeout_secs: Option<u64>,
     #[serde(skip)]
     pub injected_authorization: Option<String>,
 }
@@ -69,9 +73,10 @@ pub async fn perform_addon_network_request(
         return Err("Addon network request body is too large".to_string());
     }
 
+    let timeout_secs = resolve_request_timeout_secs(request.timeout_secs);
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(timeout_secs))
         .resolve_to_addrs(&host, &resolved_addresses)
         .build()
         .map_err(|e| e.to_string())?;
@@ -160,6 +165,12 @@ pub fn resolve_addon_network_auth_header(
         return Err("Addon network auth secret is empty".to_string());
     }
     Ok(Some(format!("{} {}", scheme, secret)))
+}
+
+fn resolve_request_timeout_secs(timeout_secs: Option<u64>) -> u64 {
+    timeout_secs
+        .unwrap_or(REQUEST_TIMEOUT_SECS)
+        .min(MAX_REQUEST_TIMEOUT_SECS)
 }
 
 fn validate_url(url: &str, allowed_hosts: &[String]) -> Result<Url, String> {
@@ -336,6 +347,16 @@ mod tests {
         fn delete_secret(&self, _service: &str) -> Result<()> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn resolves_request_timeout() {
+        assert_eq!(resolve_request_timeout_secs(None), REQUEST_TIMEOUT_SECS);
+        assert_eq!(resolve_request_timeout_secs(Some(30)), 30);
+        assert_eq!(
+            resolve_request_timeout_secs(Some(9999)),
+            MAX_REQUEST_TIMEOUT_SECS
+        );
     }
 
     #[test]

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -1959,6 +1959,7 @@ mod service_tests {
                         auth_type: "bearer".to_string(),
                         secret_key: "api-token".to_string(),
                     }),
+                    timeout_secs: None,
                     injected_authorization: Some("Bearer secret-token".to_string()),
                 },
             )
@@ -2025,6 +2026,7 @@ mod service_tests {
                         auth_type: "bearer".to_string(),
                         secret_key: "api-token".to_string(),
                     }),
+                    timeout_secs: None,
                     injected_authorization: Some("Bearer secret-token".to_string()),
                 },
             )

--- a/packages/addon-sdk/CHANGELOG.md
+++ b/packages/addon-sdk/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `NetworkRequest.timeoutSecs` — optional per-request timeout override (in
+  seconds) for the addon network broker. Defaults to 10s when omitted;
+  clamped server-side to a 120s maximum. Lets addons make longer-running
+  non-streaming calls (e.g. LLM completions) that exceed the default timeout.
+
 ## [3.6.1] - 2026-07-06
 
 Follow-up to the v3.6 sandbox release: sidebar icons are now a typed, curated

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -766,6 +766,11 @@ export interface NetworkRequest {
   headers?: Record<string, string>;
   body?: string;
   auth?: NetworkAuth;
+  /**
+   * Per-request timeout override, in seconds. Defaults to 10s when omitted.
+   * Clamped server-side to a 120s maximum.
+   */
+  timeoutSecs?: number;
 }
 
 export interface NetworkResponse {


### PR DESCRIPTION
## Summary
- The addon network broker's `perform_addon_network_request` hard-coded a 10s `reqwest` timeout applied to every addon network call, with no override available.
- This is too short for non-streaming AI/LLM completion APIs (e.g. Anthropic, OpenAI): the response body is fully buffered before it's returned to the addon (no streaming support), and the server holds the connection open for the entire generation/input-processing time before sending anything back. Confirmed directly building an addon calling `api.anthropic.com/v1/messages`, which consistently timed out at ~10.0s regardless of `max_tokens` once the input context was large.
- Adds an optional `timeoutSecs` field to `AddonNetworkRequest`/`NetworkRequest`, defaulting to the existing 10s and clamped server-side to a 120s maximum so an addon can't request an unbounded hang.
- No permission/manifest changes: `network.request` is already the coarsest `riskLevel: 'high'` permission category covering the whole capability (headers, body, auth all ride under the same grant), so extending how long an already-authorized host can be contacted doesn't introduce a new privilege tier.

## Changes
- `crates/core/src/addons/network.rs`: `timeout_secs: Option<u64>` field, `MAX_REQUEST_TIMEOUT_SECS` clamp constant, `resolve_request_timeout_secs()` helper + unit test.
- `crates/core/src/addons/tests.rs`: updated two struct-literal test call sites for the new field.
- `packages/addon-sdk/src/host-api.ts`: mirrored `timeoutSecs?: number` on the public `NetworkRequest` SDK type.
- `apps/frontend/src/adapters/types.ts`: mirrored the field on the adapter-layer `AddonNetworkRequest` type.
- `packages/addon-sdk/CHANGELOG.md`: `Unreleased` / `Added` entry.

## Test plan
- [x] `cargo check -p wealthfolio-core`
- [x] `cargo test -p wealthfolio-core addons::network::` (incl. new `resolves_request_timeout` clamp test)
- [x] `cargo test -p wealthfolio-core network_auth`
- [x] `pnpm exec tsc --noEmit` in `apps/frontend` and `packages/addon-sdk`
- [x] `vitest run src/addons/type-bridge.test.ts` in `apps/frontend`

## CLA
- [x] I confirm I have read and agree to [CLA.md](CLA.md).
