### PR TITLE
feat: add MCP activity update tools

### DIFF
--- a/apps/server/tests/agent_access.rs
+++ b/apps/server/tests/agent_access.rs
@@ -449,7 +449,7 @@ async fn mcp_pat_lifecycle() {
 /// A write/suggest-scoped token sees the draft, suggest, commit, AND import
 /// tools via `tools/list` — proving scope-gated visibility extends past the
 /// read-only catalog. (Read-only tokens see 17; the full MCP catalog is
-/// 16 read + get_import_mapping + 5 draft/suggest + 3 commit + 2 import = 27.)
+/// 16 read + get_import_mapping + 6 draft/suggest + 4 commit + 2 import = 29.)
 #[tokio::test]
 async fn mcp_write_scoped_token_sees_write_tools() {
     let server = spawn_server(true, false).await;
@@ -489,14 +489,18 @@ async fn mcp_write_scoped_token_sees_write_tools() {
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert_eq!(
         tools.len(),
-        27,
-        "full-scope token must see all 27 tools: {names:?}"
+        29,
+        "full-scope token must see all 29 tools: {names:?}"
     );
     assert!(
         names.contains(&"commit_activity_import"),
         "import tool visible"
     );
     assert!(names.contains(&"record_activity"), "draft tool visible");
+    assert!(
+        names.contains(&"prepare_activity_update"),
+        "activity update preparation tool visible"
+    );
     assert!(
         names.contains(&"prepare_asset_classification"),
         "suggest tool visible"
@@ -508,6 +512,10 @@ async fn mcp_write_scoped_token_sees_write_tools() {
     assert!(
         names.contains(&"commit_activity_drafts"),
         "batch commit tool visible"
+    );
+    assert!(
+        names.contains(&"commit_activity_update"),
+        "activity update commit tool visible"
     );
     assert!(
         names.contains(&"commit_asset_classification_draft"),

--- a/crates/agent-tools/src/catalog.rs
+++ b/crates/agent-tools/src/catalog.rs
@@ -202,6 +202,7 @@ mod tests {
         // Draft/suggest tools are present.
         assert!(names.contains(&"record_activity"));
         assert!(names.contains(&"prepare_asset_classification"));
+        assert!(names.contains(&"prepare_activity_update"));
         // Commit and CSV-import tools are NOT exposed to the assistant.
         assert!(!names.contains(&"commit_activity_draft"));
         assert!(!names.contains(&"commit_activity_drafts"));
@@ -215,6 +216,8 @@ mod tests {
     fn mcp_catalog_includes_commit_and_import_tools() {
         let catalog = AgentToolCatalog::mcp_catalog();
         let names: Vec<&str> = catalog.iter().map(|tool| tool.name()).collect();
+        assert!(names.contains(&"prepare_activity_update"));
+        assert!(names.contains(&"commit_activity_update"));
         assert!(names.contains(&"commit_activity_draft"));
         assert!(names.contains(&"commit_activity_drafts"));
         assert!(names.contains(&"commit_asset_classification_draft"));
@@ -233,6 +236,7 @@ mod tests {
             "commit_activity_draft",
             "commit_activity_drafts",
             "commit_asset_classification_draft",
+            "commit_activity_update",
         ] {
             let err = catalog
                 .execute(Arc::new(PanicEnv), &granted, name, serde_json::json!({}))

--- a/crates/agent-tools/src/tools/activity_update.rs
+++ b/crates/agent-tools/src/tools/activity_update.rs
@@ -1,0 +1,362 @@
+//! MCP tools for reviewing and committing an in-place activity update.
+//!
+//! `prepare_activity_update` loads the current activity and merges an allowed
+//! partial patch into the core [`ActivityUpdate`] payload. The result is a
+//! reviewable, complete update that preserves every field not explicitly
+//! patched, including the original RFC3339 timestamp. `commit_activity_update`
+//! persists that reviewed payload through the same activity service used by the
+//! application.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use wealthfolio_core::activities::{Activity, ActivityUpdate, AssetResolutionInput};
+
+use crate::env::AgentEnvironment;
+use crate::scope::AgentScope;
+use crate::tool::{AgentTool, AgentToolAccess, AgentToolError, AgentToolResult};
+use crate::tools::commit_activity::CommittedActivity;
+
+const PATCH_FIELDS: &[&str] = &[
+    "accountId",
+    "asset",
+    "activityType",
+    "subtype",
+    "activityDate",
+    "quantity",
+    "unitPrice",
+    "currency",
+    "fee",
+    "tax",
+    "amount",
+    "status",
+    "notes",
+    "fxRate",
+    "metadata",
+];
+
+fn redact_update(args: &serde_json::Value) -> serde_json::Value {
+    let mut redacted = serde_json::Map::new();
+    if let Some(obj) = args.as_object() {
+        if let Some(id) = obj.get("activityId").and_then(|value| value.as_str()) {
+            redacted.insert("activityId".to_string(), serde_json::json!(id));
+        }
+        if obj.contains_key("patch") {
+            redacted.insert("patch".to_string(), serde_json::json!("[redacted]"));
+        }
+        if obj.contains_key("update") {
+            redacted.insert("update".to_string(), serde_json::json!("[redacted]"));
+        }
+    }
+    serde_json::Value::Object(redacted)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareActivityUpdateArgs {
+    pub activity_id: String,
+    pub patch: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareActivityUpdateOutput {
+    pub original: ActivityUpdate,
+    pub update: ActivityUpdate,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitActivityUpdateArgs {
+    pub update: ActivityUpdate,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitActivityUpdateOutput {
+    pub updated: CommittedActivity,
+}
+
+fn activity_to_update(activity: Activity) -> ActivityUpdate {
+    ActivityUpdate {
+        id: activity.id,
+        account_id: activity.account_id,
+        asset: activity.asset_id.map(|id| AssetResolutionInput {
+            id: Some(id),
+            ..Default::default()
+        }),
+        activity_type: activity.activity_type,
+        subtype: activity.subtype,
+        activity_date: activity.activity_date.to_rfc3339(),
+        quantity: Some(activity.quantity),
+        unit_price: Some(activity.unit_price),
+        currency: activity.currency,
+        fee: Some(activity.fee),
+        tax: Some(activity.tax),
+        amount: Some(activity.amount),
+        status: Some(activity.status),
+        notes: activity.notes,
+        fx_rate: Some(activity.fx_rate),
+        metadata: activity.metadata.map(|metadata| metadata.to_string()),
+    }
+}
+
+fn merge_patch(
+    original: &ActivityUpdate,
+    activity_id: &str,
+    patch: serde_json::Value,
+) -> Result<ActivityUpdate, AgentToolError> {
+    let patch = patch
+        .as_object()
+        .ok_or_else(|| AgentToolError::InvalidInput("patch must be a JSON object".to_string()))?;
+    let mut update = serde_json::to_value(original)?;
+    let update_object = update
+        .as_object_mut()
+        .expect("ActivityUpdate serializes as an object");
+
+    for (field, value) in patch {
+        if !PATCH_FIELDS.contains(&field.as_str()) {
+            return Err(AgentToolError::InvalidInput(format!(
+                "patch contains unsupported field: {field}"
+            )));
+        }
+        update_object.insert(field.clone(), value.clone());
+    }
+
+    let update: ActivityUpdate = serde_json::from_value(update)?;
+    if update.id != activity_id {
+        return Err(AgentToolError::InvalidInput(
+            "patch must not change activityId".to_string(),
+        ));
+    }
+    Ok(update)
+}
+
+fn committed_summary(activity: Activity) -> CommittedActivity {
+    CommittedActivity {
+        id: activity.id,
+        account_id: activity.account_id,
+        asset_id: activity.asset_id,
+        activity_type: activity.activity_type,
+        activity_date: activity.activity_date.to_rfc3339(),
+        currency: activity.currency,
+    }
+}
+
+pub struct PrepareActivityUpdate;
+
+#[async_trait::async_trait]
+impl AgentTool for PrepareActivityUpdate {
+    fn name(&self) -> &'static str {
+        "prepare_activity_update"
+    }
+
+    fn description(&self) -> &'static str {
+        "Load one existing activity and prepare a complete in-place update for review. \
+         This does not mutate data. The partial patch may change only documented \
+         editable fields; every unspecified field, including the full timestamp, is preserved."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "activityId": { "type": "string" },
+                "patch": {
+                    "type": "object",
+                    "description": "Partial editable fields to apply before review.",
+                    "properties": {
+                        "accountId": { "type": "string" },
+                        "asset": { "type": ["object", "null"] },
+                        "activityType": { "type": "string" },
+                        "subtype": { "type": ["string", "null"] },
+                        "activityDate": { "type": "string", "description": "RFC3339 timestamp; preserves time and offset." },
+                        "quantity": { "type": ["number", "string", "null"] },
+                        "unitPrice": { "type": ["number", "string", "null"] },
+                        "currency": { "type": "string" },
+                        "fee": { "type": ["number", "string", "null"] },
+                        "tax": { "type": ["number", "string", "null"] },
+                        "amount": { "type": ["number", "string", "null"] },
+                        "status": { "type": "string" },
+                        "notes": { "type": ["string", "null"] },
+                        "fxRate": { "type": ["number", "string", "null"] },
+                        "metadata": { "type": ["string", "null"] }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "required": ["activityId", "patch"]
+        })
+    }
+
+    fn required_scopes(&self) -> &'static [AgentScope] {
+        &[AgentScope::ActivitiesRead, AgentScope::ActivitiesDraft]
+    }
+
+    fn access_level(&self) -> AgentToolAccess {
+        AgentToolAccess::Draft
+    }
+
+    fn sanitize_args_for_audit(&self, args: &serde_json::Value) -> serde_json::Value {
+        redact_update(args)
+    }
+
+    async fn call(
+        &self,
+        env: Arc<dyn AgentEnvironment>,
+        args: serde_json::Value,
+    ) -> Result<AgentToolResult, AgentToolError> {
+        let args: PrepareActivityUpdateArgs = serde_json::from_value(args)?;
+        let activity_id = args.activity_id.trim();
+        if activity_id.is_empty() {
+            return Err(AgentToolError::InvalidInput(
+                "activityId must not be empty".to_string(),
+            ));
+        }
+        let original = activity_to_update(
+            env.activity_service()
+                .get_activity(activity_id)
+                .map_err(|error| AgentToolError::ExecutionFailed(error.to_string()))?,
+        );
+        let update = merge_patch(&original, activity_id, args.patch)?;
+        Ok(AgentToolResult {
+            content: serde_json::to_value(PrepareActivityUpdateOutput { original, update })?,
+        })
+    }
+}
+
+pub struct CommitActivityUpdate;
+
+#[async_trait::async_trait]
+impl AgentTool for CommitActivityUpdate {
+    fn name(&self) -> &'static str {
+        "commit_activity_update"
+    }
+
+    fn description(&self) -> &'static str {
+        "Persist one reviewed activity update from prepare_activity_update. This MUTATES \
+         data - call only after the prepared update has been reviewed and confirmed."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "update": { "type": "object", "description": "Complete reviewed update returned by prepare_activity_update." }
+            },
+            "required": ["update"]
+        })
+    }
+
+    fn required_scopes(&self) -> &'static [AgentScope] {
+        &[AgentScope::ActivitiesDraft, AgentScope::ActivitiesWrite]
+    }
+
+    fn access_level(&self) -> AgentToolAccess {
+        AgentToolAccess::Write
+    }
+
+    fn sanitize_args_for_audit(&self, args: &serde_json::Value) -> serde_json::Value {
+        redact_update(args)
+    }
+
+    async fn call(
+        &self,
+        env: Arc<dyn AgentEnvironment>,
+        args: serde_json::Value,
+    ) -> Result<AgentToolResult, AgentToolError> {
+        let args: CommitActivityUpdateArgs = serde_json::from_value(args)?;
+        let updated = env
+            .activity_service()
+            .update_activity(args.update)
+            .await
+            .map_err(|error| AgentToolError::ExecutionFailed(error.to_string()))?;
+        env.health_service().clear_cache().await;
+        Ok(AgentToolResult {
+            content: serde_json::to_value(CommitActivityUpdateOutput {
+                updated: committed_summary(updated),
+            })?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use rust_decimal::Decimal;
+    use wealthfolio_core::activities::ActivityStatus;
+
+    use super::*;
+
+    fn activity() -> Activity {
+        Activity {
+            id: "activity-1".to_string(),
+            account_id: "account-1".to_string(),
+            asset_id: None,
+            activity_type: "DEPOSIT".to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: None,
+            status: ActivityStatus::Posted,
+            activity_date: Utc.with_ymd_and_hms(2026, 8, 2, 13, 28, 53).unwrap(),
+            settlement_date: None,
+            quantity: None,
+            unit_price: None,
+            amount: Some(Decimal::new(500000, 2)),
+            fee: None,
+            tax: None,
+            currency: "SAR".to_string(),
+            fx_rate: None,
+            notes: Some("original note".to_string()),
+            metadata: None,
+            source_system: None,
+            source_record_id: None,
+            source_group_id: None,
+            idempotency_key: None,
+            import_run_id: None,
+            is_user_modified: false,
+            needs_review: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn prepare_preserves_full_timestamp_and_unpatched_fields() {
+        let original = activity_to_update(activity());
+        let update = merge_patch(
+            &original,
+            "activity-1",
+            serde_json::json!({ "notes": "corrected note" }),
+        )
+        .unwrap();
+
+        assert_eq!(update.activity_date, "2026-08-02T13:28:53+00:00");
+        assert_eq!(update.amount, Some(Some(Decimal::new(500000, 2))));
+        assert_eq!(update.notes.as_deref(), Some("corrected note"));
+    }
+
+    #[test]
+    fn prepare_rejects_unsupported_patch_field() {
+        let original = activity_to_update(activity());
+        assert!(matches!(
+            merge_patch(
+                &original,
+                "activity-1",
+                serde_json::json!({ "id": "other" })
+            ),
+            Err(AgentToolError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn audit_redacts_financial_payloads() {
+        assert_eq!(
+            redact_update(&serde_json::json!({
+                "activityId": "activity-1",
+                "patch": { "amount": 5000, "notes": "private" }
+            })),
+            serde_json::json!({ "activityId": "activity-1", "patch": "[redacted]" })
+        );
+    }
+}

--- a/crates/agent-tools/src/tools/mod.rs
+++ b/crates/agent-tools/src/tools/mod.rs
@@ -7,6 +7,7 @@
 pub mod accounts;
 pub mod activities;
 pub mod activity_import;
+pub mod activity_update;
 pub mod allocation;
 pub mod asset_classification;
 pub mod asset_taxonomies;
@@ -91,6 +92,11 @@ pub use record_activity::{
     ResolvedAsset, SubtypeOption, ValidationError, ValidationResult,
 };
 
+pub use activity_update::{
+    CommitActivityUpdate, CommitActivityUpdateArgs, CommitActivityUpdateOutput,
+    PrepareActivityUpdate, PrepareActivityUpdateArgs, PrepareActivityUpdateOutput,
+};
+
 // MCP-only commit tools.
 pub use commit_activity::{
     CommitActivityDraft, CommitActivityDraftOutput, CommitActivityDrafts, CommitActivityDraftsArgs,
@@ -147,6 +153,7 @@ pub fn draft_suggest_tools() -> Vec<Arc<dyn AgentTool>> {
         Arc::new(ProposeCategories),
         Arc::new(CreateCategorizationRule),
         Arc::new(PrepareAssetClassification),
+        Arc::new(PrepareActivityUpdate),
     ]
 }
 
@@ -157,6 +164,7 @@ pub fn commit_tools() -> Vec<Arc<dyn AgentTool>> {
         Arc::new(CommitActivityDraft),
         Arc::new(CommitActivityDrafts),
         Arc::new(CommitAssetClassificationDraft),
+        Arc::new(CommitActivityUpdate),
     ]
 }
 


### PR DESCRIPTION
## What changed

Adds a two-step MCP flow for updating an existing activity in place:

- `prepare_activity_update` loads an activity and returns a reviewable complete update while preserving unpatched fields and RFC3339 timestamp precision
- `commit_activity_update` persists the reviewed update through the existing activity service
- Adds scope-gated catalog registration and server visibility coverage

## Why

MCP users need to correct existing activity records without deleting and recreating them, which can lose timestamps and source context.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wealthfolio-agent-tools` - 76 passed
- `cargo clippy -p wealthfolio-agent-tools --all-targets -- -D warnings`
- `cargo test -p wealthfolio-server --test agent_access mcp_write_scoped_token_sees_write_tools` - passed

Draft PR for maintainer review.