### PR TITLE
fix(dashboard): count hidden accounts in group stats, keep groups of one

### DIFF
--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -429,6 +429,62 @@ describe("AccountsSummary", () => {
     ]);
   });
 
+  it("counts hidden accounts in group totals without rendering them", async () => {
+    const user = userEvent.setup();
+
+    renderAccountsSummary({
+      accounts: [
+        createAccount({ id: "visible", name: "Visible Account", group: "Brokerage" }),
+        createAccount({
+          id: "hidden",
+          name: "Hidden Account",
+          group: "Brokerage",
+          isActive: false,
+        }),
+      ],
+      valuations: [
+        createValuation({ accountId: "visible", totalValue: 100, totalValueBase: 100 }),
+        createValuation({ accountId: "hidden", totalValue: 25, totalValueBase: 25 }),
+      ],
+      performanceByScopeKey: {
+        "accounts:hidden,visible": { pnl: 40, returnValue: 0.4 },
+      },
+    });
+
+    // The component must opt out of the hook's default active-only filtering, or hidden
+    // accounts never reach the grouping logic at all.
+    expect(mockUseAccounts).toHaveBeenCalledWith(expect.objectContaining({ filterActive: false }));
+
+    // Hidden accounts stay in the group's scope, so their gain history is not dropped.
+    expect(getLastPerformanceScopes()).toContainEqual({ accountIds: ["visible", "hidden"] });
+
+    // Group value spans both members: 100 visible + 25 hidden. Only the group row can show
+    // this total, since the sole visible account is worth 100.
+    expect(screen.getByText("Brokerage")).toBeInTheDocument();
+    expect(screen.getByText("value:USD:125")).toBeInTheDocument();
+
+    // But the hidden account never appears as a row, expanded or not.
+    expect(screen.queryByText("Hidden Account")).not.toBeInTheDocument();
+    await user.click(screen.getByText("Brokerage"));
+    expect(screen.queryByText("Hidden Account")).not.toBeInTheDocument();
+    expect(screen.getByText("Visible Account")).toBeInTheDocument();
+  });
+
+  it("keeps a group visible when all but one member is hidden", () => {
+    renderAccountsSummary({
+      accounts: [
+        createAccount({ id: "left", name: "Still Visible", group: "Brokerage" }),
+        createAccount({ id: "gone", name: "Now Hidden", group: "Brokerage", isActive: false }),
+      ],
+      valuations: [
+        createValuation({ accountId: "left", totalValue: 100 }),
+        createValuation({ accountId: "gone", totalValue: 0 }),
+      ],
+    });
+
+    expect(screen.getByText("Brokerage")).toBeInTheDocument();
+  });
+
   it("keeps standalone account values visible while performance is loading", () => {
     renderAccountsSummary({
       accounts: [createAccount({ id: "live-account", name: "Live Account" })],

--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -412,10 +412,12 @@ describe("AccountsSummary", () => {
       ],
     });
 
+    // "Single Group" is a group of one, so it gets a group scope rather than being
+    // flattened into a standalone row.
     expect(getLastPerformanceScopes()).toEqual([
       { accountIds: ["group-a-1", "group-a-2"] },
-      { accountIds: ["standalone"] },
       { accountIds: ["single-group"] },
+      { accountIds: ["standalone"] },
     ]);
 
     await user.click(screen.getByText("Group A"));
@@ -424,9 +426,20 @@ describe("AccountsSummary", () => {
       { accountIds: ["group-a-1", "group-a-2"] },
       { accountIds: ["group-a-1"] },
       { accountIds: ["group-a-2"] },
-      { accountIds: ["standalone"] },
       { accountIds: ["single-group"] },
+      { accountIds: ["standalone"] },
     ]);
+  });
+
+  it("renders a group row for a group with a single account", () => {
+    renderAccountsSummary({
+      accounts: [createAccount({ id: "solo", name: "Solo Account", group: "Solo Group" })],
+      valuations: [createValuation({ accountId: "solo", totalValue: 400 })],
+    });
+
+    // The group header renders instead of a bare account link, so group-wide stats stay visible.
+    expect(screen.getByText("Solo Group")).toBeInTheDocument();
+    expect(screen.queryByText("Solo Account")).not.toBeInTheDocument();
   });
 
   it("counts hidden accounts in group totals without rendering them", async () => {

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -93,13 +93,6 @@ function getDashboardAccountPerformanceScopes(
   }
 
   for (const [groupName, groupAccounts] of groupedAccounts) {
-    // Membership counts hidden accounts, so hiding all but one member does not
-    // dissolve the group into a bare account row.
-    if (groupAccounts.length === 1) {
-      if (groupAccounts[0].isActive) standaloneAccountIds.push(groupAccounts[0].id);
-      continue;
-    }
-
     if (!groupAccounts.some((account) => account.isActive)) continue;
 
     addPerformanceScope(
@@ -594,13 +587,6 @@ export const AccountsSummary = React.memo(
         Object.entries(groups).forEach(([groupName, groupAccounts]) => {
           const visibleAccounts = groupAccounts.filter((account) => account.isActive);
           if (visibleAccounts.length === 0) return;
-
-          // Membership counts hidden accounts, so a group only collapses to a bare
-          // account row when it genuinely has one member.
-          if (groupAccounts.length === 1) {
-            standaloneAccounts.push(groupAccounts[0]);
-            return;
-          }
 
           const baseCurrency = groupAccounts[0]?.baseCurrency ?? settings?.baseCurrency ?? "USD";
           // Totals span every group member, hidden included, so value and gain are computed

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -40,6 +40,7 @@ interface AccountSummaryDisplayData {
   accountGroup?: string | null;
   trackingMode?: TrackingMode;
   isGroup?: boolean;
+  isActive?: boolean;
   accountCount?: number;
   accounts?: AccountSummaryDisplayData[];
   displayInAccountCurrency?: boolean;
@@ -69,33 +70,48 @@ function getDashboardAccountPerformanceScopes(
   const seenScopeKeys = new Set<string>();
 
   if (!accountsGrouped) {
-    accounts.forEach((account) => addPerformanceScope(scopes, seenScopeKeys, [account.id]));
+    accounts
+      .filter((account) => account.isActive)
+      .forEach((account) => addPerformanceScope(scopes, seenScopeKeys, [account.id]));
     return scopes;
   }
 
-  const groupedAccountIds = new Map<string, string[]>();
+  // Hidden accounts still count toward their group's totals, so groups are bucketed over
+  // every non-archived account. Only visible accounts get a row, and therefore a scope, of
+  // their own.
+  const groupedAccounts = new Map<string, Account[]>();
   const standaloneAccountIds: string[] = [];
 
   for (const account of accounts) {
     const groupName = account.group ?? "Uncategorized";
     if (groupName === "Uncategorized") {
-      standaloneAccountIds.push(account.id);
+      if (account.isActive) standaloneAccountIds.push(account.id);
       continue;
     }
 
-    groupedAccountIds.set(groupName, [...(groupedAccountIds.get(groupName) ?? []), account.id]);
+    groupedAccounts.set(groupName, [...(groupedAccounts.get(groupName) ?? []), account]);
   }
 
-  for (const [groupName, accountIds] of groupedAccountIds) {
-    if (accountIds.length === 1) {
-      standaloneAccountIds.push(accountIds[0]);
+  for (const [groupName, groupAccounts] of groupedAccounts) {
+    // Membership counts hidden accounts, so hiding all but one member does not
+    // dissolve the group into a bare account row.
+    if (groupAccounts.length === 1) {
+      if (groupAccounts[0].isActive) standaloneAccountIds.push(groupAccounts[0].id);
       continue;
     }
 
-    addPerformanceScope(scopes, seenScopeKeys, accountIds);
+    if (!groupAccounts.some((account) => account.isActive)) continue;
+
+    addPerformanceScope(
+      scopes,
+      seenScopeKeys,
+      groupAccounts.map((account) => account.id),
+    );
 
     if (expandedGroups[groupName]) {
-      accountIds.forEach((accountId) => addPerformanceScope(scopes, seenScopeKeys, [accountId]));
+      groupAccounts
+        .filter((account) => account.isActive)
+        .forEach((account) => addPerformanceScope(scopes, seenScopeKeys, [account.id]));
     }
   }
 
@@ -380,12 +396,14 @@ export const AccountsSummary = React.memo(
     const { accountsGrouped, setAccountsGrouped, settings } = useSettingsContext();
     const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
 
+    // Hidden accounts are excluded from the rendered rows below, but they still carry value
+    // and gain history that belongs to their group's totals.
     const {
       accounts: allAccounts,
       isLoading: isLoadingAccounts,
       isError: isErrorAccounts,
       error: errorAccounts,
-    } = useAccounts({ accountPurpose: AccountPurpose.PERFORMANCE });
+    } = useAccounts({ accountPurpose: AccountPurpose.PERFORMANCE, filterActive: false });
 
     const accounts = useMemo(() => allAccounts ?? [], [allAccounts]);
 
@@ -459,6 +477,7 @@ export const AccountsSummary = React.memo(
             accountGroup: acc.group ?? null,
             trackingMode: acc.trackingMode,
             isGroup: false,
+            isActive: acc.isActive,
           };
         }
 
@@ -490,6 +509,7 @@ export const AccountsSummary = React.memo(
           accountGroup: acc.group ?? null,
           trackingMode: acc.trackingMode,
           isGroup: false,
+          isActive: acc.isActive,
         };
       });
     }, [accounts, currentAccountValuations, performanceSummaries, settings?.baseCurrency]);
@@ -536,7 +556,7 @@ export const AccountsSummary = React.memo(
         );
       }
 
-      if (!combinedAccountViews || combinedAccountViews.length === 0) {
+      if (!combinedAccountViews.some((account) => account.isActive)) {
         return (
           <div className="border-border/50 bg-success/10 rounded-xl border p-6 text-center md:p-8">
             <p className="text-sm">{t("dashboard:no_accounts_found")}</p>
@@ -560,7 +580,7 @@ export const AccountsSummary = React.memo(
         combinedAccountViews.forEach((account) => {
           const groupName = account.accountGroup ?? "Uncategorized";
           if (groupName === "Uncategorized") {
-            standaloneAccounts.push(account);
+            if (account.isActive) standaloneAccounts.push(account);
           } else {
             if (!groups[groupName]) {
               groups[groupName] = [];
@@ -572,42 +592,50 @@ export const AccountsSummary = React.memo(
         const actualGroups: AccountSummaryDisplayData[] = [];
 
         Object.entries(groups).forEach(([groupName, groupAccounts]) => {
+          const visibleAccounts = groupAccounts.filter((account) => account.isActive);
+          if (visibleAccounts.length === 0) return;
+
+          // Membership counts hidden accounts, so a group only collapses to a bare
+          // account row when it genuinely has one member.
           if (groupAccounts.length === 1) {
             standaloneAccounts.push(groupAccounts[0]);
-          } else {
-            const baseCurrency = groupAccounts[0]?.baseCurrency ?? settings?.baseCurrency ?? "USD";
-            const groupAccountIds = groupAccounts
-              .map((account) => account.accountId)
-              .filter((id): id is string => Boolean(id));
-            const groupPerformance =
-              performanceSummaries?.[performanceSummaryScopeKey(groupAccountIds)];
-
-            const totalValueBaseCurrency = groupAccounts.reduce(
-              (sum, acc) => sum + Number(acc.totalValueBaseCurrency),
-              0,
-            );
-
-            const totalGainLossAmountBase = performancePeriodPnl(groupPerformance);
-            const groupTotalReturnPercentBase = performanceSummaryReturn(groupPerformance);
-
-            actualGroups.push({
-              accountName: groupName,
-              totalValueBaseCurrency,
-              baseCurrency,
-              totalGainLossAmountBaseCurrency: totalGainLossAmountBase,
-              totalGainLossPercent: groupTotalReturnPercentBase,
-              accountCurrency: baseCurrency,
-              totalValueAccountCurrency: totalValueBaseCurrency,
-              totalGainLossAmountAccountCurrency: totalGainLossAmountBase,
-              isGroup: true,
-              accountCount: groupAccounts.length,
-              accounts: groupAccounts,
-              trackingMode: groupAccounts.every((account) => account.trackingMode === "HOLDINGS")
-                ? "HOLDINGS"
-                : undefined,
-              displayInAccountCurrency: false,
-            });
+            return;
           }
+
+          const baseCurrency = groupAccounts[0]?.baseCurrency ?? settings?.baseCurrency ?? "USD";
+          // Totals span every group member, hidden included, so value and gain are computed
+          // over the same set — and match the scope key emitted for this group.
+          const groupAccountIds = groupAccounts
+            .map((account) => account.accountId)
+            .filter((id): id is string => Boolean(id));
+          const groupPerformance =
+            performanceSummaries?.[performanceSummaryScopeKey(groupAccountIds)];
+
+          const totalValueBaseCurrency = groupAccounts.reduce(
+            (sum, acc) => sum + Number(acc.totalValueBaseCurrency),
+            0,
+          );
+
+          const totalGainLossAmountBase = performancePeriodPnl(groupPerformance);
+          const groupTotalReturnPercentBase = performanceSummaryReturn(groupPerformance);
+
+          actualGroups.push({
+            accountName: groupName,
+            totalValueBaseCurrency,
+            baseCurrency,
+            totalGainLossAmountBaseCurrency: totalGainLossAmountBase,
+            totalGainLossPercent: groupTotalReturnPercentBase,
+            accountCurrency: baseCurrency,
+            totalValueAccountCurrency: totalValueBaseCurrency,
+            totalGainLossAmountAccountCurrency: totalGainLossAmountBase,
+            isGroup: true,
+            accountCount: visibleAccounts.length,
+            accounts: visibleAccounts,
+            trackingMode: groupAccounts.every((account) => account.trackingMode === "HOLDINGS")
+              ? "HOLDINGS"
+              : undefined,
+            displayInAccountCurrency: false,
+          });
         });
 
         actualGroups.sort(
@@ -673,9 +701,9 @@ export const AccountsSummary = React.memo(
           </>
         );
       } else {
-        const sortedAccounts = [...combinedAccountViews].sort(
-          (a, b) => Number(b.totalValueBaseCurrency) - Number(a.totalValueBaseCurrency),
-        );
+        const sortedAccounts = combinedAccountViews
+          .filter((account) => account.isActive)
+          .sort((a, b) => Number(b.totalValueBaseCurrency) - Number(a.totalValueBaseCurrency));
 
         return sortedAccounts.map((account) => (
           <AccountSummaryComponent


### PR DESCRIPTION
## Description

Fixes #1340

Hidden accounts (`isActive: false`, not archived) are documented as still counting toward
totals and history, and the backend honors that everywhere — `{type: "all"}` scope
resolution, snapshot recalculation, and `account_in_portfolio_scope` all exclude only
archived accounts. The dashboard's account summary did not: `useAccounts` defaults to
`filterActive: true`, and both the performance scopes and the group value sums were built
from that filtered list.

Consequences:

- Hiding an account silently removed its entire gain history from its group's TWR/PnL,
  even at zero current value, and shifted the group's TWR start date.
- The group rows disagreed with the dashboard headline (which is hidden-inclusive), by
  triple-digit percentage points on all-time in real data.
- Hiding all but one member dissolved the group entirely: the `length === 1` collapse saw
  only the filtered list, so the group and its stats vanished.

Short windows (YTD/3M) mask all of this because hidden accounts are usually dormant —
the divergence concentrates in all-time and long ranges.

## Fix

Two commits:

**`fix(dashboard): count hidden accounts in group stats`**

- Fetch with `filterActive: false` at this one call site. The hook default is left
  alone — account pickers and import flows still want active-only.
- Carry `isActive` onto the display data.
- Include hidden members in both the group's performance scope and the group's value sum,
  so value and gain are computed over the same account set — and match the headline.
- Measure group membership over all non-archived accounts, so hiding members no longer
  dissolves a group.
- Only active accounts get a rendered row; per-account scopes on expand are visible-only.

**`fix(dashboard): render single-member groups as groups`**

- Drop the `length === 1` collapse at both the scope and render sites, so a genuine
  group-of-one renders with its group header instead of a bare account row. The numbers
  are identical either way (a one-account group scope has the same scope key and value as
  the account itself); this is presentation only, split into its own commit so it can be
  dropped independently.

## Behavior note

A group's header value includes hidden members' current value, so expanded visible rows
may not sum to the header. This is intentional: the alternative (visible-only value,
hidden-inclusive gain) would compute the two numbers over different sets, and the header
would disagree with the portfolio total above it.

## Test plan

- `accounts-summary.test.tsx`: new tests — hidden accounts kept in group scope and totals
  without rendered rows (collapsed and expanded), group survives hiding all but one
  member, single-member group renders as a group, and the component actually opts out of
  the hook's active-only filter (the hook is mocked, so this pins the
  `filterActive: false` argument).
- Verified against a live dataset over HTTP: group scopes with hidden members now match
  the hidden-inclusive headline scope; YTD/3M unchanged.
- `pnpm type-check` clean.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
