### PR TITLE
Handle pre-funding negative values in returns

### DIFF
--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -615,7 +615,10 @@ impl PerformanceService {
                 warned_partial_value_coverage = true;
             }
 
-            if prev_value.is_sign_negative() || curr_value.is_sign_negative() {
+            // A negative closing value is always fatal. A negative opening
+            // value is fatal only after the return chain has started; before
+            // that it belongs to the pre-funding prefix handled below.
+            if curr_value.is_sign_negative() || (chain_started && prev_value.is_sign_negative()) {
                 not_applicable_reasons.push(format!(
                     "TWR unavailable for {} because portfolio value is negative. Review the underlying transactions, prices, and cash balances.",
                     curr_point.valuation_date
@@ -9337,6 +9340,108 @@ mod tests {
             .not_applicable_reasons
             .iter()
             .any(|reason| reason.contains("denominator") && reason.contains("negative")));
+    }
+
+    #[test]
+    fn twr_skips_negative_prefix_before_first_funded_period() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                dec!(-110),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                dec!(999525),
+                dec!(1000000),
+                dec!(190900),
+                dec!(190900),
+            ),
+            valuation(
+                "2026-06-26",
+                dec!(968216),
+                dec!(1000000),
+                dec!(704200),
+                dec!(704200),
+            ),
+        ];
+        history[1].external_inflow_base = dec!(1000000);
+        history[1].external_flow_source = ExternalFlowSource::CashAmount;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
+        assert_eq!(result.returns.twr, Some(expected));
+        assert_eq!(result.summary.percent, Some(expected));
+        assert_eq!(result.series[1].value, Decimal::ZERO);
+        assert_eq!(result.series[2].value, expected);
+        assert!(!result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("portfolio value is negative")));
+    }
+
+    #[test]
+    fn twr_rejects_negative_closing_value_before_chain_starts() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                dec!(-50),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-26",
+                dec!(100),
+                dec!(250),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-27",
+                dec!(110),
+                dec!(250),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        history[1].external_inflow_base = dec!(100);
+        history[1].external_flow_source = ExternalFlowSource::CashAmount;
+        history[2].external_inflow_base = dec!(150);
+        history[2].external_flow_source = ExternalFlowSource::CashAmount;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        assert_eq!(result.returns.twr, None);
+        assert_eq!(result.summary.percent, None);
+        assert!(result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("portfolio value is negative")));
     }
 
     #[test]

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -1023,7 +1023,7 @@ impl PerformanceService {
         let start_index = if first_value.is_sign_negative() {
             full_history
                 .iter()
-                .position(|point| Self::return_total_value(point, flow_basis).is_sign_positive())?
+                .position(|point| Self::return_total_value(point, flow_basis) > Decimal::ZERO)?
         } else {
             0
         };
@@ -9469,6 +9469,59 @@ mod tests {
             .not_applicable_reasons
             .iter()
             .any(|reason| reason.contains("portfolio value is negative")));
+    }
+
+    #[test]
+    fn value_return_skips_zero_within_negative_prefix() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                dec!(-110),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-26",
+                dec!(999525),
+                dec!(1000000),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-27",
+                dec!(968216),
+                dec!(1000000),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        history[2].external_inflow_base = dec!(1000000);
+        history[2].external_flow_source = ExternalFlowSource::CashAmount;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
+        assert_eq!(result.returns.twr, Some(expected));
+        assert_eq!(result.returns.value_return, Some(expected));
+        assert!(!result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("starting value is zero or negative")));
     }
 
     #[test]

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -1010,13 +1010,28 @@ impl PerformanceService {
         daily_flows: &[DailyExternalFlow],
         flow_basis: ExternalFlowBasis,
     ) -> Option<Decimal> {
-        let start_point = full_history.first()?;
+        let first_point = full_history.first()?;
+        let first_value = Self::return_total_value(first_point, flow_basis);
+        // A leading negative row can be pre-funding history (for example, a
+        // trade before its covering deposit). Rebase on the first positive
+        // observation, excluding the flows that established that base. A zero
+        // start remains unavailable because simple return has no denominator.
+        let start_index = if first_value.is_sign_negative() {
+            full_history
+                .iter()
+                .position(|point| Self::return_total_value(point, flow_basis).is_sign_positive())?
+        } else {
+            0
+        };
+        let scoped_history = &full_history[start_index..];
+        let scoped_flows = &daily_flows[start_index..];
+        let start_point = scoped_history.first()?;
         let start_value = Self::return_total_value(start_point, flow_basis);
         if start_value <= Decimal::ZERO {
             return None;
         }
 
-        Self::compute_simple_value_return_amount(full_history, daily_flows, flow_basis)
+        Self::compute_simple_value_return_amount(scoped_history, scoped_flows, flow_basis)
             .map(|amount| amount / start_value)
     }
 
@@ -9380,6 +9395,7 @@ mod tests {
 
         let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
         assert_eq!(result.returns.twr, Some(expected));
+        assert_eq!(result.returns.value_return, Some(expected));
         assert_eq!(result.summary.percent, Some(expected));
         assert_eq!(result.series[1].value, Decimal::ZERO);
         assert_eq!(result.series[2].value, expected);
@@ -9388,6 +9404,11 @@ mod tests {
             .not_applicable_reasons
             .iter()
             .any(|reason| reason.contains("portfolio value is negative")));
+        assert!(!result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("starting value is zero or negative")));
     }
 
     #[test]

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -298,6 +298,7 @@ pub struct PerformanceService {
 const DAYS_PER_YEAR_DECIMAL: Decimal = dec!(365.25);
 const SQRT_DAYS_PER_YEAR_APPROX: Decimal = dec!(19.111514854); // sqrt(365.25)
 const MIN_ANNUALIZATION_DAYS: i64 = 30;
+const MIN_RETURN_BASE: Decimal = Decimal::ONE;
 const ATTRIBUTION_RESIDUAL_TOLERANCE_RATE: Decimal = dec!(0.002);
 const ATTRIBUTION_RESIDUAL_LEGACY_WARNING_PREFIX: &str = "Attribution residual ";
 const ATTRIBUTION_INCOMPLETE_WARNING_PREFIX: &str = "Performance attribution is incomplete";
@@ -646,7 +647,7 @@ impl PerformanceService {
             // and must stay fatal — it nulls the headline exactly like a
             // negative portfolio value, rather than being silently paused.
             let denom_is_benign_low_base =
-                twr_denominator >= Decimal::ZERO && twr_denominator < Decimal::ONE;
+                twr_denominator >= Decimal::ZERO && twr_denominator < MIN_RETURN_BASE;
 
             // A negative denominator is fatal only where it was before: once the
             // chain has started, or on a pre-chain day whose opening value is
@@ -1024,7 +1025,7 @@ impl PerformanceService {
         let start_index = if first_value.is_sign_negative() {
             full_history
                 .iter()
-                .position(|point| Self::return_total_value(point, flow_basis) >= Decimal::ONE)?
+                .position(|point| Self::return_total_value(point, flow_basis) >= MIN_RETURN_BASE)?
         } else {
             0
         };
@@ -5361,6 +5362,20 @@ mod tests {
         }
     }
 
+    fn cash_valuation(
+        date: &str,
+        total_value: Decimal,
+        net_contribution: Decimal,
+    ) -> DailyAccountValuation {
+        valuation(
+            date,
+            total_value,
+            net_contribution,
+            Decimal::ZERO,
+            Decimal::ZERO,
+        )
+    }
+
     fn account_valuation(
         account_id: &str,
         date: &str,
@@ -9366,7 +9381,7 @@ mod tests {
     }
 
     #[test]
-    fn twr_skips_negative_prefix_before_first_funded_period() {
+    fn returns_skip_negative_prefix_before_first_funded_period() {
         let mut history = vec![
             valuation(
                 "2026-06-24",
@@ -9420,189 +9435,61 @@ mod tests {
     }
 
     #[test]
-    fn twr_skips_multiple_negative_prefix_rows() {
-        let mut history = vec![
-            valuation(
-                "2026-06-24",
-                dec!(-110),
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-25",
-                dec!(-110),
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-26",
-                dec!(999525),
-                dec!(1000000),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-27",
-                dec!(968216),
-                dec!(1000000),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-        ];
-        history[2].external_inflow_base = dec!(1000000);
-        history[2].external_flow_source = ExternalFlowSource::CashAmount;
-
-        let result = PerformanceService::compute_account_performance(
-            &history,
-            Some(TrackingMode::Transactions),
-            None,
-            true,
-        )
-        .expect("performance should compute");
-
-        let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
-        assert_eq!(result.returns.twr, Some(expected));
-        assert_eq!(result.returns.value_return, Some(expected));
-        assert!(!result
-            .data_quality
-            .not_applicable_reasons
-            .iter()
-            .any(|reason| reason.contains("portfolio value is negative")));
-    }
-
-    #[test]
-    fn value_return_skips_zero_within_negative_prefix() {
-        let mut history = vec![
-            valuation(
-                "2026-06-24",
-                dec!(-110),
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-25",
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-26",
-                dec!(999525),
-                dec!(1000000),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-27",
-                dec!(968216),
-                dec!(1000000),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-        ];
-        history[2].external_inflow_base = dec!(1000000);
-        history[2].external_flow_source = ExternalFlowSource::CashAmount;
-
-        let result = PerformanceService::compute_account_performance(
-            &history,
-            Some(TrackingMode::Transactions),
-            None,
-            true,
-        )
-        .expect("performance should compute");
-
-        let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
-        assert_eq!(result.returns.twr, Some(expected));
-        assert_eq!(result.returns.value_return, Some(expected));
-        assert!(!result
-            .data_quality
-            .not_applicable_reasons
-            .iter()
-            .any(|reason| reason.contains("starting value is zero or negative")));
-    }
-
-    #[test]
-    fn value_return_skips_dust_within_negative_prefix() {
-        let mut history = vec![
-            valuation(
-                "2026-06-24",
-                dec!(-110),
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-25",
-                dec!(0.5),
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-26",
-                dec!(999525),
-                dec!(1000000),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-27",
-                dec!(968216),
-                dec!(1000000),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-        ];
-        history[2].external_inflow_base = dec!(1000000);
-        history[2].external_flow_source = ExternalFlowSource::CashAmount;
-
-        let result = PerformanceService::compute_account_performance(
-            &history,
-            Some(TrackingMode::Transactions),
-            None,
-            true,
-        )
-        .expect("performance should compute");
-
-        let funding_period_return =
-            (dec!(999525) - dec!(0.5) - dec!(1000000)) / (dec!(0.5) + dec!(1000000));
+    fn returns_skip_prefunding_prefix_variants() {
         let funded_period_return = dec!(968216) / dec!(999525) - Decimal::ONE;
-        let expected_twr = ((Decimal::ONE + funding_period_return)
+        let dust_funding_period_return =
+            (dec!(999525) - dec!(0.5) - dec!(1000000)) / (dec!(0.5) + dec!(1000000));
+        let dust_twr = ((Decimal::ONE + dust_funding_period_return)
             * (Decimal::ONE + funded_period_return)
             - Decimal::ONE)
             .round_dp(DECIMAL_PRECISION);
         let expected_value_return = funded_period_return.round_dp(DECIMAL_PRECISION);
 
-        assert_eq!(result.returns.twr, Some(expected_twr));
-        assert_eq!(result.returns.value_return, Some(expected_value_return));
-        assert!(!result
-            .data_quality
-            .not_applicable_reasons
-            .iter()
-            .any(|reason| reason.contains("starting value is zero or negative")));
+        for (label, prefix_end_value, expected_twr) in [
+            ("negative", dec!(-110), expected_value_return),
+            ("zero", Decimal::ZERO, expected_value_return),
+            ("dust", dec!(0.5), dust_twr),
+        ] {
+            let mut history = vec![
+                cash_valuation("2026-06-24", dec!(-110), Decimal::ZERO),
+                cash_valuation("2026-06-25", prefix_end_value, Decimal::ZERO),
+                cash_valuation("2026-06-26", dec!(999525), dec!(1000000)),
+                cash_valuation("2026-06-27", dec!(968216), dec!(1000000)),
+            ];
+            history[2].external_inflow_base = dec!(1000000);
+            history[2].external_flow_source = ExternalFlowSource::CashAmount;
+
+            let result = PerformanceService::compute_account_performance(
+                &history,
+                Some(TrackingMode::Transactions),
+                None,
+                true,
+            )
+            .expect("performance should compute");
+
+            assert_eq!(result.returns.twr, Some(expected_twr), "{label} prefix");
+            assert_eq!(
+                result.returns.value_return,
+                Some(expected_value_return),
+                "{label} prefix"
+            );
+            assert!(
+                !result
+                    .data_quality
+                    .not_applicable_reasons
+                    .iter()
+                    .any(|reason| reason.contains("portfolio value is negative")
+                        || reason.contains("starting value is zero or negative")),
+                "{label} prefix"
+            );
+        }
     }
 
     #[test]
     fn value_return_requires_window_after_rebased_start() {
         let mut history = vec![
-            valuation(
-                "2026-06-24",
-                dec!(-1),
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-25",
-                dec!(100),
-                dec!(101),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
+            cash_valuation("2026-06-24", dec!(-1), Decimal::ZERO),
+            cash_valuation("2026-06-25", dec!(100), dec!(101)),
         ];
         history[1].external_inflow_base = dec!(101);
         history[1].external_flow_source = ExternalFlowSource::CashAmount;
@@ -9627,34 +9514,10 @@ mod tests {
     #[test]
     fn twr_rejects_negative_closing_value_before_chain_starts() {
         let mut history = vec![
-            valuation(
-                "2026-06-24",
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-25",
-                dec!(-50),
-                dec!(100),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-26",
-                dec!(100),
-                dec!(250),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-27",
-                dec!(110),
-                dec!(250),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
+            cash_valuation("2026-06-24", Decimal::ZERO, Decimal::ZERO),
+            cash_valuation("2026-06-25", dec!(-50), dec!(100)),
+            cash_valuation("2026-06-26", dec!(100), dec!(250)),
+            cash_valuation("2026-06-27", dec!(110), dec!(250)),
         ];
         history[1].external_inflow_base = dec!(100);
         history[1].external_flow_source = ExternalFlowSource::CashAmount;
@@ -9681,34 +9544,10 @@ mod tests {
     #[test]
     fn twr_keeps_post_chain_negative_opening_fatal() {
         let mut history = vec![
-            valuation(
-                "2026-06-24",
-                dec!(100),
-                dec!(100),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-25",
-                dec!(110),
-                dec!(100),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-26",
-                dec!(-50),
-                dec!(100),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
-            valuation(
-                "2026-06-27",
-                dec!(100),
-                dec!(250),
-                Decimal::ZERO,
-                Decimal::ZERO,
-            ),
+            cash_valuation("2026-06-24", dec!(100), dec!(100)),
+            cash_valuation("2026-06-25", dec!(110), dec!(100)),
+            cash_valuation("2026-06-26", dec!(-50), dec!(100)),
+            cash_valuation("2026-06-27", dec!(100), dec!(250)),
         ];
         history[3].external_inflow_base = dec!(150);
         history[3].external_flow_source = ExternalFlowSource::CashAmount;

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -1017,13 +1017,14 @@ impl PerformanceService {
         let first_point = full_history.first()?;
         let first_value = Self::return_total_value(first_point, flow_basis);
         // A leading negative row can be pre-funding history (for example, a
-        // trade before its covering deposit). Rebase on the first positive
-        // observation, excluding the flows that established that base. A zero
-        // start remains unavailable because simple return has no denominator.
+        // trade before its covering deposit). Rebase on the first observation
+        // with at least one base-currency unit, excluding the flows that
+        // established that base. This avoids amplifying rounding dust into an
+        // extreme simple return.
         let start_index = if first_value.is_sign_negative() {
             full_history
                 .iter()
-                .position(|point| Self::return_total_value(point, flow_basis) > Decimal::ZERO)?
+                .position(|point| Self::return_total_value(point, flow_basis) >= Decimal::ONE)?
         } else {
             0
         };
@@ -9517,6 +9518,67 @@ mod tests {
         let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
         assert_eq!(result.returns.twr, Some(expected));
         assert_eq!(result.returns.value_return, Some(expected));
+        assert!(!result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("starting value is zero or negative")));
+    }
+
+    #[test]
+    fn value_return_skips_dust_within_negative_prefix() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                dec!(-110),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                dec!(0.5),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-26",
+                dec!(999525),
+                dec!(1000000),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-27",
+                dec!(968216),
+                dec!(1000000),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        history[2].external_inflow_base = dec!(1000000);
+        history[2].external_flow_source = ExternalFlowSource::CashAmount;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        let funding_period_return =
+            (dec!(999525) - dec!(0.5) - dec!(1000000)) / (dec!(0.5) + dec!(1000000));
+        let funded_period_return = dec!(968216) / dec!(999525) - Decimal::ONE;
+        let expected_twr = ((Decimal::ONE + funding_period_return)
+            * (Decimal::ONE + funded_period_return)
+            - Decimal::ONE)
+            .round_dp(DECIMAL_PRECISION);
+        let expected_value_return = funded_period_return.round_dp(DECIMAL_PRECISION);
+
+        assert_eq!(result.returns.twr, Some(expected_twr));
+        assert_eq!(result.returns.value_return, Some(expected_value_return));
         assert!(!result
             .data_quality
             .not_applicable_reasons

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -615,10 +615,14 @@ impl PerformanceService {
                 warned_partial_value_coverage = true;
             }
 
-            // A negative closing value is always fatal. A negative opening
-            // value is fatal only after the return chain has started; before
-            // that it belongs to the pre-funding prefix handled below.
-            if curr_value.is_sign_negative() || (chain_started && prev_value.is_sign_negative()) {
+            // Skip a contiguous negative prefix before the return chain has a
+            // valid base. Once compounding starts, or if history falls from a
+            // zero/positive opening into a negative close, any negative value
+            // remains fatal.
+            let prev_value_is_negative = prev_value.is_sign_negative();
+            let curr_value_is_negative = curr_value.is_sign_negative();
+            let is_leading_negative_prefix = !chain_started && prev_value_is_negative;
+            if (prev_value_is_negative || curr_value_is_negative) && !is_leading_negative_prefix {
                 not_applicable_reasons.push(format!(
                     "TWR unavailable for {} because portfolio value is negative. Review the underlying transactions, prices, and cash balances.",
                     curr_point.valuation_date
@@ -1025,6 +1029,9 @@ impl PerformanceService {
         };
         let scoped_history = &full_history[start_index..];
         let scoped_flows = &daily_flows[start_index..];
+        if scoped_history.len() < 2 {
+            return None;
+        }
         let start_point = scoped_history.first()?;
         let start_value = Self::return_total_value(start_point, flow_basis);
         if start_value <= Decimal::ZERO {
@@ -9412,6 +9419,97 @@ mod tests {
     }
 
     #[test]
+    fn twr_skips_multiple_negative_prefix_rows() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                dec!(-110),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                dec!(-110),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-26",
+                dec!(999525),
+                dec!(1000000),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-27",
+                dec!(968216),
+                dec!(1000000),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        history[2].external_inflow_base = dec!(1000000);
+        history[2].external_flow_source = ExternalFlowSource::CashAmount;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        let expected = (dec!(968216) / dec!(999525) - Decimal::ONE).round_dp(DECIMAL_PRECISION);
+        assert_eq!(result.returns.twr, Some(expected));
+        assert_eq!(result.returns.value_return, Some(expected));
+        assert!(!result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("portfolio value is negative")));
+    }
+
+    #[test]
+    fn value_return_requires_window_after_rebased_start() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                dec!(-1),
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                dec!(100),
+                dec!(101),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        history[1].external_inflow_base = dec!(101);
+        history[1].external_flow_source = ExternalFlowSource::CashAmount;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        assert_eq!(result.returns.twr, None);
+        assert_eq!(result.returns.value_return, None);
+        assert!(result
+            .data_quality
+            .not_applicable_reasons
+            .iter()
+            .any(|reason| reason.contains("starting value is zero or negative")));
+    }
+
+    #[test]
     fn twr_rejects_negative_closing_value_before_chain_starts() {
         let mut history = vec![
             valuation(
@@ -9463,6 +9561,65 @@ mod tests {
             .not_applicable_reasons
             .iter()
             .any(|reason| reason.contains("portfolio value is negative")));
+    }
+
+    #[test]
+    fn twr_keeps_post_chain_negative_opening_fatal() {
+        let mut history = vec![
+            valuation(
+                "2026-06-24",
+                dec!(100),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-25",
+                dec!(110),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-26",
+                dec!(-50),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "2026-06-27",
+                dec!(100),
+                dec!(250),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        history[3].external_inflow_base = dec!(150);
+        history[3].external_flow_source = ExternalFlowSource::CashAmount;
+        let daily_flows = PerformanceService::daily_external_flow_series(
+            &history,
+            ExternalFlowBasis::BaseCurrency,
+        );
+
+        let result = PerformanceService::compute_time_weighted_returns(
+            &history,
+            &daily_flows,
+            ExternalFlowBasis::BaseCurrency,
+        )
+        .expect("TWR computation should complete");
+
+        assert!(!result.samples[0].1.excluded_from_compounding);
+        assert!(result.samples[1].1.excluded_from_compounding);
+        assert!(result.samples[2].1.excluded_from_compounding);
+        assert_eq!(
+            result
+                .not_applicable_reasons
+                .iter()
+                .filter(|reason| reason.contains("portfolio value is negative"))
+                .count(),
+            2
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- skip a contiguous leading negative valuation prefix before TWR compounding starts, including multi-day T+2 settlement gaps
- rebase transaction-mode value return on the first observation with at least one base-currency unit when history starts negative, skipping zero and rounding-dust prefix rows
- keep zero/positive-to-negative transitions and every negative value after the return chain starts fatal
- require a following valuation after the rebased value-return start so a single point cannot produce a fabricated 0% return
- add regression coverage for the exact issue, multi-day, zero-interleaved, and dust prefixes, negative guard behavior, and the single-point boundary

## Root cause

The first-activity valuation introduced in 3.6.3 can be negative before the account's covering deposit. The TWR negative-value gate rejected that prefix before the existing pre-chain exclusion, while simple value return always anchored to the first history row. Together, those paths made both returns unavailable for the full period.

## Impact

Accounts with one or more transient non-positive opening valuations, such as trades recorded before a T+2 covering deposit, report TWR and value return from the first valid funded period. The flow that establishes that base is excluded from the rebased value-return numerator. Zero and sub-unit rounding-dust rows are not used as value-return denominators. Genuine transitions into negative value remain unavailable, as do negative observations after compounding starts and rebased scopes without a return window. A history that starts at zero retains its existing unavailable value-return result.

Fixes #1425

## Validation

- `cargo test -p wealthfolio-core` (1,732 unit tests and 12 property tests passed)
- `cargo check -p wealthfolio-core`
- `cargo clippy -p wealthfolio-core --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

