### PR TITLE
fix(logos): make logo retrieval exchange aware

### DIFF
--- a/apps/frontend/src/components/classification/classification-sheet.tsx
+++ b/apps/frontend/src/components/classification/classification-sheet.tsx
@@ -18,6 +18,7 @@ interface ClassificationSheetProps {
   assetId: string;
   assetName?: string;
   assetSymbol?: string;
+  exchangeMic?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -34,6 +35,7 @@ export function ClassificationSheet({
   assetId,
   assetName,
   assetSymbol,
+  exchangeMic,
   open,
   onOpenChange,
 }: ClassificationSheetProps) {
@@ -70,7 +72,9 @@ export function ClassificationSheet({
       <SheetContent side="right" className="flex h-full w-full flex-col sm:max-w-lg">
         <SheetHeader className="shrink-0 pb-4">
           <div className="flex items-center gap-3">
-            {assetSymbol && <TickerAvatar symbol={assetSymbol} className="size-10" />}
+            {assetSymbol && (
+              <TickerAvatar symbol={assetSymbol} exchangeMic={exchangeMic} className="size-10" />
+            )}
             <div className="min-w-0 flex-1">
               <SheetTitle className="truncate text-lg">
                 {assetSymbol || t("asset:classification.classifyAsset")}

--- a/apps/frontend/src/components/ticker-avatar.test.tsx
+++ b/apps/frontend/src/components/ticker-avatar.test.tsx
@@ -1,7 +1,15 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TickerAvatar } from "./ticker-avatar";
+
+vi.mock("@/hooks/use-ticker-logo-suffix", () => ({
+  useTickerLogoSuffix: vi.fn((mic?: string | null) => {
+    if (mic?.toUpperCase() === "XPAR") return "PA";
+    if (mic?.toUpperCase() === "XTSE") return "TO";
+    return undefined;
+  }),
+}));
 
 describe("TickerAvatar", () => {
   it("renders cash symbols with a painted avatar background", () => {
@@ -30,5 +38,18 @@ describe("TickerAvatar", () => {
     render(<TickerAvatar symbol="ABCDE" />);
 
     expect(screen.getByTitle("ABCDE")).toHaveTextContent("ABCD");
+  });
+
+  it("handles exchangeMic suffix resolution for symbols without existing suffix", () => {
+    const { container } = render(<TickerAvatar symbol="DG" exchangeMic="XPAR" />);
+    // Avatar rendered with fallback title DG
+    expect(screen.getByTitle("DG")).toBeInTheDocument();
+    expect(container.querySelector("span[title='DG']")).toHaveTextContent("DG");
+  });
+
+  it("does not duplicate suffix when symbol already has a delimiter", () => {
+    const { container } = render(<TickerAvatar symbol="DG.PA" exchangeMic="XPAR" />);
+    expect(screen.getByTitle("DG.PA")).toBeInTheDocument();
+    expect(container.querySelector("span[title='DG.PA']")).toHaveTextContent("DG");
   });
 });

--- a/apps/frontend/src/components/ticker-avatar.tsx
+++ b/apps/frontend/src/components/ticker-avatar.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { parseOccSymbol } from "@/lib/occ-symbol";
+import { useTickerLogoSuffix } from "@/hooks/use-ticker-logo-suffix";
 import { Avatar, AvatarFallback, AvatarImage } from "@wealthfolio/ui";
 
 interface TickerAvatarProps {
   symbol: string;
+  exchangeMic?: string | null;
   className?: string;
   imageClassName?: string;
 }
@@ -33,9 +35,12 @@ const getFallbackAvatarLabel = (symbol: string): string => symbol.slice(0, 4);
 
 export const TickerAvatar = ({
   symbol,
+  exchangeMic,
   className = "size-8",
   imageClassName = "object-contain p-2",
 }: TickerAvatarProps) => {
+  const suffix = useTickerLogoSuffix(exchangeMic);
+
   // For OCC option symbols (e.g. "AAPL250321C00150000"), use the underlying ticker for logo
   const parsed = symbol ? parseOccSymbol(symbol) : null;
   const logoSymbol = parsed ? parsed.underlying : symbol;
@@ -44,8 +49,19 @@ export const TickerAvatar = ({
   const baseSymbol = logoSymbol ? logoSymbol.split(/[.:-]/)[0].toUpperCase() : "";
   const fullSymbol = logoSymbol ? logoSymbol.toUpperCase() : "";
 
-  // Try full symbol first, then fallback to base symbol
-  const primaryLogoUrl = fullSymbol ? `/ticker-logos/${fullSymbol}.png` : "";
+  // Check if logoSymbol already contains an explicit delimiter/suffix
+  const hasExistingSuffix = Boolean(logoSymbol && /[.:-]/.test(logoSymbol));
+
+  // If exchangeMic provides a suffix and symbol has no existing suffix, attempt {baseSymbol}.{suffix} first
+  const exchangeSymbol =
+    !hasExistingSuffix && suffix && baseSymbol ? `${baseSymbol}.${suffix}` : null;
+
+  // Try exchange-suffixed symbol first, then full symbol, then fallback to base symbol
+  const primaryLogoUrl = exchangeSymbol
+    ? `/ticker-logos/${exchangeSymbol}.png`
+    : fullSymbol
+      ? `/ticker-logos/${fullSymbol}.png`
+      : "";
   const fallbackLogoUrl = baseSymbol ? `/ticker-logos/${baseSymbol}.png` : "";
   const cashAvatarLabel = getCashAvatarLabel(fullSymbol);
   const fallbackAvatarLabel = baseSymbol ? getFallbackAvatarLabel(baseSymbol) : "•";

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/asset-classification-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/asset-classification-tool-ui.tsx
@@ -742,7 +742,11 @@ export function AssetClassificationToolUIContentImpl({
                       isSelected && "border-primary/50 bg-primary/5",
                     )}
                   >
-                    <TickerAvatar symbol={avatarSymbol} className="size-8 shrink-0" />
+                    <TickerAvatar
+                      symbol={avatarSymbol}
+                      exchangeMic={candidate.exchangeMic}
+                      className="size-8 shrink-0"
+                    />
                     <div className="min-w-0">
                       <div className="truncate text-sm font-medium">{candidate.label}</div>
                       <div className="text-muted-foreground mt-0.5 truncate text-xs">

--- a/apps/frontend/src/hooks/use-ticker-logo-suffix.test.tsx
+++ b/apps/frontend/src/hooks/use-ticker-logo-suffix.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useTickerLogoSuffix, useTickerLogoSuffixes } from "./use-ticker-logo-suffix";
+import * as adapters from "@/adapters";
+
+vi.mock("@/adapters", () => ({
+  getExchanges: vi.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  function TestWrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return TestWrapper;
+};
+
+describe("useTickerLogoSuffix", () => {
+  it("builds a mic to suffix map from exchange list", async () => {
+    vi.mocked(adapters.getExchanges).mockResolvedValueOnce([
+      {
+        mic: "XPAR",
+        name: "Euronext Paris",
+        longName: "Euronext Paris",
+        currency: "EUR",
+        logoSuffix: ".PA",
+      },
+      { mic: "XNAS", name: "NASDAQ", longName: "NASDAQ", currency: "USD", logoSuffix: "" },
+      {
+        mic: "XTSE",
+        name: "TSX",
+        longName: "Toronto Stock Exchange",
+        currency: "CAD",
+        logoSuffix: "TO",
+      },
+    ]);
+
+    const { result } = renderHook(() => useTickerLogoSuffixes(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        XPAR: "PA",
+        XTSE: "TO",
+      });
+    });
+  });
+
+  it("returns the suffix for a specific exchangeMic", async () => {
+    vi.mocked(adapters.getExchanges).mockResolvedValueOnce([
+      {
+        mic: "XPAR",
+        name: "Euronext Paris",
+        longName: "Euronext Paris",
+        currency: "EUR",
+        logoSuffix: ".PA",
+      },
+    ]);
+
+    const { result } = renderHook(() => useTickerLogoSuffix("xpar"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe("PA");
+    });
+  });
+
+  it("returns undefined for null, undefined, or unknown mic", async () => {
+    vi.mocked(adapters.getExchanges).mockResolvedValueOnce([
+      {
+        mic: "XPAR",
+        name: "Euronext Paris",
+        longName: "Euronext Paris",
+        currency: "EUR",
+        logoSuffix: ".PA",
+      },
+    ]);
+
+    const { result } = renderHook(() => useTickerLogoSuffix(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/hooks/use-ticker-logo-suffix.ts
+++ b/apps/frontend/src/hooks/use-ticker-logo-suffix.ts
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
+import * as adapters from "@/adapters";
+
+const fallbackQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      staleTime: Infinity,
+    },
+  },
+});
+
+export function useTickerLogoSuffixes(): Record<string, string> {
+  let queryClient: QueryClient | undefined;
+  try {
+    queryClient = useQueryClient();
+  } catch {
+    queryClient = fallbackQueryClient;
+  }
+
+  const { data: exchanges = [] } = useQuery(
+    {
+      queryKey: ["exchanges"],
+      queryFn: () =>
+        typeof adapters.getExchanges === "function" ? adapters.getExchanges() : Promise.resolve([]),
+      staleTime: Infinity,
+    },
+    queryClient,
+  );
+
+  return useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const exchange of exchanges) {
+      if (exchange.logoSuffix && exchange.mic) {
+        const cleanSuffix = exchange.logoSuffix.trim().replace(/^\./, "").toUpperCase();
+        if (cleanSuffix) {
+          map[exchange.mic.trim().toUpperCase()] = cleanSuffix;
+        }
+      }
+    }
+    return map;
+  }, [exchanges]);
+}
+
+export function useTickerLogoSuffix(exchangeMic?: string | null): string | undefined {
+  const suffixMap = useTickerLogoSuffixes();
+  if (!exchangeMic) return undefined;
+  return suffixMap[exchangeMic.trim().toUpperCase()];
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -540,6 +540,7 @@ export interface ExchangeInfo {
   name: string;
   longName: string;
   currency: string;
+  logoSuffix?: string | null;
 }
 
 export interface MarketDataProviderInfo {
@@ -749,6 +750,7 @@ export interface HoldingSummary {
   marketValue: number; // Base currency value
   currency: string;
   weightInCategory: number; // Percentage weight within the category (0-100)
+  exchangeMic?: string | null;
 }
 
 /**

--- a/apps/frontend/src/pages/activity/components/activity-date-list.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-date-list.tsx
@@ -200,7 +200,11 @@ function ActivityDateListItem({
   const content = (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+        <TickerAvatar
+          symbol={avatarSymbol}
+          exchangeMic={activity.exchangeMic}
+          className="h-10 w-10 flex-shrink-0"
+        />
         <div className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] gap-x-3">
           <p className="truncate text-base font-semibold leading-5">{displaySymbol}</p>
           {activity.activityType !== ActivityType.SPLIT ? (

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -134,7 +134,11 @@ export const ActivityTableMobile = ({
                 {(() => {
                   const inner = (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+                      <TickerAvatar
+                        symbol={avatarSymbol}
+                        exchangeMic={activity.exchangeMic}
+                        className="h-10 w-10 flex-shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-baseline justify-between gap-2">
                           <p className="truncate font-semibold">{displaySymbol}</p>
@@ -203,7 +207,11 @@ export const ActivityTableMobile = ({
                 {(() => {
                   const inner = (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10" />
+                      <TickerAvatar
+                        symbol={avatarSymbol}
+                        exchangeMic={activity.exchangeMic}
+                        className="h-10 w-10"
+                      />
                       <div>
                         <p className="font-semibold">{displaySymbol}</p>
                         <p className="text-muted-foreground text-xs">

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -226,7 +226,11 @@ export const ActivityTable = ({
 
           const content = (
             <div className="flex max-w-[220px] items-center gap-2">
-              <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
+              <TickerAvatar
+                symbol={avatarSymbol}
+                exchangeMic={row.original.exchangeMic}
+                className="h-8 w-8 shrink-0"
+              />
               <div className="flex min-w-0 flex-col">
                 <span className="flex items-center gap-1 truncate font-medium">
                   <span className="truncate">{displaySymbol}</span>

--- a/apps/frontend/src/pages/activity/components/forms/bulk-holdings-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/bulk-holdings-form.tsx
@@ -80,6 +80,12 @@ const HoldingRow = memo(
       defaultValue: "",
     });
 
+    const exchangeMic = useWatch({
+      control,
+      name: `holdings.${index}.exchangeMic`,
+      defaultValue: "",
+    });
+
     const sharesOwned = useWatch({
       control,
       name: `holdings.${index}.sharesOwned`,
@@ -186,7 +192,7 @@ const HoldingRow = memo(
         {/* Ticker Input */}
         <div className="col-span-3 sm:col-span-6">
           <div className="flex min-w-0 items-center gap-2">
-            <TickerAvatar symbol={ticker} className="shrink-0" />
+            <TickerAvatar symbol={ticker} exchangeMic={exchangeMic} className="shrink-0" />
             <div className="min-w-0 flex-1">
               <FormField
                 control={control}

--- a/apps/frontend/src/pages/activity/import/steps/asset-review-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/asset-review-step.tsx
@@ -97,7 +97,11 @@ function NeedsFixingRow({
     >
       {/* Col 1: avatar + symbol + count */}
       <div className="flex items-center gap-2.5">
-        <TickerAvatar symbol={symbol} className="size-7 shrink-0" />
+        <TickerAvatar
+          symbol={symbol}
+          exchangeMic={item.draft?.instrumentExchangeMic ?? undefined}
+          className="size-7 shrink-0"
+        />
         <div className="flex min-w-0 flex-col">
           <div className="flex items-center gap-1.5">
             <span className="font-mono text-sm font-bold tracking-tight">{symbol}</span>
@@ -199,7 +203,11 @@ function AutoResolvedRow({
     >
       {/* Col 1: avatar + symbol + name */}
       <div className="flex items-center gap-2.5">
-        <TickerAvatar symbol={symbol} className="size-7 shrink-0" />
+        <TickerAvatar
+          symbol={symbol}
+          exchangeMic={asset?.instrumentExchangeMic ?? undefined}
+          className="size-7 shrink-0"
+        />
         <div className="flex min-w-0 flex-col">
           <div className="flex items-center gap-1.5">
             <span className="font-mono text-sm font-bold tracking-tight">{symbol}</span>
@@ -318,7 +326,11 @@ function ReadyAssetRow({
     >
       {/* Col 1: avatar + symbol + name */}
       <div className="flex items-center gap-2.5">
-        <TickerAvatar symbol={symbol} className="size-7 shrink-0" />
+        <TickerAvatar
+          symbol={symbol}
+          exchangeMic={asset?.instrumentExchangeMic ?? undefined}
+          className="size-7 shrink-0"
+        />
         <div className="flex min-w-0 flex-col">
           <div className="flex items-center gap-1.5">
             <span className="font-mono text-sm font-bold tracking-tight">{symbol}</span>

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -655,7 +655,11 @@ export function AssetEditSheet({
       <SheetContent side="right" className="pb-safe flex h-full w-full flex-col sm:max-w-2xl">
         <SheetHeader className="shrink-0 pb-4">
           <div className="flex items-center gap-3">
-            <TickerAvatar symbol={asset.displayCode ?? ""} className="size-10" />
+            <TickerAvatar
+              symbol={asset.displayCode ?? ""}
+              exchangeMic={asset.instrumentExchangeMic ?? undefined}
+              className="size-10"
+            />
             <div className="min-w-0 flex-1">
               <SheetTitle className="truncate text-lg">
                 {asset.displayCode ?? asset.name ?? t("asset:editSheet.unknown")}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -1386,6 +1386,11 @@ export const AssetProfilePage = () => {
                   assetProfile?.displayCode ??
                   assetId
                 }
+                exchangeMic={
+                  holding?.instrument?.exchangeMic ??
+                  assetProfile?.instrumentExchangeMic ??
+                  undefined
+                }
                 className="size-9"
               />
             )

--- a/apps/frontend/src/pages/asset/assets-table-mobile.tsx
+++ b/apps/frontend/src/pages/asset/assets-table-mobile.tsx
@@ -226,7 +226,11 @@ export function AssetsTableMobile({
                   const avatarSymbol = parsedOption ? parsedOption.underlying : rawSymbol;
                   return (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+                      <TickerAvatar
+                        symbol={avatarSymbol}
+                        exchangeMic={asset.instrumentExchangeMic ?? undefined}
+                        className="h-10 w-10 flex-shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
                           <p className="truncate font-semibold">{displaySymbol}</p>

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -107,7 +107,11 @@ export function AssetsTable({
               onClick={() => navigate(`/holdings/${encodeURIComponent(asset.id)}`)}
               className="hover:bg-muted/60 focus-visible:ring-ring group flex w-full items-center gap-2.5 rounded-md py-1 text-left transition"
             >
-              <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
+              <TickerAvatar
+                symbol={avatarSymbol}
+                exchangeMic={asset.instrumentExchangeMic ?? undefined}
+                className="h-8 w-8 shrink-0"
+              />
               <div className="min-w-0 flex-1">
                 <div className="group-hover:text-primary flex items-center gap-1.5 font-semibold leading-tight transition-colors">
                   {displaySymbol}

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -73,7 +73,11 @@ function HoldingRow({
       onKeyDown={(e) => e.key === "Enter" && onClick?.()}
     >
       <div className="flex min-w-0 flex-1 items-center gap-3">
-        <TickerAvatar symbol={avatarSymbol} className="size-9 shrink-0" />
+        <TickerAvatar
+          symbol={avatarSymbol}
+          exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+          className="size-9 shrink-0"
+        />
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-sm font-semibold">{title}</span>
           <span className="text-muted-foreground truncate text-xs">{subtitle}</span>
@@ -134,7 +138,11 @@ function StackedAvatars({ holdings, totalRemaining, onClick }: StackedAvatarsPro
               className={cn("relative", index > 0 && "-ml-2")}
               style={{ zIndex: displayedHoldings.length - index }}
             >
-              <TickerAvatar symbol={avatarSym} className="ring-background size-8 ring-2" />
+              <TickerAvatar
+                symbol={avatarSym}
+                exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+                className="ring-background size-8 ring-2"
+              />
             </div>
           );
         })}

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -408,7 +408,11 @@ export function AllocationDetailSheet({
                         )}
                         onClick={() => handleHoldingClick(holding)}
                       >
-                        <TickerAvatar symbol={avatarSymbol} className="h-9 w-9" />
+                        <TickerAvatar
+                          symbol={avatarSymbol}
+                          exchangeMic={holding.exchangeMic ?? undefined}
+                          className="h-9 w-9"
+                        />
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-semibold">{primaryLabel}</p>
                           <p className="text-muted-foreground truncate text-xs">{secondaryLabel}</p>

--- a/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
@@ -129,6 +129,7 @@ export const HoldingsEditMode = ({
           quantity: String(h.quantity),
           averageCost,
           currency: h.localCurrency,
+          exchangeMic: h.instrument?.exchangeMic ?? undefined,
           isNew: false,
         };
       });
@@ -463,7 +464,11 @@ export const HoldingsEditMode = ({
                         {/* Symbol */}
                         <div className="col-span-5">
                           <div className="flex items-center gap-2">
-                            <TickerAvatar symbol={holding.symbol} className="h-7 w-7 shrink-0" />
+                            <TickerAvatar
+                              symbol={holding.symbol}
+                              exchangeMic={holding.exchangeMic}
+                              className="h-7 w-7 shrink-0"
+                            />
                             <div className="min-w-0">
                               <div className="truncate text-sm font-medium">{holding.symbol}</div>
                               {holding.name && (

--- a/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
@@ -268,7 +268,11 @@ function HoldingRow({
       >
         {/* Symbol/Name Column */}
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 flex-shrink-0" />
+          <TickerAvatar
+            symbol={avatarSymbol}
+            exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+            className="h-8 w-8 flex-shrink-0"
+          />
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex items-center gap-2">
               <span className="truncate font-medium">{symbol}</span>

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -194,7 +194,11 @@ export const HoldingsTableMobile = ({
               >
                 <div className="flex items-center justify-between">
                   <div className="flex flex-1 items-center gap-3 overflow-hidden">
-                    <TickerAvatar symbol={avatarSymbol} className="h-10 w-10" />
+                    <TickerAvatar
+                      symbol={avatarSymbol}
+                      exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+                      className="h-10 w-10"
+                    />
                     <div className="flex-1 overflow-hidden">
                       <div className="flex items-center gap-1.5">
                         <p className="truncate font-semibold">{displaySymbol}</p>

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -229,7 +229,11 @@ const getColumns = (
       const isManual = holding.instrument?.quoteMode === "MANUAL";
       const content = (
         <div className="flex items-center">
-          <TickerAvatar symbol={avatarSymbol} className="mr-2 h-8 w-8" />
+          <TickerAvatar
+            symbol={avatarSymbol}
+            exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+            className="mr-2 h-8 w-8"
+          />
           <div className="flex flex-col">
             <div className="flex items-center gap-1.5">
               <span className="font-medium">{displaySymbol}</span>

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -115,6 +115,7 @@ export const HoldingsPage = () => {
     id: string;
     symbol: string;
     name?: string;
+    exchangeMic?: string;
   } | null>(null);
 
   // Edit mode state for HOLDINGS-mode accounts
@@ -446,6 +447,7 @@ export const HoldingsPage = () => {
                   id: holding.instrument?.id ?? holding.id,
                   symbol: holding.instrument?.symbol ?? holding.id,
                   name: holding.instrument?.name ?? undefined,
+                  exchangeMic: holding.instrument?.exchangeMic ?? undefined,
                 })
               }
             />
@@ -760,6 +762,7 @@ export const HoldingsPage = () => {
         assetId={classifyAsset?.id ?? ""}
         assetSymbol={classifyAsset?.symbol}
         assetName={classifyAsset?.name}
+        exchangeMic={classifyAsset?.exchangeMic}
       />
     </>
   );

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -192,6 +192,9 @@ impl AllocationService {
                 if existing_summary.unit_price.is_none() {
                     existing_summary.unit_price = summary.unit_price;
                 }
+                if existing_summary.exchange_mic.is_none() {
+                    existing_summary.exchange_mic = summary.exchange_mic;
+                }
                 *existing_value += value;
             } else {
                 non_cash_index_by_id.insert(summary.id.clone(), merged.len());
@@ -1055,6 +1058,10 @@ impl AllocationService {
                     currency: base_currency.to_string(),
                     weight_in_category: Decimal::ZERO,
                     unit_price: holding.price,
+                    exchange_mic: holding
+                        .instrument
+                        .as_ref()
+                        .and_then(|i| i.exchange_mic.clone()),
                 },
                 matched_value,
             ));

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -70,6 +70,8 @@ pub struct HoldingSummary {
     /// Use this for trade sizing instead of market_value/quantity,
     /// which gives a wrong result when market_value is weighted across categories.
     pub unit_price: Option<Decimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_mic: Option<String>,
 }
 
 /// Position view model for frontend display with daily and total performance

--- a/crates/market-data/src/resolver/exchange_registry.rs
+++ b/crates/market-data/src/resolver/exchange_registry.rs
@@ -61,6 +61,7 @@ pub struct ExchangeInfo {
     pub name: String,
     pub long_name: String,
     pub currency: String,
+    pub logo_suffix: Option<String>,
 }
 
 /// Return the list of "real" exchanges (those with a name).
@@ -71,11 +72,20 @@ pub fn get_exchange_list() -> Vec<ExchangeInfo> {
         .iter()
         .filter_map(|e| {
             let name = e.name.as_ref()?;
+            let logo_suffix = e.yahoo.as_ref().and_then(|y| {
+                let s = y.suffix.trim().trim_start_matches('.').to_string();
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            });
             Some(ExchangeInfo {
                 mic: e.mic.clone(),
                 long_name: e.long_name.as_ref().unwrap_or(name).clone(),
                 name: name.clone(),
                 currency: e.currency.as_ref()?.clone(),
+                logo_suffix,
             })
         })
         .collect()
@@ -207,5 +217,28 @@ impl ExchangeRegistry {
             yahoo_suffix_to_mic: suffix_to_mic,
             yahoo_suffixes,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_exchange_list_logo_suffix() {
+        let exchanges = get_exchange_list();
+        assert!(!exchanges.is_empty());
+
+        let xpar = exchanges
+            .iter()
+            .find(|e| e.mic == "XPAR")
+            .expect("XPAR should be in registry");
+        assert_eq!(xpar.logo_suffix.as_deref(), Some("PA"));
+
+        let xnas = exchanges
+            .iter()
+            .find(|e| e.mic == "XNAS")
+            .expect("XNAS should be in registry");
+        assert_eq!(xnas.logo_suffix, None);
     }
 }


### PR DESCRIPTION
fix #1451


### Description

Fixes an issue where assets with identical ticker symbols across different exchanges (for example, Dollar General on NYSE `DG` vs. Vinci on Euronext Paris `DG`) inadvertently resolved to the same logo (`DG.png`), displaying the wrong corporate logo for non-US assets.

This PR makes ticker logo resolution exchange-aware by using the exchange MIC to look up corresponding logo suffixes (e.g., `XPAR` → `PA` → `DG.PA.png`) before gracefully falling back to the base symbol logo.

---

### Key Changes

#### 1. Backend

- **`crates/market-data`**: Added `logo_suffix: Option<String>` to `ExchangeInfo` in `exchange_registry.rs`, extracting it from `yahoo.suffix` (e.g. `XPAR` → `Some("PA")`, `XNAS` → `None`).
- **`crates/core`**: Added and populated `exchange_mic: Option<String>` on `HoldingSummary` in `holdings_model.rs` and `allocation_service.rs`.

#### 2. Frontend Core

- **`useTickerLogoSuffix` Hook**: Created `use-ticker-logo-suffix.ts` to query the exchanges list with shared React Query cache (`queryKey: ["exchanges"]`, `staleTime: Infinity`) and build a fast MIC-to-suffix lookup map.
- **`TickerAvatar` Resolution Chain**: Updated `ticker-avatar.tsx` to accept optional `exchangeMic`.
  - Attempts `/ticker-logos/${baseSymbol}.${suffix}.png` (e.g., `DG.PA.png`) when an exchange suffix is available and the symbol does not already contain a delimiter.
  - Automatically falls back to `/ticker-logos/${baseSymbol}.png` if the suffixed image fails to load or no suffix exists.

#### 3. Propagated `exchangeMic` to Call Sites

- **Holdings**: Top holdings, holdings tables (desktop & mobile), grouped table, edit mode, and allocation detail sheet.
- **Activities & Imports**: Activity tables (desktop & mobile), date list view, bulk holdings form, and CSV import asset review step.
- **Assets & Profiles**: Assets table (desktop & mobile), asset edit sheet, asset profile page, and asset classification sheets / AI tool UIs.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
