### PR TITLE
feat(performance): add monthly performance breakdown matrix and chart with benchmark comparison

### DIFF
--- a/apps/frontend/src/i18n/locales/en/performance.json
+++ b/apps/frontend/src/i18n/locales/en/performance.json
@@ -133,5 +133,21 @@
     "contributions_desc": "Cash you added to the account",
     "distributions": "Distributions",
     "distributions_desc": "Cash withdrawn from the account"
+  },
+  "monthly": {
+    "title": "Monthly Performance",
+    "info": "Monthly breakdown of investment returns by year and month, with comparison against benchmark if selected.",
+    "view_portfolio": "Portfolio",
+    "view_benchmark": "Benchmark",
+    "view_relative": "Relative (Alpha)",
+    "benchmark_comparison": "vs Benchmark",
+    "alpha": "Alpha",
+    "portfolio": "Portfolio",
+    "benchmark": "Benchmark",
+    "excess_return": "Excess Return",
+    "year_total": "Total",
+    "ytd": "YTD",
+    "no_data": "No monthly data available for the selected item.",
+    "select_item": "Select item"
   }
 }

--- a/apps/frontend/src/i18n/locales/fr/performance.json
+++ b/apps/frontend/src/i18n/locales/fr/performance.json
@@ -130,8 +130,24 @@
     "taxes": "Impôts",
     "taxes_desc": "Retenues fiscales sur les revenus",
     "contributions": "Contributions",
-    "contributions_desc": "Liquidités ajoutées au compte",
+    "contributions_desc": "Fonds ajoutés au compte",
     "distributions": "Distributions",
-    "distributions_desc": "Liquidités retirées du compte"
+    "distributions_desc": "Fonds retirés du compte"
+  },
+  "monthly": {
+    "title": "Performances mensuelles",
+    "info": "Répartition mensuelle des rendements par année et par mois, avec comparaison par rapport à l'indice de référence.",
+    "view_portfolio": "Portefeuille",
+    "view_benchmark": "Indice",
+    "view_relative": "Relatif (Alpha)",
+    "benchmark_comparison": "vs Indice",
+    "alpha": "Alpha",
+    "portfolio": "Portefeuille",
+    "benchmark": "Indice de référence",
+    "excess_return": "Rendement relatif",
+    "year_total": "Total",
+    "ytd": "YTD",
+    "no_data": "Aucune donnée mensuelle disponible pour la sélection.",
+    "select_item": "Sélectionner un élément"
   }
 }

--- a/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-card.test.tsx
+++ b/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-card.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MonthlyPerformanceCard } from "./monthly-performance-card";
+import type { ReturnData } from "@/lib/types";
+
+// Mock i18next
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "performance:monthly.title": "Monthly Performance",
+        "performance:monthly.info": "Monthly breakdown of investment returns",
+        "performance:monthly.view_portfolio": "Portfolio",
+        "performance:monthly.view_benchmark": "Benchmark",
+        "performance:monthly.view_relative": "Relative (Alpha)",
+        "performance:monthly.alpha": "Alpha",
+        "performance:monthly.year_total": "Total",
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+describe("MonthlyPerformanceCard", () => {
+  it("renders monthly performance chart and table when portfolio series is provided", () => {
+    const portfolioSeries: ReturnData[] = [
+      { date: "2025-01-01", value: 0 },
+      { date: "2025-01-31", value: 0.05 },
+      { date: "2025-02-28", value: 0.03 },
+      { date: "2025-03-31", value: 0.08 },
+    ];
+
+    render(
+      <MonthlyPerformanceCard portfolioSeries={portfolioSeries} portfolioName="My Portfolio" />,
+    );
+
+    expect(screen.getByText("Monthly Performance")).toBeInTheDocument();
+    expect(screen.getByText("2025")).toBeInTheDocument();
+  });
+
+  it("renders benchmark toggle when benchmark series is provided", () => {
+    const portfolioSeries: ReturnData[] = [
+      { date: "2025-01-01", value: 0 },
+      { date: "2025-01-31", value: 0.05 },
+    ];
+    const benchmarkSeries: ReturnData[] = [
+      { date: "2025-01-01", value: 0 },
+      { date: "2025-01-31", value: 0.02 },
+    ];
+
+    render(
+      <MonthlyPerformanceCard
+        portfolioSeries={portfolioSeries}
+        portfolioName="My Portfolio"
+        benchmarkSeries={benchmarkSeries}
+        benchmarkName="S&P 500"
+      />,
+    );
+
+    expect(screen.getByText("My Portfolio")).toBeInTheDocument();
+    expect(screen.getByText("S&P 500")).toBeInTheDocument();
+    expect(screen.getByText("Relative (Alpha)")).toBeInTheDocument();
+  });
+
+  it("filters displayed years based on dateRange while keeping full year complete", () => {
+    const portfolioSeries: ReturnData[] = [
+      { date: "2023-01-01", value: 0 },
+      { date: "2023-12-31", value: 0.1 },
+      { date: "2024-12-31", value: 0.2 },
+      { date: "2025-12-31", value: 0.3 },
+      { date: "2026-06-30", value: 0.35 },
+    ];
+
+    // dateRange for 2025 - 2026 (e.g. 2Y)
+    const dateRange = {
+      from: new Date("2025-06-01"),
+      to: new Date("2026-06-30"),
+    };
+
+    render(
+      <MonthlyPerformanceCard
+        portfolioSeries={portfolioSeries}
+        portfolioName="My Portfolio"
+        dateRange={dateRange}
+      />,
+    );
+
+    // 2026 and 2025 should be in the document
+    expect(screen.getByText("2026")).toBeInTheDocument();
+    expect(screen.getByText("2025")).toBeInTheDocument();
+    // 2023 and 2024 should not be in the document
+    expect(screen.queryByText("2023")).not.toBeInTheDocument();
+    expect(screen.queryByText("2024")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-card.tsx
+++ b/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-card.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Skeleton,
+  Icons,
+  cn,
+} from "@wealthfolio/ui";
+import { useTranslation } from "react-i18next";
+import type { DateRange, ReturnData } from "@/lib/types";
+import {
+  calculateMonthlyReturns,
+  buildMonthlyComparison,
+  type MonthlyViewMode,
+} from "../../monthly-performance-utils";
+import { MonthlyPerformanceChart } from "./monthly-performance-chart";
+import { MonthlyPerformanceTable } from "./monthly-performance-table";
+
+export interface MonthlyPerformanceCardProps {
+  portfolioSeries: ReturnData[] | undefined;
+  portfolioName: string;
+  benchmarkSeries?: ReturnData[] | undefined;
+  benchmarkName?: string;
+  dateRange?: DateRange | undefined;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export const MonthlyPerformanceCard: React.FC<MonthlyPerformanceCardProps> = ({
+  portfolioSeries,
+  portfolioName,
+  benchmarkSeries,
+  benchmarkName,
+  dateRange,
+  isLoading,
+  className,
+}) => {
+  const { t } = useTranslation();
+  const [viewMode, setViewMode] = useState<MonthlyViewMode>("portfolio");
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+
+  // Compute monthly comparison data across full history
+  const comparisonData = useMemo(() => {
+    if (!portfolioSeries?.length) return [];
+    const portfolioMonthly = calculateMonthlyReturns(portfolioSeries);
+    const benchmarkMonthly = benchmarkSeries?.length
+      ? calculateMonthlyReturns(benchmarkSeries)
+      : undefined;
+    return buildMonthlyComparison(portfolioMonthly, benchmarkMonthly);
+  }, [portfolioSeries, benchmarkSeries]);
+
+  // Filter years according to the selected dateRange (while keeping each selected year complete)
+  const filteredComparisonData = useMemo(() => {
+    if (!comparisonData.length) return [];
+    const startYear = dateRange?.from ? dateRange.from.getFullYear() : undefined;
+    const endYear = dateRange?.to ? dateRange.to.getFullYear() : undefined;
+
+    const filtered = comparisonData.filter((row) => {
+      if (startYear !== undefined && row.year < startYear) return false;
+      if (endYear !== undefined && row.year > endYear) return false;
+      return true;
+    });
+
+    return filtered.length > 0 ? filtered : comparisonData;
+  }, [comparisonData, dateRange]);
+
+  // Set default selected year to latest available year in the filtered range
+  useEffect(() => {
+    if (filteredComparisonData.length > 0) {
+      if (selectedYear === null || !filteredComparisonData.some((d) => d.year === selectedYear)) {
+        setSelectedYear(filteredComparisonData[0].year);
+      }
+    }
+  }, [filteredComparisonData, selectedYear]);
+
+  const hasBenchmark = Boolean(benchmarkSeries && benchmarkSeries.length > 0 && benchmarkName);
+
+  // If benchmark is removed and viewMode was benchmark/relative, reset to portfolio
+  useEffect(() => {
+    if (!hasBenchmark && (viewMode === "benchmark" || viewMode === "relative")) {
+      setViewMode("portfolio");
+    }
+  }, [hasBenchmark, viewMode]);
+
+  const activeYearData = useMemo(() => {
+    if (!filteredComparisonData.length || selectedYear === null) return null;
+    return filteredComparisonData.find((d) => d.year === selectedYear) ?? filteredComparisonData[0];
+  }, [filteredComparisonData, selectedYear]);
+
+  if (isLoading) {
+    return (
+      <Card className={cn("overflow-hidden", className)}>
+        <CardHeader className="flex flex-row items-center justify-between pb-2 pt-5">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-8 w-44" />
+        </CardHeader>
+        <CardContent className="space-y-6 pt-2">
+          <Skeleton className="h-48 w-full rounded-lg" />
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!comparisonData.length || !activeYearData) {
+    return null;
+  }
+
+  return (
+    <Card className={cn("overflow-hidden", className)}>
+      <CardHeader className="flex flex-col gap-3 pb-2 pt-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <CardTitle className="text-lg font-bold tracking-tight sm:text-xl">
+            {t("performance:monthly.title")}
+          </CardTitle>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground inline-flex h-4 w-4 items-center justify-center transition-colors"
+                aria-label={t("performance:monthly.info")}
+              >
+                <Icons.HelpCircle className="h-4 w-4" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent side="top" align="start" className="max-w-xs text-xs">
+              {t("performance:monthly.info")}
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        {/* View Mode Toggle when Benchmark is present */}
+        {hasBenchmark && (
+          <div className="bg-muted/40 inline-flex items-center rounded-lg p-1 text-xs">
+            <Button
+              variant={viewMode === "portfolio" ? "secondary" : "ghost"}
+              size="sm"
+              className={cn(
+                "h-7 rounded-md px-2.5 text-xs font-medium",
+                viewMode === "portfolio" && "bg-background text-foreground shadow-xs",
+              )}
+              onClick={() => setViewMode("portfolio")}
+            >
+              {portfolioName || t("performance:monthly.view_portfolio")}
+            </Button>
+            <Button
+              variant={viewMode === "benchmark" ? "secondary" : "ghost"}
+              size="sm"
+              className={cn(
+                "h-7 rounded-md px-2.5 text-xs font-medium",
+                viewMode === "benchmark" && "bg-background text-foreground shadow-xs",
+              )}
+              onClick={() => setViewMode("benchmark")}
+            >
+              {benchmarkName || t("performance:monthly.view_benchmark")}
+            </Button>
+            <Button
+              variant={viewMode === "relative" ? "secondary" : "ghost"}
+              size="sm"
+              className={cn(
+                "h-7 rounded-md px-2.5 text-xs font-medium",
+                viewMode === "relative" && "bg-background text-foreground shadow-xs",
+              )}
+              onClick={() => setViewMode("relative")}
+            >
+              {t("performance:monthly.view_relative")}
+            </Button>
+          </div>
+        )}
+      </CardHeader>
+
+      <CardContent className="space-y-4 pt-2">
+        {/* Top Monthly Bar Chart */}
+        <MonthlyPerformanceChart
+          year={activeYearData.year}
+          months={activeYearData.months}
+          viewMode={viewMode}
+          portfolioName={portfolioName}
+          benchmarkName={benchmarkName}
+        />
+
+        {/* Bottom Monthly Table Matrix */}
+        <MonthlyPerformanceTable
+          data={filteredComparisonData}
+          selectedYear={activeYearData.year}
+          onSelectYear={setSelectedYear}
+          viewMode={viewMode}
+        />
+      </CardContent>
+    </Card>
+  );
+};

--- a/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-chart.tsx
+++ b/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-chart.tsx
@@ -1,0 +1,221 @@
+import React, { useMemo } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  Cell,
+} from "recharts";
+import { GainPercent } from "@wealthfolio/ui";
+import { useTranslation } from "react-i18next";
+import type { MonthlyComparisonCell, MonthlyViewMode } from "../../monthly-performance-utils";
+
+const MONTH_KEYS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+export interface MonthlyPerformanceChartProps {
+  year: number;
+  months: (MonthlyComparisonCell | null)[];
+  viewMode: MonthlyViewMode;
+  portfolioName: string;
+  benchmarkName?: string;
+}
+
+interface ChartMonthPoint {
+  monthIndex: number;
+  name: string;
+  portfolioReturn: number | null;
+  benchmarkReturn: number | null;
+  relativeReturn: number | null;
+  value: number | null;
+}
+
+export const MonthlyPerformanceChart: React.FC<MonthlyPerformanceChartProps> = ({
+  year,
+  months,
+  viewMode,
+  portfolioName,
+  benchmarkName,
+}) => {
+  const { t } = useTranslation();
+
+  const data: ChartMonthPoint[] = useMemo(() => {
+    return MONTH_KEYS.map((name, index) => {
+      const cell = months[index];
+      const pRet = cell?.portfolioReturn ?? null;
+      const bRet = cell?.benchmarkReturn ?? null;
+      const rRet = cell?.relativeReturn ?? null;
+
+      let value: number | null = null;
+      if (viewMode === "benchmark") {
+        value = bRet;
+      } else if (viewMode === "relative") {
+        value = rRet;
+      } else {
+        value = pRet;
+      }
+
+      return {
+        monthIndex: index,
+        name,
+        portfolioReturn: pRet,
+        benchmarkReturn: bRet,
+        relativeReturn: rRet,
+        value,
+      };
+    });
+  }, [months, viewMode]);
+
+  // Determine domain bounds
+  const { yMin, yMax } = useMemo(() => {
+    const validValues = data.map((d) => d.value).filter((v): v is number => v !== null);
+    if (validValues.length === 0) {
+      return { yMin: -0.05, yMax: 0.05 };
+    }
+    const maxAbs = Math.max(...validValues.map((v) => Math.abs(v)), 0.02);
+    // Add small headroom
+    const roundedMax = Math.ceil(maxAbs * 110) / 100;
+    return { yMin: -roundedMax, yMax: roundedMax };
+  }, [data]);
+
+  return (
+    <div className="relative h-48 w-full select-none sm:h-56">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 12, right: 28, left: 8, bottom: 0 }}>
+          <defs>
+            <linearGradient id="positiveBarGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#4ade80" stopOpacity={0.95} />
+              <stop offset="100%" stopColor="#22c55e" stopOpacity={0.8} />
+            </linearGradient>
+            <linearGradient id="negativeBarGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#ef4444" stopOpacity={0.8} />
+              <stop offset="100%" stopColor="#dc2626" stopOpacity={0.95} />
+            </linearGradient>
+          </defs>
+
+          {/* Vertical month guide columns background */}
+          <CartesianGrid
+            strokeDasharray="0"
+            stroke="var(--border)"
+            strokeOpacity={0.25}
+            horizontal={false}
+            vertical={true}
+          />
+
+          <XAxis
+            dataKey="name"
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "var(--muted-foreground)", fontSize: 11 }}
+            dy={4}
+          />
+
+          <YAxis
+            orientation="right"
+            domain={[yMin, yMax]}
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "var(--muted-foreground)", fontSize: 10 }}
+            tickFormatter={(val: number) => {
+              if (Math.abs(val) < 0.0001) return "0.00%";
+              return `${val > 0 ? "+" : ""}${(val * 100).toFixed(2)}%`;
+            }}
+            width={48}
+          />
+
+          <ReferenceLine y={0} stroke="var(--border)" strokeOpacity={0.8} strokeWidth={1} />
+
+          <Tooltip
+            cursor={{ fill: "var(--accent)", fillOpacity: 0.15 }}
+            content={({ active, payload }) => {
+              if (!active || !payload || !payload.length) return null;
+              const point = payload[0].payload as ChartMonthPoint;
+              if (
+                point.portfolioReturn === null &&
+                point.benchmarkReturn === null &&
+                point.relativeReturn === null
+              ) {
+                return null;
+              }
+
+              return (
+                <div className="bg-popover text-popover-foreground border-border min-w-[12rem] rounded-lg border p-2.5 shadow-md">
+                  <div className="text-muted-foreground mb-1.5 border-b pb-1 font-mono text-xs font-semibold">
+                    {point.name} {year}
+                  </div>
+                  <div className="space-y-1 text-xs">
+                    {point.portfolioReturn !== null && (
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-muted-foreground truncate">{portfolioName}:</span>
+                        <GainPercent
+                          value={point.portfolioReturn}
+                          className="font-mono font-medium"
+                        />
+                      </div>
+                    )}
+                    {benchmarkName && point.benchmarkReturn !== null && (
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-muted-foreground truncate">{benchmarkName}:</span>
+                        <GainPercent
+                          value={point.benchmarkReturn}
+                          className="font-mono font-medium"
+                        />
+                      </div>
+                    )}
+                    {benchmarkName && point.relativeReturn !== null && (
+                      <div className="border-border/60 mt-1 flex items-center justify-between gap-4 border-t pt-1">
+                        <span className="text-muted-foreground font-medium">
+                          {t("performance:monthly.alpha")}:
+                        </span>
+                        <GainPercent
+                          value={point.relativeReturn}
+                          className="font-mono font-semibold"
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            }}
+          />
+
+          <Bar
+            dataKey="value"
+            radius={4}
+            maxBarSize={48}
+            isAnimationActive={true}
+            animationDuration={400}
+          >
+            {data.map((entry, index) => {
+              const val = entry.value;
+              if (val === null) return <Cell key={`cell-${index}`} fill="transparent" />;
+              const isPositive = val >= 0;
+              return (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={isPositive ? "url(#positiveBarGradient)" : "url(#negativeBarGradient)"}
+                />
+              );
+            })}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-table.tsx
+++ b/apps/frontend/src/pages/performance/components/monthly-performance/monthly-performance-table.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { formatPercent, GainPercent } from "@wealthfolio/ui";
+import { cn } from "@/lib/utils";
+import { useTranslation } from "react-i18next";
+import type { YearComparisonData, MonthlyViewMode } from "../../monthly-performance-utils";
+
+const MONTH_HEADERS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+export interface MonthlyPerformanceTableProps {
+  data: YearComparisonData[];
+  selectedYear: number;
+  onSelectYear: (year: number) => void;
+  viewMode: MonthlyViewMode;
+}
+
+export const MonthlyPerformanceTable: React.FC<MonthlyPerformanceTableProps> = ({
+  data,
+  selectedYear,
+  onSelectYear,
+  viewMode,
+}) => {
+  const { t } = useTranslation();
+
+  if (!data.length) {
+    return (
+      <div className="text-muted-foreground py-8 text-center text-sm">
+        {t("performance:monthly.no_data")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <div className="min-w-[640px] space-y-1 py-1 font-mono text-xs">
+        {/* Table Header */}
+        <div className="text-muted-foreground/70 grid grid-cols-[3.5rem_repeat(12,1fr)_4.5rem] items-center px-3 py-1.5 text-center text-[11px] font-medium">
+          <div className="text-left font-semibold">{t("performance:time_period")}</div>
+          {MONTH_HEADERS.map((m) => (
+            <div key={m}>{m}</div>
+          ))}
+          <div className="text-right font-semibold">{t("performance:monthly.year_total")}</div>
+        </div>
+
+        {/* Year Rows */}
+        <div className="space-y-1">
+          {data.map((row) => {
+            const isSelected = row.year === selectedYear;
+
+            // Compute year total return based on viewMode
+            let yearTotalValue: number | null = null;
+            if (viewMode === "benchmark") {
+              yearTotalValue = row.benchmarkYearTotal;
+            } else if (viewMode === "relative") {
+              yearTotalValue = row.relativeYearTotal;
+            } else {
+              yearTotalValue = row.portfolioYearTotal;
+            }
+
+            return (
+              <div
+                key={row.year}
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelectYear(row.year)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelectYear(row.year);
+                  }
+                }}
+                className={cn(
+                  "grid cursor-pointer grid-cols-[3.5rem_repeat(12,1fr)_4.5rem] items-center rounded-lg px-3 py-2 text-center transition-all",
+                  isSelected
+                    ? "bg-primary/15 border-primary/40 border font-semibold shadow-sm dark:border-emerald-500/40 dark:bg-emerald-950/40"
+                    : "hover:bg-muted/40 text-muted-foreground border border-transparent",
+                )}
+              >
+                {/* Year Header */}
+                <div
+                  className={cn(
+                    "text-left font-semibold",
+                    isSelected ? "text-primary dark:text-emerald-400" : "text-foreground",
+                  )}
+                >
+                  {row.year}
+                </div>
+
+                {/* 12 Month Cells */}
+                {row.months.map((cell, monthIdx) => {
+                  if (!cell) {
+                    return (
+                      <div key={monthIdx} className="text-muted-foreground/30">
+                        -
+                      </div>
+                    );
+                  }
+
+                  let val: number | null = null;
+                  if (viewMode === "benchmark") {
+                    val = cell.benchmarkReturn;
+                  } else if (viewMode === "relative") {
+                    val = cell.relativeReturn;
+                  } else {
+                    val = cell.portfolioReturn;
+                  }
+
+                  if (val === null) {
+                    return (
+                      <div key={monthIdx} className="text-muted-foreground/30">
+                        -
+                      </div>
+                    );
+                  }
+
+                  const isPositive = val >= 0;
+
+                  return (
+                    <div
+                      key={monthIdx}
+                      className={cn(
+                        "text-[11px] font-medium tracking-tight",
+                        isPositive ? "text-gain" : "text-loss",
+                      )}
+                    >
+                      {formatPercent(val)}
+                    </div>
+                  );
+                })}
+
+                {/* Year Total / YTD */}
+                <div className="text-right text-[11px] font-bold">
+                  {yearTotalValue !== null ? (
+                    <GainPercent value={yearTotalValue} />
+                  ) : (
+                    <span className="text-muted-foreground/30">-</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/pages/performance/monthly-performance-utils.test.ts
+++ b/apps/frontend/src/pages/performance/monthly-performance-utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildMonthlyComparison, calculateMonthlyReturns } from "./monthly-performance-utils";
+import type { ReturnData } from "@/lib/types";
+
+describe("monthly-performance-utils", () => {
+  it("calculates monthly returns accurately from cumulative series", () => {
+    // Cumulative returns starting at 0% at beginning of Jan 2025
+    // Jan 31: 5% (cumulative = 0.05) -> Jan return = +5%
+    // Feb 28: 2% (cumulative = 0.02) -> Feb return = (1 + 0.02)/(1 + 0.05) - 1 = -2.857%
+    // Mar 31: 10% (cumulative = 0.10) -> Mar return = (1 + 0.10)/(1 + 0.02) - 1 = +7.843%
+    const series: ReturnData[] = [
+      { date: "2025-01-01", value: 0 },
+      { date: "2025-01-15", value: 0.02 },
+      { date: "2025-01-31", value: 0.05 },
+      { date: "2025-02-14", value: 0.03 },
+      { date: "2025-02-28", value: 0.02 },
+      { date: "2025-03-15", value: 0.06 },
+      { date: "2025-03-31", value: 0.1 },
+    ];
+
+    const result = calculateMonthlyReturns(series);
+    expect(result).toHaveLength(1);
+    expect(result[0].year).toBe(2025);
+
+    // Jan
+    expect(result[0].months[0]).toBeCloseTo(0.05, 4);
+    // Feb: (1.02 / 1.05) - 1 = -0.02857
+    expect(result[0].months[1]).toBeCloseTo(1.02 / 1.05 - 1, 4);
+    // Mar: (1.10 / 1.02) - 1 = 0.07843
+    expect(result[0].months[2]).toBeCloseTo(1.1 / 1.02 - 1, 4);
+    // Apr .. Dec should be null
+    expect(result[0].months[3]).toBeNull();
+
+    // Year total compounded should be exactly 10% (0.10)
+    expect(result[0].yearTotal).toBeCloseTo(0.1, 4);
+  });
+
+  it("handles multi-year series and sorts years descending", () => {
+    const series: ReturnData[] = [
+      { date: "2024-11-01", value: 0 },
+      { date: "2024-11-30", value: 0.02 },
+      { date: "2024-12-31", value: 0.04 },
+      { date: "2025-01-31", value: 0.08 },
+    ];
+
+    const result = calculateMonthlyReturns(series);
+    expect(result).toHaveLength(2);
+    expect(result[0].year).toBe(2025);
+    expect(result[1].year).toBe(2024);
+
+    // 2024: Nov = 2%, Dec = (1.04/1.02) - 1
+    expect(result[1].months[10]).toBeCloseTo(0.02, 4);
+    expect(result[1].months[11]).toBeCloseTo(1.04 / 1.02 - 1, 4);
+    expect(result[1].yearTotal).toBeCloseTo(0.04, 4);
+
+    // 2025: Jan = (1.08/1.04) - 1
+    expect(result[0].months[0]).toBeCloseTo(1.08 / 1.04 - 1, 4);
+    expect(result[0].yearTotal).toBeCloseTo(1.08 / 1.04 - 1, 4);
+  });
+
+  it("builds monthly comparison with benchmark and computes relative returns", () => {
+    const portfolio = [
+      {
+        year: 2025,
+        months: [0.03, -0.01, 0.05, ...Array(9).fill(null)],
+        yearTotal: 1.03 * 0.99 * 1.05 - 1,
+      },
+    ];
+
+    const benchmark = [
+      {
+        year: 2025,
+        months: [0.01, 0.02, 0.03, ...Array(9).fill(null)],
+        yearTotal: 1.01 * 1.02 * 1.03 - 1,
+      },
+    ];
+
+    const comparison = buildMonthlyComparison(portfolio, benchmark);
+    expect(comparison).toHaveLength(1);
+    expect(comparison[0].year).toBe(2025);
+
+    // Jan: portfolio 3%, benchmark 1% => relative +2%
+    expect(comparison[0].months[0]?.portfolioReturn).toBe(0.03);
+    expect(comparison[0].months[0]?.benchmarkReturn).toBe(0.01);
+    expect(comparison[0].months[0]?.relativeReturn).toBeCloseTo(0.02, 4);
+
+    // Feb: portfolio -1%, benchmark 2% => relative -3%
+    expect(comparison[0].months[1]?.relativeReturn).toBeCloseTo(-0.03, 4);
+
+    // Mar: portfolio 5%, benchmark 3% => relative +2%
+    expect(comparison[0].months[2]?.relativeReturn).toBeCloseTo(0.02, 4);
+  });
+});

--- a/apps/frontend/src/pages/performance/monthly-performance-utils.ts
+++ b/apps/frontend/src/pages/performance/monthly-performance-utils.ts
@@ -1,0 +1,221 @@
+import type { ReturnData } from "@/lib/types";
+
+export interface MonthlyReturnCell {
+  month: number; // 0-indexed (0 = Jan, 11 = Dec)
+  value: number; // Decimal (e.g. 0.05 for 5%)
+}
+
+export interface YearPerformanceData {
+  year: number;
+  months: (number | null)[]; // Array of length 12 (Jan = index 0 .. Dec = index 11), null if no data
+  yearTotal: number | null; // Compounded annual return (or YTD)
+}
+
+export interface MonthlyComparisonCell {
+  month: number;
+  portfolioReturn: number | null;
+  benchmarkReturn: number | null;
+  relativeReturn: number | null; // portfolioReturn - benchmarkReturn
+}
+
+export interface YearComparisonData {
+  year: number;
+  months: (MonthlyComparisonCell | null)[]; // 12 elements
+  portfolioYearTotal: number | null;
+  benchmarkYearTotal: number | null;
+  relativeYearTotal: number | null;
+}
+
+export type MonthlyViewMode = "portfolio" | "benchmark" | "relative";
+
+const ONE = 1;
+
+/**
+ * Parses "YYYY-MM-DD" into { year, monthIndex (0..11), day }
+ */
+function parseDateParts(dateStr: string): { year: number; month: number; day: number } | null {
+  const parts = dateStr.split("-");
+  if (parts.length < 3) return null;
+  const year = parseInt(parts[0], 10);
+  const month = parseInt(parts[1], 10) - 1; // 0-based
+  const day = parseInt(parts[2], 10);
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) return null;
+  return { year, month, day };
+}
+
+/**
+ * Calculates monthly returns for every year/month present in a cumulative return series.
+ * Series should be sorted by date ascending.
+ *
+ * For each month:
+ * Return = (1 + R_end_of_month) / (1 + R_end_of_previous_month) - 1
+ */
+export function calculateMonthlyReturns(series: ReturnData[]): YearPerformanceData[] {
+  if (!series || series.length < 2) {
+    return [];
+  }
+
+  // Sort series by date ascending
+  const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date));
+
+  // Map of "YYYY-MM" to the last ReturnData point in that month
+  // Also track the first point of each month to find the starting baseline
+  const pointsByMonth = new Map<string, ReturnData[]>();
+
+  for (const point of sorted) {
+    const parts = parseDateParts(point.date);
+    if (!parts) continue;
+    const monthKey = `${parts.year}-${String(parts.month + 1).padStart(2, "0")}`;
+    const list = pointsByMonth.get(monthKey) ?? [];
+    list.push(point);
+    pointsByMonth.set(monthKey, list);
+  }
+
+  const sortedMonthKeys = Array.from(pointsByMonth.keys()).sort();
+  if (sortedMonthKeys.length === 0) return [];
+
+  // Map of monthKey -> monthly return (number)
+  const monthlyReturnMap = new Map<string, number>();
+
+  // Map of monthKey -> last cumulative value
+  const lastCumulativeByMonth = new Map<string, number>();
+  for (const [key, pts] of pointsByMonth.entries()) {
+    lastCumulativeByMonth.set(key, pts[pts.length - 1].value);
+  }
+
+  // To compute the return for the first month in history:
+  // we look at the first point in that month.
+  for (let i = 0; i < sortedMonthKeys.length; i++) {
+    const monthKey = sortedMonthKeys[i];
+    const pts = pointsByMonth.get(monthKey)!;
+    const endPoint = pts[pts.length - 1];
+
+    let baseFactor: number;
+
+    if (i === 0) {
+      // First month: base is the first point in this month
+      const startPoint = pts[0];
+      baseFactor = ONE + Number(startPoint.value);
+    } else {
+      // Base is the last point of the previous available month
+      const prevMonthKey = sortedMonthKeys[i - 1];
+      const prevVal = lastCumulativeByMonth.get(prevMonthKey)!;
+      baseFactor = ONE + Number(prevVal);
+    }
+
+    const endFactor = ONE + Number(endPoint.value);
+
+    if (baseFactor !== 0 && Number.isFinite(baseFactor) && Number.isFinite(endFactor)) {
+      const monthReturn = endFactor / baseFactor - ONE;
+      monthlyReturnMap.set(monthKey, monthReturn);
+    }
+  }
+
+  // Group months by year
+  const yearsMap = new Map<number, (number | null)[]>();
+
+  for (const [monthKey, ret] of monthlyReturnMap.entries()) {
+    const [yStr, mStr] = monthKey.split("-");
+    const year = parseInt(yStr, 10);
+    const monthIdx = parseInt(mStr, 10) - 1;
+
+    if (!yearsMap.has(year)) {
+      yearsMap.set(year, Array(12).fill(null));
+    }
+    yearsMap.get(year)![monthIdx] = ret;
+  }
+
+  const sortedYears = Array.from(yearsMap.keys()).sort((a, b) => b - a); // Descending years
+
+  return sortedYears.map((year) => {
+    const months = yearsMap.get(year)!;
+    // Compounded year total: product of (1 + r_m) - 1 for all non-null months
+    let compoundFactor = ONE;
+    let hasAnyMonth = false;
+
+    for (const mRet of months) {
+      if (mRet !== null && Number.isFinite(mRet)) {
+        compoundFactor *= ONE + mRet;
+        hasAnyMonth = true;
+      }
+    }
+
+    const yearTotal = hasAnyMonth ? compoundFactor - ONE : null;
+
+    return {
+      year,
+      months,
+      yearTotal,
+    };
+  });
+}
+
+/**
+ * Combines portfolio monthly returns with benchmark monthly returns to produce
+ * a full comparison matrix including excess returns (alpha).
+ */
+export function buildMonthlyComparison(
+  portfolioData: YearPerformanceData[],
+  benchmarkData: YearPerformanceData[] | null | undefined,
+): YearComparisonData[] {
+  const benchmarkYearMap = new Map<number, YearPerformanceData>();
+  if (benchmarkData) {
+    for (const b of benchmarkData) {
+      benchmarkYearMap.set(b.year, b);
+    }
+  }
+
+  // Collect all unique years in descending order
+  const allYearsSet = new Set<number>();
+  for (const p of portfolioData) allYearsSet.add(p.year);
+  if (benchmarkData) {
+    for (const b of benchmarkData) allYearsSet.add(b.year);
+  }
+  const allYears = Array.from(allYearsSet).sort((a, b) => b - a);
+
+  const portfolioYearMap = new Map<number, YearPerformanceData>();
+  for (const p of portfolioData) {
+    portfolioYearMap.set(p.year, p);
+  }
+
+  return allYears.map((year) => {
+    const pYear = portfolioYearMap.get(year);
+    const bYear = benchmarkYearMap.get(year);
+
+    const months: (MonthlyComparisonCell | null)[] = Array(12).fill(null);
+
+    for (let m = 0; m < 12; m++) {
+      const pRet = pYear?.months[m] ?? null;
+      const bRet = bYear?.months[m] ?? null;
+
+      if (pRet === null && bRet === null) {
+        months[m] = null;
+      } else {
+        const relativeReturn =
+          pRet !== null && bRet !== null ? pRet - bRet : pRet !== null ? pRet : null;
+
+        months[m] = {
+          month: m,
+          portfolioReturn: pRet,
+          benchmarkReturn: bRet,
+          relativeReturn,
+        };
+      }
+    }
+
+    const portfolioYearTotal = pYear?.yearTotal ?? null;
+    const benchmarkYearTotal = bYear?.yearTotal ?? null;
+    const relativeYearTotal =
+      portfolioYearTotal !== null && benchmarkYearTotal !== null
+        ? portfolioYearTotal - benchmarkYearTotal
+        : portfolioYearTotal;
+
+    return {
+      year,
+      months,
+      portfolioYearTotal,
+      benchmarkYearTotal,
+      relativeYearTotal,
+    };
+  });
+}

--- a/apps/frontend/src/pages/performance/performance-page.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.tsx
@@ -76,6 +76,7 @@ import {
   migratePerformanceSelectedItemId,
   migratePerformanceSelectedItems,
 } from "./performance-selection";
+import { MonthlyPerformanceCard } from "./components/monthly-performance/monthly-performance-card";
 
 type TFunction = ReturnType<typeof useTranslation>["t"];
 
@@ -1095,6 +1096,13 @@ export default function PerformancePage() {
     dateRange: getPerformanceDateRangeForRequest(dateRange),
   });
 
+  // Fetch all-time performance history for the multi-year monthly breakdown matrix
+  const { data: allTimePerformanceData, isLoading: isLoadingAllTimePerformance } =
+    useCalculatePerformanceHistory({
+      selectedItems,
+      dateRange: undefined,
+    });
+
   const selectedPerformanceData = useMemo(() => {
     if (!performanceData?.length || !selectedItems) return null;
     const targetId = selectedItemId ?? performanceData.find((item) => item !== null)?.id; // Find first non-null item ID if none selected
@@ -1112,6 +1120,29 @@ export default function PerformancePage() {
 
   const selectedChartMetric = selectedPerformanceData?.chartMetric ?? "twr";
   const activeChartAnchorId = selectedPerformanceData?.result.id ?? selectedItemId;
+
+  const activeAnchorItem = useMemo(
+    () => selectedItems.find((item) => item.id === activeChartAnchorId) ?? selectedItems[0],
+    [activeChartAnchorId, selectedItems],
+  );
+
+  const activePortfolioAllTimeResult = useMemo(
+    () => allTimePerformanceData?.find((item) => item?.id === activeAnchorItem?.id),
+    [allTimePerformanceData, activeAnchorItem],
+  );
+
+  const benchmarkItem = useMemo(
+    () => selectedItems.find((item) => item.type === "symbol"),
+    [selectedItems],
+  );
+
+  const benchmarkAllTimeResult = useMemo(
+    () =>
+      benchmarkItem
+        ? allTimePerformanceData?.find((item) => item?.id === benchmarkItem.id)
+        : undefined,
+    [allTimePerformanceData, benchmarkItem],
+  );
 
   // Calculate derived chart data
   const chartData = useMemo(() => {
@@ -1804,6 +1835,22 @@ export default function PerformancePage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Monthly Performance Breakdown Matrix and Bar Chart */}
+        <MonthlyPerformanceCard
+          portfolioSeries={activePortfolioAllTimeResult?.series}
+          portfolioName={activeAnchorItem?.name ?? t("performance:all_portfolio")}
+          benchmarkSeries={benchmarkAllTimeResult?.series}
+          benchmarkName={
+            benchmarkItem
+              ? benchmarkItem.name !== benchmarkItem.id
+                ? `${benchmarkItem.name} (${benchmarkItem.id})`
+                : benchmarkItem.name
+              : undefined
+          }
+          dateRange={dateRange}
+          isLoading={isLoadingAllTimePerformance}
+        />
       </div>
     </>
   );


### PR DESCRIPTION


### 📝 Summary

Adds a **Monthly Performance** breakdown card to the Performance view, displaying investment returns month-by-month and year-by-year through an interactive bar chart and a multi-year matrix table, with full benchmark excess return (Alpha) comparison support.

---

### ✨ Features & Key Changes

1. **Monthly & Relative Return Calculations (`monthly-performance-utils.ts`)**:
   - Calculates discrete monthly returns $r_M = \frac{1 + R_{end}}{1 + R_{prev}} - 1$ and compounded annual/YTD returns $\prod (1 + r_M) - 1$ from cumulative return series.
   - Computes relative/excess return (**Alpha** $= r_{\text{portfolio}} - r_{\text{benchmark}}$) when a benchmark index is selected.

2. **Monthly Bar Chart (`monthly-performance-chart.tsx`)**:
   - Renders 12 months (Jan–Dec) for the selected year with a zero-baseline reference.
   - Vibrant green gradient bars for positive returns, vibrant red gradient bars for negative returns.
   - Interactive tooltip displaying Portfolio return, Benchmark return, and Alpha / Relative return.

3. **Multi-Year Matrix Table (`monthly-performance-table.tsx`)**:
   - Historical grid with descending year rows, Jan–Dec columns, and Annual Total / YTD.
   - Click to select a year and sync the bar chart above (highlights active year row).
   - Filters years based on the active date range selector (e.g. selecting `3Y` shows the last 3 years while keeping all 12 months complete for each year).

4. **Benchmark Comparison & View Modes (`monthly-performance-card.tsx`)**:
   - Seamless view mode toggle when a benchmark is selected: **Portfolio**, **Benchmark**, or **Relative (Alpha)**.


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).


<img width="1576" height="996" alt="image" src="https://github.com/user-attachments/assets/77d2499b-2ac0-430a-9996-e26e8fc83b07" />
