### PR TITLE
fix(net-worth): stop dividing the Δ column by a non-baseline (#1456)

### DIFF
--- a/apps/frontend/src/i18n/locales/de/insights.json
+++ b/apps/frontend/src/i18n/locales/de/insights.json
@@ -92,6 +92,7 @@
       "category": "Kategorie",
       "value": "Wert",
       "delta_period": "Δ {{period}}",
+      "new": "Neu",
       "liabilities": "Verbindlichkeiten",
       "net_worth": "Nettovermögen"
     },

--- a/apps/frontend/src/i18n/locales/en/insights.json
+++ b/apps/frontend/src/i18n/locales/en/insights.json
@@ -92,6 +92,7 @@
       "category": "Category",
       "value": "Value",
       "delta_period": "Δ {{period}}",
+      "new": "New",
       "liabilities": "Liabilities",
       "net_worth": "Net Worth"
     },

--- a/apps/frontend/src/i18n/locales/es/insights.json
+++ b/apps/frontend/src/i18n/locales/es/insights.json
@@ -92,6 +92,7 @@
       "category": "Categoría",
       "value": "Valor",
       "delta_period": "Δ {{period}}",
+      "new": "Nuevo",
       "liabilities": "Pasivos",
       "net_worth": "Patrimonio neto"
     },

--- a/apps/frontend/src/i18n/locales/fr/insights.json
+++ b/apps/frontend/src/i18n/locales/fr/insights.json
@@ -92,6 +92,7 @@
       "category": "Catégorie",
       "value": "Valeur",
       "delta_period": "Δ {{period}}",
+      "new": "Nouveau",
       "liabilities": "Passifs",
       "net_worth": "Valeur nette"
     },

--- a/apps/frontend/src/i18n/locales/ja/insights.json
+++ b/apps/frontend/src/i18n/locales/ja/insights.json
@@ -91,6 +91,7 @@
       "category": "カテゴリ",
       "value": "評価額",
       "delta_period": "Δ {{period}}",
+      "new": "新規",
       "liabilities": "負債",
       "net_worth": "純資産"
     },

--- a/apps/frontend/src/i18n/locales/ko/insights.json
+++ b/apps/frontend/src/i18n/locales/ko/insights.json
@@ -91,6 +91,7 @@
       "category": "카테고리",
       "value": "가치",
       "delta_period": "Δ {{period}}",
+      "new": "신규",
       "liabilities": "부채",
       "net_worth": "순자산"
     },

--- a/apps/frontend/src/i18n/locales/zh/insights.json
+++ b/apps/frontend/src/i18n/locales/zh/insights.json
@@ -91,6 +91,7 @@
       "category": "类别",
       "value": "价值",
       "delta_period": "Δ {{period}}",
+      "new": "新增",
       "liabilities": "负债",
       "net_worth": "净资产"
     },

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -29,6 +29,7 @@ const ROW_GRID =
 
 function ChangeCell({ change, currency }: { change: Change; currency: string }) {
   const formatting = useNumberFormatting();
+  const { t } = useTranslation();
   const isZero = Math.abs(change.amount) < 0.005;
   const color = isZero
     ? "text-muted-foreground/60"
@@ -45,7 +46,7 @@ function ChangeCell({ change, currency }: { change: Change; currency: string }) 
         <CompactAmount value={Math.abs(change.amount)} currency={currency} />
       </span>
       <span className="text-muted-foreground/60 hidden w-12 shrink-0 text-right text-sm tabular-nums md:block">
-        {formatChangePercent(change.percent, formatting)}
+        {formatChangePercent(change, t("insights:networth.breakdown_table.new"), formatting)}
       </span>
     </div>
   );

--- a/apps/frontend/src/pages/net-worth/components/category-detail-sheet.tsx
+++ b/apps/frontend/src/pages/net-worth/components/category-detail-sheet.tsx
@@ -117,8 +117,12 @@ export function CategoryDetailSheet({
                     <CompactAmount value={Math.abs(change.amount)} currency={currency} />
                   </span>
                   <span>
-                    {sign}
-                    {formatChangePercent(change.percent, formatting)}
+                    {change.percent !== null && sign}
+                    {formatChangePercent(
+                      change,
+                      t("insights:networth.breakdown_table.new"),
+                      formatting,
+                    )}
                   </span>
                   <span className="text-muted-foreground font-normal">
                     {t("insights:networth.category_sheet.over_period", { period: periodLabel })}

--- a/apps/frontend/src/pages/net-worth/components/utils.test.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.test.ts
@@ -71,32 +71,64 @@ describe("net worth utils", () => {
   });
 
   it("derives asset and liability changes with the right sign", () => {
-    expect(deriveChange([100, 125], false)).toEqual({ amount: 25, percent: 0.25 });
-    expect(deriveChange([125, 100], true)).toEqual({ amount: 25, percent: 0.2 });
-    expect(deriveChange([100], false)).toEqual({ amount: 0, percent: 0 });
+    expect(deriveChange([100, 125], false)).toEqual({ amount: 25, percent: 0.25, isNew: false });
+    expect(deriveChange([125, 100], true)).toEqual({ amount: 25, percent: 0.2, isNew: false });
+    expect(deriveChange([100], false)).toEqual({ amount: 0, percent: 0, isNew: false });
   });
 
   it("reports no percentage when the range starts without a usable baseline", () => {
     // A category added mid-range must read as "New", never as 0%.
-    expect(deriveChange([0, 400_000], false)).toEqual({ amount: 400_000, percent: null });
+    expect(deriveChange([0, 400_000], false)).toEqual({
+      amount: 400_000,
+      percent: null,
+      isNew: true,
+    });
     // Forward-filled rounding residue must not become a denominator.
     const residue = deriveChange([2e-8, 25_000], false);
     expect(residue.percent).toBeNull();
     expect(residue.amount).toBeCloseTo(25_000);
+    // The floor applies to both ends: a row that still ends below one unit never
+    // became real, so residue surfacing from zero does not earn the "New" label.
+    expect(deriveChange([0, 2e-8], false).isNew).toBe(false);
     // A real balance is a baseline, however large the swing on top of it.
-    expect(deriveChange([1, 3], false)).toEqual({ amount: 2, percent: 2 });
+    expect(deriveChange([1, 3], false)).toEqual({ amount: 2, percent: 2, isNew: false });
   });
 
   it("formats change percentages, collapsing unreadable ratios to a multiple", () => {
     const formatting = createFormatter("en-US");
-    expect(formatChangePercent({ amount: 25, percent: 0.25 }, "New", formatting)).toBe("25.0%");
-    expect(formatChangePercent({ amount: 400, percent: 4 }, "New", formatting)).toBe("400%");
-    // 500 → 1,250,000 is 249,900%, which nobody can read; show the multiple.
-    expect(formatChangePercent({ amount: 1_249_500, percent: 2499 }, "New", formatting)).toBe(
-      "2.5K×",
+    expect(
+      formatChangePercent({ amount: 25, percent: 0.25, isNew: false }, "New", formatting),
+    ).toBe("25.0%");
+    expect(formatChangePercent({ amount: 400, percent: 4, isNew: false }, "New", formatting)).toBe(
+      "400%",
     );
-    expect(formatChangePercent({ amount: 400_000, percent: null }, "New", formatting)).toBe("New");
-    expect(formatChangePercent({ amount: -5, percent: null }, "New", formatting)).toBe("—");
+    // 500 → 1,250,000 is 249,900%, which nobody can read; show the multiple.
+    expect(
+      formatChangePercent({ amount: 1_249_500, percent: 2499, isNew: false }, "New", formatting),
+    ).toBe("2.5K×");
+    expect(
+      formatChangePercent({ amount: 400_000, percent: null, isNew: true }, "New", formatting),
+    ).toBe("New");
+    expect(
+      formatChangePercent({ amount: -5, percent: null, isNew: false }, "New", formatting),
+    ).toBe("—");
+  });
+
+  it("labels a liability added mid-range as new, despite the inverted sign", () => {
+    const formatting = createFormatter("en-US");
+    // A mortgage taken out during the range: raw series grows 0 -> 400k, but the
+    // liability sign convention makes `amount` negative. "New" must follow the raw
+    // values, not the sign, or a new mortgage reads as "-$400K —".
+    const mortgage = deriveChange([0, 400_000], true);
+    expect(mortgage.amount).toBe(-400_000);
+    expect(mortgage.percent).toBeNull();
+    expect(formatChangePercent(mortgage, "New", formatting)).toBe("New");
+
+    // The mirror case: a dust liability cleared to zero never had a baseline and
+    // is not new, so it must stay an em dash even though `amount` is positive.
+    const dustCleared = deriveChange([0.5, 0], true);
+    expect(dustCleared.amount).toBe(0.5);
+    expect(formatChangePercent(dustCleared, "New", formatting)).toBe("—");
   });
 
   it("keeps the plain-percent range in step with the multiple threshold", () => {

--- a/apps/frontend/src/pages/net-worth/components/utils.test.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.test.ts
@@ -1,3 +1,4 @@
+import { createFormatter } from "@wealthfolio/ui";
 import { describe, expect, it } from "vitest";
 
 import type { NetWorthHistoryPoint, TaxonomyAllocation } from "@/lib/types";
@@ -6,7 +7,9 @@ import {
   computeMomentum,
   computeVelocity,
   deriveChange,
+  formatChangePercent,
   investmentAllocation,
+  isPlainPercent,
   parseHistory,
   type ParsedHistoryPoint,
 } from "./utils";
@@ -70,8 +73,37 @@ describe("net worth utils", () => {
   it("derives asset and liability changes with the right sign", () => {
     expect(deriveChange([100, 125], false)).toEqual({ amount: 25, percent: 0.25 });
     expect(deriveChange([125, 100], true)).toEqual({ amount: 25, percent: 0.2 });
-    expect(deriveChange([0, 25], false)).toEqual({ amount: 25, percent: 0 });
     expect(deriveChange([100], false)).toEqual({ amount: 0, percent: 0 });
+  });
+
+  it("reports no percentage when the range starts without a usable baseline", () => {
+    // A category added mid-range must read as "New", never as 0%.
+    expect(deriveChange([0, 400_000], false)).toEqual({ amount: 400_000, percent: null });
+    // Forward-filled rounding residue must not become a denominator.
+    const residue = deriveChange([2e-8, 25_000], false);
+    expect(residue.percent).toBeNull();
+    expect(residue.amount).toBeCloseTo(25_000);
+    // A real balance is a baseline, however large the swing on top of it.
+    expect(deriveChange([1, 3], false)).toEqual({ amount: 2, percent: 2 });
+  });
+
+  it("formats change percentages, collapsing unreadable ratios to a multiple", () => {
+    const formatting = createFormatter("en-US");
+    expect(formatChangePercent({ amount: 25, percent: 0.25 }, "New", formatting)).toBe("25.0%");
+    expect(formatChangePercent({ amount: 400, percent: 4 }, "New", formatting)).toBe("400%");
+    // 500 → 1,250,000 is 249,900%, which nobody can read; show the multiple.
+    expect(formatChangePercent({ amount: 1_249_500, percent: 2499 }, "New", formatting)).toBe(
+      "2.5K×",
+    );
+    expect(formatChangePercent({ amount: 400_000, percent: null }, "New", formatting)).toBe("New");
+    expect(formatChangePercent({ amount: -5, percent: null }, "New", formatting)).toBe("—");
+  });
+
+  it("keeps the plain-percent range in step with the multiple threshold", () => {
+    expect(isPlainPercent(9.99)).toBe(true);
+    expect(isPlainPercent(-9.99)).toBe(true);
+    expect(isPlainPercent(10)).toBe(false);
+    expect(isPlainPercent(null)).toBe(false);
   });
 
   it("decomposes monthly velocity into market gains, contributions, and equity built", () => {

--- a/apps/frontend/src/pages/net-worth/components/utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.ts
@@ -134,8 +134,20 @@ export function seriesFor(history: ParsedHistoryPoint[], key: string): number[] 
 
 export interface Change {
   amount: number;
-  percent: number;
+  /** Ratio (0.145 = 14.5%), or null when the range starts with no usable baseline. */
+  percent: number | null;
 }
+
+/**
+ * A starting value below this counts as "no baseline" rather than a divisor. Over
+ * long ranges the first point is often zero (the category was added later) or
+ * rounding residue forward-filled from years ago, and dividing by either produces
+ * percentages in the millions.
+ */
+const BASELINE_FLOOR = 1;
+
+/** Past this ratio a percentage stops being readable, so it renders as a multiple. */
+const MULTIPLE_THRESHOLD = 10;
 
 /**
  * Change over the range from a value series. Liabilities are stored as positive
@@ -147,16 +159,34 @@ export function deriveChange(series: number[], isLiability: boolean): Change {
   const last = series[series.length - 1];
   const amount = isLiability ? first - last : last - first;
   const base = Math.abs(first);
-  return { amount, percent: base > 0 ? amount / base : 0 };
+  return { amount, percent: base >= BASELINE_FLOOR ? amount / base : null };
 }
 
-/** Percent is a ratio (0.145 = 14.5%); drop decimals for very large swings. */
+/** True when the ratio is small enough to read as a plain percentage. */
+export function isPlainPercent(percent: number | null): percent is number {
+  return percent !== null && Math.abs(percent) < MULTIPLE_THRESHOLD;
+}
+
+/**
+ * Display string for a change: a percentage, a multiple once the ratio outgrows
+ * MULTIPLE_THRESHOLD (3,347,531% reads as "33K×"), or `newLabel` for a row that
+ * grew from nothing.
+ */
 export function formatChangePercent(
-  percent: number,
-  formatting: Pick<FormattingApi, "formatPercent">,
+  change: Change,
+  newLabel: string,
+  formatting: Pick<FormattingApi, "formatPercent" | "formatDecimal">,
 ): string {
-  const abs = Math.abs(percent);
-  return formatting.formatPercent(abs, { digits: abs >= 10 ? 0 : 1, signDisplay: "never" });
+  if (change.percent === null) return change.amount > 0 ? newLabel : "—";
+  const abs = Math.abs(change.percent);
+  if (abs >= MULTIPLE_THRESHOLD) {
+    const multiple = formatting.formatDecimal(1 + abs, {
+      notation: "compact",
+      maximumFractionDigits: 1,
+    });
+    return `${multiple}×`;
+  }
+  return formatting.formatPercent(abs, { digits: abs >= 1 ? 0 : 1, signDisplay: "never" });
 }
 
 const MS_PER_DAY = 86_400_000;

--- a/apps/frontend/src/pages/net-worth/components/utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.ts
@@ -136,6 +136,12 @@ export interface Change {
   amount: number;
   /** Ratio (0.145 = 14.5%), or null when the range starts with no usable baseline. */
   percent: number | null;
+  /**
+   * The row had no usable baseline but ends holding a real value, so it was added
+   * during the range. Derived from the raw series rather than `amount`, because
+   * liability amounts are sign-inverted and a new debt yields a negative amount.
+   */
+  isNew: boolean;
 }
 
 /**
@@ -154,12 +160,17 @@ const MULTIPLE_THRESHOLD = 10;
  * magnitudes, so a reduction is expressed as a positive (good) change.
  */
 export function deriveChange(series: number[], isLiability: boolean): Change {
-  if (series.length < 2) return { amount: 0, percent: 0 };
+  if (series.length < 2) return { amount: 0, percent: 0, isNew: false };
   const first = series[0];
   const last = series[series.length - 1];
   const amount = isLiability ? first - last : last - first;
   const base = Math.abs(first);
-  return { amount, percent: base >= BASELINE_FLOOR ? amount / base : null };
+  const hasBaseline = base >= BASELINE_FLOOR;
+  return {
+    amount,
+    percent: hasBaseline ? amount / base : null,
+    isNew: !hasBaseline && Math.abs(last) >= BASELINE_FLOOR,
+  };
 }
 
 /** True when the ratio is small enough to read as a plain percentage. */
@@ -177,7 +188,7 @@ export function formatChangePercent(
   newLabel: string,
   formatting: Pick<FormattingApi, "formatPercent" | "formatDecimal">,
 ): string {
-  if (change.percent === null) return change.amount > 0 ? newLabel : "—";
+  if (change.percent === null) return change.isNew ? newLabel : "—";
   const abs = Math.abs(change.percent);
   if (abs >= MULTIPLE_THRESHOLD) {
     const multiple = formatting.formatDecimal(1 + abs, {

--- a/apps/frontend/src/pages/net-worth/net-worth-content.tsx
+++ b/apps/frontend/src/pages/net-worth/net-worth-content.tsx
@@ -13,6 +13,7 @@ import {
   GainPercent,
   IntervalSelector,
   getInitialIntervalData,
+  useNumberFormatting,
   usePersistentState,
   type TimePeriod,
 } from "@wealthfolio/ui";
@@ -36,8 +37,12 @@ import {
   averageMonthlyChange,
   computeMomentum,
   computeVelocity,
+  deriveChange,
+  formatChangePercent,
   investmentAllocation,
+  isPlainPercent,
   parseHistory,
+  toneClass,
   type ParsedNetWorth,
   type SelectedCategory,
 } from "./components/utils";
@@ -50,6 +55,7 @@ const MS_PER_DAY = 86_400_000;
 
 export function NetWorthContent() {
   const { t } = useTranslation();
+  const formatting = useNumberFormatting();
   const { settings } = useSettingsContext();
   const { data: netWorthData, isLoading, isError, error } = useNetWorth();
   const isMobile = useIsMobileViewport();
@@ -148,15 +154,16 @@ export function NetWorthContent() {
     return computeMomentum(longHistory, historyDates.startDate, historyDates.endDate);
   }, [longHistory, historyDates, periodCode]);
 
-  // Net worth change over the selected range (simple delta).
-  const { gainLossAmount, gainLossPercent } = useMemo(() => {
-    if (parsedHistory.length < 2) return { gainLossAmount: 0, gainLossPercent: 0 };
-    const first = parsedHistory[0].netWorth;
-    const last = parsedHistory[parsedHistory.length - 1].netWorth;
-    const change = last - first;
-    const base = first !== 0 ? Math.abs(first) : 1;
-    return { gainLossAmount: change, gainLossPercent: change / base };
-  }, [parsedHistory]);
+  // Net worth change over the selected range, on the same baseline rules as the
+  // breakdown rows so the header and the table agree.
+  const netWorthChange = useMemo(
+    () =>
+      deriveChange(
+        parsedHistory.map((point) => point.netWorth),
+        false,
+      ),
+    [parsedHistory],
+  );
 
   const currency = netWorthData?.currency || settings?.baseCurrency || "USD";
   const hasStaleValuations = netWorthData && netWorthData.staleAssets.length > 0;
@@ -246,16 +253,28 @@ export function NetWorthContent() {
                 <>
                   <GainAmount
                     className="lg:text-md text-sm font-light"
-                    value={gainLossAmount}
+                    value={netWorthChange.amount}
                     currency={currency}
                     displayCurrency={false}
                   />
                   <div className="border-secondary my-1 border-r pr-2" />
-                  <GainPercent
-                    className="lg:text-md text-sm font-light"
-                    value={gainLossPercent}
-                    animated={true}
-                  />
+                  {isPlainPercent(netWorthChange.percent) ? (
+                    <GainPercent
+                      className="lg:text-md text-sm font-light"
+                      value={netWorthChange.percent}
+                      animated={true}
+                    />
+                  ) : (
+                    <span
+                      className={`lg:text-md text-sm font-light ${toneClass(netWorthChange.amount)}`}
+                    >
+                      {formatChangePercent(
+                        netWorthChange,
+                        t("insights:networth.breakdown_table.new"),
+                        formatting,
+                      )}
+                    </span>
+                  )}
                 </>
               )}
               {periodCode && (


### PR DESCRIPTION
Fixes #1456

## What

Over the ALL range the Δ column showed percentages with six or more digits, and a category that grew from nothing showed `0.0%`. Both came from `deriveChange` dividing the range change by the first history point with no guard on the denominator.

`Change.percent` is now nullable. A starting value under one currency unit is treated as **no baseline** rather than a divisor, and `formatChangePercent` renders those rows as `New` (or `—` when the row shrank to nothing). Genuine but unreadable ratios past 10× collapse to a multiple.

## Before / after

Using the reproduction from #1456 — a history whose first point predates most positions:

| Row                                | before                 | after   |
| ---------------------------------- | ---------------------- | ------- |
| Investments (500 → 1,250,000)      | `249,900%`             | `2.5K×` |
| Properties (0 → 400,000)           | `0.0%`                 | `New`   |
| Cash (2e-8 → 25,000)               | `124,999,999,999,900%` | `New`   |
| Net worth header (500 → 1,675,000) | `334,900%`             | `3.4K×` |

Shorter ranges are unchanged: any row whose starting value is a real balance still renders a plain percentage, animated in the header exactly as before. Only ratios past 10× and rows with no baseline take the new paths.

## Design notes

- **Why `New` rather than `∞%` or a hidden cell.** `0.0%` was actively misleading — the point is to stop claiming a ratio that does not exist, while still telling the reader why. `—` covers the mirror case (a row that ended at nothing).
- **Why a multiple past 10×.** `2.5K×` fits the existing `w-12` percent column and is how people read growth at that scale. Nothing in the layout moved.
- **`BASELINE_FLOOR` is one unit of the display currency**, not a ratio-relative threshold. A ratio-relative rule would suppress percentages for legitimately explosive-but-small positions; an absolute floor only rejects balances that were never real.

## Tests

Four cases added to `components/utils.test.ts`: zero baseline, float-residue baseline, a genuine small baseline that must still produce a percentage, and the formatter's percent/multiple/`New`/`—` branches, plus `isPlainPercent` boundaries.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
