### PR TITLE
fix: translate net worth category labels

### DIFF
--- a/apps/frontend/src/lib/net-worth-category-label.test.ts
+++ b/apps/frontend/src/lib/net-worth-category-label.test.ts
@@ -1,0 +1,31 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it, vi } from "vitest";
+import { getNetWorthCategoryLabel } from "./net-worth-category-label";
+
+describe("getNetWorthCategoryLabel", () => {
+  it.each([
+    ["cash", "holdings:group_cash"],
+    ["investments", "holdings:group_investments"],
+    ["properties", "holdings:group_properties"],
+    ["vehicles", "holdings:group_vehicles"],
+    ["collectibles", "holdings:group_collectibles"],
+    ["preciousMetals", "holdings:group_precious_metals"],
+    ["otherAssets", "holdings:group_other_assets"],
+  ])("translates the %s category using %s", (category, key) => {
+    const t = vi.fn(
+      (translationKey: string) => `translated:${translationKey}`,
+    ) as unknown as TFunction;
+
+    expect(getNetWorthCategoryLabel(t, category, "Backend name")).toBe(`translated:${key}`);
+    expect(t).toHaveBeenCalledWith(key, "Backend name");
+  });
+
+  it("preserves the backend name for an unknown category", () => {
+    const t = vi.fn() as unknown as TFunction;
+
+    expect(getNetWorthCategoryLabel(t, "futureCategory", "Future category")).toBe(
+      "Future category",
+    );
+    expect(t).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/lib/net-worth-category-label.ts
+++ b/apps/frontend/src/lib/net-worth-category-label.ts
@@ -1,0 +1,17 @@
+import type { TFunction } from "i18next";
+
+const NET_WORTH_CATEGORY_KEYS: Record<string, string> = {
+  cash: "holdings:group_cash",
+  investments: "holdings:group_investments",
+  properties: "holdings:group_properties",
+  vehicles: "holdings:group_vehicles",
+  collectibles: "holdings:group_collectibles",
+  preciousMetals: "holdings:group_precious_metals",
+  otherAssets: "holdings:group_other_assets",
+};
+
+/** Localize a built-in top-level net-worth category, preserving unknown names. */
+export function getNetWorthCategoryLabel(t: TFunction, category: string, fallback: string): string {
+  const key = NET_WORTH_CATEGORY_KEYS[category];
+  return key ? t(key, fallback) : fallback;
+}

--- a/apps/frontend/src/pages/holdings/components/net-worth-widget.tsx
+++ b/apps/frontend/src/pages/holdings/components/net-worth-widget.tsx
@@ -14,6 +14,7 @@ import {
 } from "@wealthfolio/ui/components/ui/tooltip";
 import { PrivacyAmount } from "@wealthfolio/ui";
 import { useNetWorth } from "@/hooks/use-alternative-assets";
+import { getNetWorthCategoryLabel } from "@/lib/net-worth-category-label";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { cn, parseLocalDate } from "@/lib/utils";
 import { useMemo, useState } from "react";
@@ -174,7 +175,7 @@ export const NetWorthWidget = ({
       totalAssets: parseFloat(netWorthData.assets.total) || 0,
       totalLiabilities: parseFloat(netWorthData.liabilities.total) || 0,
       assetsBreakdown: netWorthData.assets.breakdown.map((item) => ({
-        label: item.name,
+        label: getNetWorthCategoryLabel(t, item.category, item.name),
         value: parseFloat(item.value) || 0,
       })),
       liabilitiesBreakdown: netWorthData.liabilities.breakdown.map((item) => ({
@@ -183,7 +184,7 @@ export const NetWorthWidget = ({
         isDebt: true,
       })),
     };
-  }, [netWorthData]);
+  }, [netWorthData, t]);
 
   // Build breakdown items for display
   const breakdownItems = useMemo((): BreakdownItem[] => {

--- a/apps/frontend/src/pages/net-worth/net-worth-content.tsx
+++ b/apps/frontend/src/pages/net-worth/net-worth-content.tsx
@@ -1,6 +1,7 @@
 import { useNetWorth, useNetWorthHistory } from "@/hooks/use-alternative-assets";
 import { usePortfolioAllocations } from "@/hooks/use-portfolio-allocations";
 import { useIsMobileViewport } from "@/hooks/use-platform";
+import { getNetWorthCategoryLabel } from "@/lib/net-worth-category-label";
 import { useSettingsContext } from "@/lib/settings-provider";
 import type { DateRange } from "@/lib/types";
 import { formatDateISO } from "@/lib/utils";
@@ -110,7 +111,7 @@ export function NetWorthContent() {
         total: parseFloat(netWorthData.assets.total) || 0,
         breakdown: (netWorthData.assets.breakdown || []).map((item) => ({
           category: item.category,
-          name: item.name,
+          name: getNetWorthCategoryLabel(t, item.category, item.name),
           value: parseFloat(item.value) || 0,
           assetId: item.assetId,
           children: (item.children ?? []).map((child) => ({
@@ -131,7 +132,7 @@ export function NetWorthContent() {
         })),
       },
     };
-  }, [netWorthData]);
+  }, [netWorthData, t]);
 
   const parsedHistory = useMemo(() => parseHistory(historyData), [historyData]);
   const longHistory = useMemo(() => parseHistory(longHistoryData), [longHistoryData]);


### PR DESCRIPTION
Follow-up to #1464.

## Problem

The net-worth backend returns a stable category identifier together with an English display name. The Net Worth page and holdings Net Worth widget rendered that English name directly, so built-in asset categories remained untranslated in non-English locales.

## Changes

- Add a shared helper that maps stable backend category identifiers to the existing `holdings:group_*` translations.
- Apply it to top-level asset categories in the Net Worth page and holdings widget.
- Preserve the backend name for unknown or future category identifiers.
- Leave individual asset and liability names unchanged.
- Recompute parsed labels when the active translation function changes.
- Cover all seven built-in mappings and the unknown-category fallback with unit tests.

## Validation

- `pnpm --filter frontend test --run src/lib/net-worth-category-label.test.ts` — 8 tests passed
- `pnpm run build:types && pnpm --filter frontend type-check`
- ESLint on all changed TypeScript files
- Prettier and `git diff --check`
