### PR TITLE
Rebalance: allow selecting eligible holdings in Cash Flow Only mode

### DIFF
--- a/apps/frontend/src/adapters/adapter-command-parity.test.ts
+++ b/apps/frontend/src/adapters/adapter-command-parity.test.ts
@@ -3,7 +3,14 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { calculateRebalancePlan as calculateTauriRebalancePlan } from "./tauri";
 import { COMMANDS, invoke } from "./web/core";
+
+const { platformInvokeMock } = vi.hoisted(() => ({
+  platformInvokeMock: vi.fn(),
+}));
+
+vi.mock("#platform", () => ({ invoke: platformInvokeMock }));
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const frontendSrcDir = path.resolve(currentDir, "..");
@@ -106,6 +113,38 @@ function collectNamedReexports(
 
   return { hasStar, names };
 }
+
+describe("rebalance eligibility transport", () => {
+  it("canonicalizes the Tauri shared request before web transport", async () => {
+    const mock = stubFetch({});
+    platformInvokeMock
+      .mockReset()
+      .mockImplementation((command, payload) => invoke(command, payload));
+
+    await calculateTauriRebalancePlan("target-1", 100, { type: "all" }, "cash_flow_only", [
+      "asset-z",
+      "asset-a",
+      "asset-z",
+    ]);
+
+    const { body } = lastCall(mock);
+    const parsed = JSON.parse(body as string) as { eligibleAssetIds?: unknown };
+    expect(parsed.eligibleAssetIds).toEqual(["asset-a", "asset-z"]);
+  });
+
+  it("omits the allowlist when no restriction is supplied", async () => {
+    const mock = stubFetch({});
+    await invoke("calculate_rebalance_plan", {
+      targetId: "target-1",
+      availableCash: 100,
+      filter: { type: "all" },
+      scenarioMode: "cash_flow_only",
+    });
+
+    const { body } = lastCall(mock);
+    expect(JSON.parse(body as string)).not.toHaveProperty("eligibleAssetIds");
+  });
+});
 
 describe("adapter command parity", () => {
   it("registers every command reachable from the web adapter", () => {

--- a/apps/frontend/src/adapters/shared/allocation-targets.ts
+++ b/apps/frontend/src/adapters/shared/allocation-targets.ts
@@ -105,16 +105,33 @@ export const saveTargetConstraints = async (
 
 // ── Rebalance ─────────────────────────────────────────────────────────────────
 
+export function canonicalizeEligibleAssetIds(
+  eligibleAssetIds?: readonly string[],
+): string[] | undefined {
+  if (eligibleAssetIds === undefined) return undefined;
+  return [...new Set(eligibleAssetIds)].sort();
+}
+
 export const calculateRebalancePlan = async (
   targetId: string,
   availableCash: number,
   filter: AccountScope,
   scenarioMode: ScenarioMode = "cash_flow_only",
+  eligibleAssetIds?: readonly string[],
 ): Promise<RebalancePlan> => {
-  return invoke<RebalancePlan>("calculate_rebalance_plan", {
+  const payload: {
+    targetId: string;
+    availableCash: number;
+    filter: AccountScope;
+    scenarioMode: ScenarioMode;
+    eligibleAssetIds?: string[];
+  } = {
     targetId,
     availableCash,
     filter,
     scenarioMode,
-  });
+  };
+  const canonicalIds = canonicalizeEligibleAssetIds(eligibleAssetIds);
+  if (canonicalIds !== undefined) payload.eligibleAssetIds = canonicalIds;
+  return invoke<RebalancePlan>("calculate_rebalance_plan", payload);
 };

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -2005,17 +2005,19 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "calculate_rebalance_plan": {
-      const { targetId, availableCash, filter, scenarioMode } = payload as {
+      const { targetId, availableCash, filter, scenarioMode, eligibleAssetIds } = payload as {
         targetId: string;
         availableCash: number;
         filter: unknown;
         scenarioMode: string;
+        eligibleAssetIds?: string[];
       };
       body = JSON.stringify({
         targetId,
         availableCash,
         filter,
         scenarioMode,
+        ...(eligibleAssetIds === undefined ? {} : { eligibleAssetIds }),
       });
       break;
     }

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -356,6 +356,7 @@ export {
 export {
   archiveAllocationTarget,
   calculateRebalancePlan,
+  canonicalizeEligibleAssetIds,
   createAllocationTarget,
   deleteAllocationTarget,
   getAllocationTargetDrift,

--- a/apps/frontend/src/i18n/locales/de/allocation.json
+++ b/apps/frontend/src/i18n/locales/de/allocation.json
@@ -113,7 +113,7 @@
   "eligibleHoldings": {
     "label": "Geeignete Bestände",
     "triggerLabel": "{{label}}: {{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "ausgewählt",
     "notSelected": "nicht ausgewählt",
     "allSelected": "Alle Bestände ausgewählt",

--- a/apps/frontend/src/i18n/locales/de/allocation.json
+++ b/apps/frontend/src/i18n/locales/de/allocation.json
@@ -110,6 +110,29 @@
     "modeVerbHybrid": "Bargeld und Verkäufe",
     "modeVerbCashFlow": "Cashflow-Käufe"
   },
+  "eligibleHoldings": {
+    "label": "Geeignete Bestände",
+    "triggerLabel": "{{label}}: {{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "ausgewählt",
+    "notSelected": "nicht ausgewählt",
+    "allSelected": "Alle Bestände ausgewählt",
+    "selectedCount": "{{selected}} von {{total}} ausgewählt",
+    "searchPlaceholder": "Bestände suchen",
+    "noMatches": "Keine passenden Bestände.",
+    "selectAll": "Alle auswählen",
+    "clear": "Leeren",
+    "emptyGuidance": "Wählen Sie mindestens einen Bestand aus, um einen Plan zu berechnen.",
+    "groups": {
+      "equity": "Aktien",
+      "bond": "Anleihen",
+      "crypto": "Krypto",
+      "option": "Optionen",
+      "metal": "Metalle",
+      "fx": "Devisen",
+      "other": "Sonstige"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}} führen {{lifted}} näher an das Ziel und verringern die Übergewichtung von {{shrank}} von {{before}} auf {{after}}.",
     "lift": "{{verb}} führen {{lifted}} näher an das Ziel.",

--- a/apps/frontend/src/i18n/locales/en/allocation.json
+++ b/apps/frontend/src/i18n/locales/en/allocation.json
@@ -110,6 +110,29 @@
     "modeVerbHybrid": "Cash and sells",
     "modeVerbCashFlow": "Cash-flow buys"
   },
+  "eligibleHoldings": {
+    "label": "Eligible holdings",
+    "triggerLabel": "{{label}}: {{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "selected",
+    "notSelected": "not selected",
+    "allSelected": "All holdings selected",
+    "selectedCount": "{{selected}} of {{total}} selected",
+    "searchPlaceholder": "Search holdings",
+    "noMatches": "No holding matches.",
+    "selectAll": "Select all",
+    "clear": "Clear",
+    "emptyGuidance": "Select at least one holding to calculate a plan.",
+    "groups": {
+      "equity": "Equity",
+      "bond": "Bond",
+      "crypto": "Crypto",
+      "option": "Option",
+      "metal": "Metal",
+      "fx": "FX",
+      "other": "Other"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}} lift {{lifted}} toward target and shrink the {{shrank}} overweight from {{before}} to {{after}}.",
     "lift": "{{verb}} lift {{lifted}} toward target.",

--- a/apps/frontend/src/i18n/locales/en/allocation.json
+++ b/apps/frontend/src/i18n/locales/en/allocation.json
@@ -113,7 +113,7 @@
   "eligibleHoldings": {
     "label": "Eligible holdings",
     "triggerLabel": "{{label}}: {{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "selected",
     "notSelected": "not selected",
     "allSelected": "All holdings selected",

--- a/apps/frontend/src/i18n/locales/es/allocation.json
+++ b/apps/frontend/src/i18n/locales/es/allocation.json
@@ -110,6 +110,29 @@
     "modeVerbHybrid": "Efectivo y ventas",
     "modeVerbCashFlow": "Compras con flujo de efectivo"
   },
+  "eligibleHoldings": {
+    "label": "Posiciones elegibles",
+    "triggerLabel": "{{label}}: {{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "seleccionada",
+    "notSelected": "no seleccionada",
+    "allSelected": "Todas las posiciones seleccionadas",
+    "selectedCount": "{{selected}} de {{total}} seleccionadas",
+    "searchPlaceholder": "Buscar posiciones",
+    "noMatches": "No hay coincidencias.",
+    "selectAll": "Seleccionar todo",
+    "clear": "Limpiar",
+    "emptyGuidance": "Selecciona al menos una posición para calcular un plan.",
+    "groups": {
+      "equity": "Renta variable",
+      "bond": "Bonos",
+      "crypto": "Cripto",
+      "option": "Opciones",
+      "metal": "Metales",
+      "fx": "Divisas",
+      "other": "Otros"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}} elevar {{lifted}} hacia el objetivo y reducir el sobrepeso de {{shrank}} de {{before}} a {{after}}.",
     "lift": "{{verb}} elevar {{lifted}} hacia el objetivo.",

--- a/apps/frontend/src/i18n/locales/es/allocation.json
+++ b/apps/frontend/src/i18n/locales/es/allocation.json
@@ -113,7 +113,7 @@
   "eligibleHoldings": {
     "label": "Posiciones elegibles",
     "triggerLabel": "{{label}}: {{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "seleccionada",
     "notSelected": "no seleccionada",
     "allSelected": "Todas las posiciones seleccionadas",

--- a/apps/frontend/src/i18n/locales/fr/allocation.json
+++ b/apps/frontend/src/i18n/locales/fr/allocation.json
@@ -113,7 +113,7 @@
   "eligibleHoldings": {
     "label": "Titres éligibles",
     "triggerLabel": "{{label}} : {{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "sélectionné",
     "notSelected": "non sélectionné",
     "allSelected": "Tous les titres sélectionnés",

--- a/apps/frontend/src/i18n/locales/fr/allocation.json
+++ b/apps/frontend/src/i18n/locales/fr/allocation.json
@@ -110,6 +110,29 @@
     "modeVerbHybrid": "La trésorerie et les ventes",
     "modeVerbCashFlow": "Les achats par flux de trésorerie"
   },
+  "eligibleHoldings": {
+    "label": "Titres éligibles",
+    "triggerLabel": "{{label}} : {{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "sélectionné",
+    "notSelected": "non sélectionné",
+    "allSelected": "Tous les titres sélectionnés",
+    "selectedCount": "{{selected}} sur {{total}} sélectionnés",
+    "searchPlaceholder": "Rechercher des titres",
+    "noMatches": "Aucun titre correspondant.",
+    "selectAll": "Tout sélectionner",
+    "clear": "Effacer",
+    "emptyGuidance": "Sélectionnez au moins un titre pour calculer un plan.",
+    "groups": {
+      "equity": "Actions",
+      "bond": "Obligations",
+      "crypto": "Crypto",
+      "option": "Options",
+      "metal": "Métaux",
+      "fx": "Devises",
+      "other": "Autres"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}} rapprochent {{lifted}} de la cible et réduisent la surpondération de {{shrank}} de {{before}} à {{after}}.",
     "lift": "{{verb}} rapprochent {{lifted}} de la cible.",

--- a/apps/frontend/src/i18n/locales/ja/allocation.json
+++ b/apps/frontend/src/i18n/locales/ja/allocation.json
@@ -107,6 +107,29 @@
     "modeVerbHybrid": "現金と売却",
     "modeVerbCashFlow": "新規資金での買付"
   },
+  "eligibleHoldings": {
+    "label": "購入対象の保有銘柄",
+    "triggerLabel": "{{label}}：{{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "選択中",
+    "notSelected": "未選択",
+    "allSelected": "すべての保有銘柄を選択中",
+    "selectedCount": "{{total}}件中{{selected}}件を選択中",
+    "searchPlaceholder": "保有銘柄を検索",
+    "noMatches": "一致する保有銘柄がありません。",
+    "selectAll": "すべて選択",
+    "clear": "クリア",
+    "emptyGuidance": "プランを計算するには、少なくとも1件を選択してください。",
+    "groups": {
+      "equity": "株式",
+      "bond": "債券",
+      "crypto": "暗号資産",
+      "option": "オプション",
+      "metal": "金属",
+      "fx": "為替",
+      "other": "その他"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}}により{{lifted}}を目標に近づけ、{{shrank}}の超過を{{before}}から{{after}}に縮小します。",
     "lift": "{{verb}}により{{lifted}}を目標に近づけます。",

--- a/apps/frontend/src/i18n/locales/ja/allocation.json
+++ b/apps/frontend/src/i18n/locales/ja/allocation.json
@@ -110,7 +110,7 @@
   "eligibleHoldings": {
     "label": "購入対象の保有銘柄",
     "triggerLabel": "{{label}}：{{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "選択中",
     "notSelected": "未選択",
     "allSelected": "すべての保有銘柄を選択中",

--- a/apps/frontend/src/i18n/locales/ko/allocation.json
+++ b/apps/frontend/src/i18n/locales/ko/allocation.json
@@ -107,6 +107,29 @@
     "modeVerbHybrid": "현금 및 매도",
     "modeVerbCashFlow": "현금흐름 매수"
   },
+  "eligibleHoldings": {
+    "label": "매수 가능 보유 종목",
+    "triggerLabel": "{{label}}: {{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "선택됨",
+    "notSelected": "선택되지 않음",
+    "allSelected": "모든 보유 종목 선택됨",
+    "selectedCount": "{{total}}개 중 {{selected}}개 선택됨",
+    "searchPlaceholder": "보유 종목 검색",
+    "noMatches": "일치하는 보유 종목이 없습니다.",
+    "selectAll": "모두 선택",
+    "clear": "지우기",
+    "emptyGuidance": "계획을 계산하려면 하나 이상의 보유 종목을 선택하세요.",
+    "groups": {
+      "equity": "주식",
+      "bond": "채권",
+      "crypto": "암호화폐",
+      "option": "옵션",
+      "metal": "금속",
+      "fx": "외환",
+      "other": "기타"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}}: {{lifted}}을(를) 목표로 끌어올리고, {{shrank}}의 초과 비중을 {{before}}에서 {{after}}로 줄입니다.",
     "lift": "{{verb}}: {{lifted}}을(를) 목표로 끌어올립니다.",

--- a/apps/frontend/src/i18n/locales/ko/allocation.json
+++ b/apps/frontend/src/i18n/locales/ko/allocation.json
@@ -110,7 +110,7 @@
   "eligibleHoldings": {
     "label": "매수 가능 보유 종목",
     "triggerLabel": "{{label}}: {{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "선택됨",
     "notSelected": "선택되지 않음",
     "allSelected": "모든 보유 종목 선택됨",

--- a/apps/frontend/src/i18n/locales/zh/allocation.json
+++ b/apps/frontend/src/i18n/locales/zh/allocation.json
@@ -110,7 +110,7 @@
   "eligibleHoldings": {
     "label": "可买入的持仓",
     "triggerLabel": "{{label}}：{{summary}}",
-    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "rowLabel": "{{symbol}} {{name}} {{details}} — {{state}}",
     "selected": "已选择",
     "notSelected": "未选择",
     "allSelected": "已选择全部持仓",

--- a/apps/frontend/src/i18n/locales/zh/allocation.json
+++ b/apps/frontend/src/i18n/locales/zh/allocation.json
@@ -107,6 +107,29 @@
     "modeVerbHybrid": "现金与卖出",
     "modeVerbCashFlow": "现金流买入"
   },
+  "eligibleHoldings": {
+    "label": "可买入的持仓",
+    "triggerLabel": "{{label}}：{{summary}}",
+    "rowLabel": "{{symbol}} {{name}} — {{state}}",
+    "selected": "已选择",
+    "notSelected": "未选择",
+    "allSelected": "已选择全部持仓",
+    "selectedCount": "已选择 {{selected}} / {{total}}",
+    "searchPlaceholder": "搜索持仓",
+    "noMatches": "没有匹配的持仓。",
+    "selectAll": "全选",
+    "clear": "清除",
+    "emptyGuidance": "请至少选择一项持仓后再计算计划。",
+    "groups": {
+      "equity": "股票",
+      "bond": "债券",
+      "crypto": "加密货币",
+      "option": "期权",
+      "metal": "金属",
+      "fx": "外汇",
+      "other": "其他"
+    }
+  },
   "narrative": {
     "liftAndShrink": "{{verb}}将 {{lifted}} 提升至目标，并将 {{shrank}} 的超配从 {{before}} 缩减至 {{after}}。",
     "lift": "{{verb}}将 {{lifted}} 提升至目标。",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -622,6 +622,8 @@ export interface Instrument {
   preferredProvider?: string | null;
   isin?: string | null;
   exchangeMic?: string | null;
+  /** Canonical market instrument type (for example EQUITY or BOND). */
+  instrumentType?: string | null;
 
   // Taxonomy-based classifications
   classifications?: AssetClassifications | null;

--- a/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.test.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.test.tsx
@@ -32,6 +32,8 @@ function holding(
   name: string,
   instrumentType?: string,
   holdingType: Holding["holdingType"] = HoldingType.SECURITY,
+  currency = "USD",
+  exchangeMic?: string,
 ): Holding {
   return {
     id: `${assetId}-${symbol}`,
@@ -41,8 +43,9 @@ function holding(
       id: assetId,
       symbol,
       name,
-      currency: "USD",
+      currency,
       quoteMode: "MARKET",
+      exchangeMic,
       instrumentType,
     },
   } as Holding;
@@ -130,6 +133,43 @@ describe("EligibleHoldingsSelector", () => {
     await user.click(screen.getByRole("option", { name: /VTI.*Vanguard Total Stock/i }));
     expect(screen.getByRole("button", { name: /Eligible holdings/ })).toHaveTextContent(
       "2 of 3 selected",
+    );
+  });
+
+  it("disambiguates duplicate labels and reaches each row from the keyboard", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        holdings={[
+          holding("asset-xnas", "ABC", "Acme Corp", "EQUITY", HoldingType.SECURITY, "USD", "XNAS"),
+          holding("asset-xtse", "ABC", "Acme Corp", "EQUITY", HoldingType.SECURITY, "CAD", "XTSE"),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Eligible holdings/ }));
+    expect(
+      screen.getByRole("option", { name: /ABC.*Acme Corp.*XNAS.*USD.*selected/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /ABC.*Acme Corp.*XTSE.*CAD.*selected/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("XNAS · USD")).toBeInTheDocument();
+    expect(screen.getByText("XTSE · CAD")).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByRole("option")
+        .filter((option) => option.getAttribute("aria-selected") === "true"),
+    ).toHaveLength(1);
+
+    await user.click(screen.getByPlaceholderText("Search holdings"));
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(
+      screen.getByRole("option", { name: /ABC.*Acme Corp.*XTSE.*CAD.*not selected/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Eligible holdings/ })).toHaveTextContent(
+      "1 of 2 selected",
     );
   });
 

--- a/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.test.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HoldingType } from "@/lib/constants";
+import type { Holding } from "@/lib/types";
+import { PlannerInput } from "./rebalance-tab";
+import { EligibleHoldingsSelector } from "./eligible-holdings-selector";
+import { getEligibleHoldings, groupEligibleHoldings } from "./eligible-holdings";
+
+if (typeof ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {
+      return undefined;
+    }
+    unobserve() {
+      return undefined;
+    }
+    disconnect() {
+      return undefined;
+    }
+  } as typeof ResizeObserver;
+}
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => undefined;
+}
+
+function holding(
+  assetId: string,
+  symbol: string,
+  name: string,
+  instrumentType?: string,
+  holdingType: Holding["holdingType"] = HoldingType.SECURITY,
+): Holding {
+  return {
+    id: `${assetId}-${symbol}`,
+    accountId: "account-1",
+    holdingType,
+    instrument: {
+      id: assetId,
+      symbol,
+      name,
+      currency: "USD",
+      quoteMode: "MARKET",
+      instrumentType,
+    },
+  } as Holding;
+}
+
+function Harness({ holdings }: { holdings: Holding[] }) {
+  const [excludedAssetIds, setExcludedAssetIds] = useState<Set<string>>(new Set());
+  return (
+    <EligibleHoldingsSelector
+      holdings={holdings}
+      excludedAssetIds={excludedAssetIds}
+      onToggle={(assetId) =>
+        setExcludedAssetIds((previous) => {
+          const next = new Set(previous);
+          if (next.has(assetId)) next.delete(assetId);
+          else next.add(assetId);
+          return next;
+        })
+      }
+      onSelectAll={() => setExcludedAssetIds(new Set())}
+      onClear={() =>
+        setExcludedAssetIds(new Set(getEligibleHoldings(holdings).map((row) => row.assetId)))
+      }
+    />
+  );
+}
+
+describe("EligibleHoldingsSelector", () => {
+  const holdings = [
+    holding("asset-bond", "BND", "Bond fund", "BOND"),
+    holding("asset-vti", "VTI", "Vanguard Total Stock", "EQUITY"),
+    holding("asset-vti", "VTI", "Vanguard Total Stock", "EQUITY", HoldingType.SECURITY),
+    holding("asset-unknown", "MYST", "Mystery asset"),
+    holding("cash-usd", "USD", "Cash", undefined, HoldingType.CASH),
+  ];
+
+  it("selects each unique non-cash instrument initially and groups it by type", () => {
+    render(<Harness holdings={holdings} />);
+
+    expect(screen.getByRole("button", { name: /Eligible holdings/ })).toHaveTextContent(
+      "All holdings selected",
+    );
+
+    expect(groupEligibleHoldings(getEligibleHoldings(holdings)).map((group) => group.key)).toEqual([
+      "EQUITY",
+      "BOND",
+      "OTHER",
+    ]);
+
+    expect(screen.queryByText("Equity")).not.toBeInTheDocument();
+  });
+
+  it("announces selection state on the trigger and rows", async () => {
+    const user = userEvent.setup();
+    render(<Harness holdings={holdings} />);
+
+    expect(
+      screen.getByRole("button", { name: /Eligible holdings.*All holdings selected/i }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /Eligible holdings.*All holdings selected/i }),
+    );
+    const vti = screen.getByRole("option", { name: /VTI.*selected/i });
+    expect(vti).toHaveAccessibleName(/selected/i);
+
+    await user.click(vti);
+    expect(screen.getByRole("option", { name: /VTI.*not selected/i })).toBeInTheDocument();
+  });
+
+  it("opens grouped rows, searches by name, and toggles individual holdings", async () => {
+    const user = userEvent.setup();
+    render(<Harness holdings={holdings} />);
+    await user.click(screen.getByRole("button", { name: /Eligible holdings/ }));
+
+    expect(screen.getByText("Equity")).not.toBeInstanceOf(HTMLButtonElement);
+    expect(screen.getByText("Bond")).toBeInTheDocument();
+    expect(screen.getByText("Other")).toBeInTheDocument();
+
+    const search = screen.getByPlaceholderText("Search holdings");
+    await user.type(search, "Vanguard");
+    expect(screen.getByText("VTI")).toBeInTheDocument();
+    expect(screen.queryByText("BND")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("option", { name: /VTI.*Vanguard Total Stock/i }));
+    expect(screen.getByRole("button", { name: /Eligible holdings/ })).toHaveTextContent(
+      "2 of 3 selected",
+    );
+  });
+
+  it("supports Clear and Select all and explains the empty state", async () => {
+    const user = userEvent.setup();
+    render(<Harness holdings={holdings} />);
+    await user.click(screen.getByRole("button", { name: /Eligible holdings/ }));
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(screen.getByRole("button", { name: /Eligible holdings/ })).toHaveTextContent(
+      "0 of 3 selected",
+    );
+    expect(
+      screen.getByText("Select at least one holding to calculate a plan."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Select all" }));
+    expect(screen.getByRole("button", { name: /Eligible holdings/ })).toHaveTextContent(
+      "All holdings selected",
+    );
+  });
+
+  it("disables Calculate and Enter when no holding is eligible", () => {
+    const onCalculate = vi.fn();
+    render(
+      <PlannerInput
+        description=""
+        cashValue="100"
+        availableCash={100}
+        currency="USD"
+        onCashChange={vi.fn()}
+        onCalculate={onCalculate}
+        hasPlan={false}
+        isCalculating={false}
+        isSourceLoading={false}
+        hasEligibleHoldings={false}
+        eligibleHoldingsSelector={<p>Select at least one holding to calculate a plan.</p>}
+      />,
+    );
+
+    const calculate = screen.getByRole("button", { name: "Calculate plan" });
+    expect(calculate).toBeDisabled();
+    expect(
+      screen.getByText("Select at least one holding to calculate a plan."),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    expect(onCalculate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.tsx
@@ -103,14 +103,24 @@ export function EligibleHoldingsSelector({
                 <CommandGroup key={group.key} heading={groupLabel(group.key, t)}>
                   {group.holdings.map((holding) => {
                     const selected = !excludedAssetIds.has(holding.assetId);
+                    const details = [holding.exchangeMic, holding.currency]
+                      .filter((value): value is string => Boolean(value))
+                      .join(" · ");
                     return (
                       <CommandItem
                         key={holding.assetId}
-                        value={`${holding.symbol} ${holding.name ?? ""}`}
+                        value={holding.assetId}
+                        keywords={[
+                          holding.symbol,
+                          holding.name ?? "",
+                          holding.exchangeMic ?? "",
+                          holding.currency,
+                        ]}
                         onSelect={() => onToggle(holding.assetId)}
                         aria-label={t("allocation:eligibleHoldings.rowLabel", {
                           symbol: holding.symbol,
                           name: holding.name ?? "",
+                          details,
                           state: t(
                             selected
                               ? "allocation:eligibleHoldings.selected"
@@ -129,6 +139,9 @@ export function EligibleHoldingsSelector({
                               {holding.name}
                             </span>
                           )}
+                          <span className="text-muted-foreground/80 block truncate font-mono text-[11px]">
+                            {details}
+                          </span>
                         </span>
                       </CommandItem>
                     );

--- a/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/eligible-holdings-selector.tsx
@@ -1,0 +1,174 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Icons } from "@wealthfolio/ui";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@wealthfolio/ui/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@wealthfolio/ui/components/ui/popover";
+import type { Holding } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { getEligibleHoldings, groupEligibleHoldings } from "./eligible-holdings";
+
+function groupLabel(key: string, t: (key: string) => string): string {
+  const labels: Record<string, string> = {
+    EQUITY: t("allocation:eligibleHoldings.groups.equity"),
+    BOND: t("allocation:eligibleHoldings.groups.bond"),
+    CRYPTO: t("allocation:eligibleHoldings.groups.crypto"),
+    OPTION: t("allocation:eligibleHoldings.groups.option"),
+    METAL: t("allocation:eligibleHoldings.groups.metal"),
+    FX: t("allocation:eligibleHoldings.groups.fx"),
+    OTHER: t("allocation:eligibleHoldings.groups.other"),
+  };
+  return labels[key] ?? key;
+}
+
+function SelectionMark({ selected }: { selected: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors",
+        selected ? "border-foreground bg-foreground text-background" : "border-border",
+      )}
+    >
+      <Icons.Check className={cn("h-3 w-3", !selected && "opacity-0")} />
+    </span>
+  );
+}
+
+export interface EligibleHoldingsSelectorProps {
+  holdings: Holding[];
+  excludedAssetIds: ReadonlySet<string>;
+  onToggle: (assetId: string) => void;
+  onSelectAll: () => void;
+  onClear: () => void;
+}
+
+export function EligibleHoldingsSelector({
+  holdings,
+  excludedAssetIds,
+  onToggle,
+  onSelectAll,
+  onClear,
+}: EligibleHoldingsSelectorProps) {
+  const { t } = useTranslation();
+  const eligibleHoldings = useMemo(() => getEligibleHoldings(holdings), [holdings]);
+  const groupedHoldings = useMemo(
+    () => groupEligibleHoldings(eligibleHoldings),
+    [eligibleHoldings],
+  );
+  const selectedCount = eligibleHoldings.reduce(
+    (count, holding) => count + (excludedAssetIds.has(holding.assetId) ? 0 : 1),
+    0,
+  );
+  const allSelected = eligibleHoldings.length > 0 && selectedCount === eligibleHoldings.length;
+  const summary = allSelected
+    ? t("allocation:eligibleHoldings.allSelected")
+    : t("allocation:eligibleHoldings.selectedCount", {
+        selected: selectedCount,
+        total: eligibleHoldings.length,
+      });
+  const label = t("allocation:eligibleHoldings.label");
+
+  return (
+    <div className="mt-4">
+      <div className="text-muted-foreground font-mono text-xs uppercase tracking-[0.14em]">
+        {t("allocation:eligibleHoldings.label")}
+      </div>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("allocation:eligibleHoldings.triggerLabel", { label, summary })}
+            className="border-border/70 hover:border-foreground/40 mt-1.5 flex w-full items-center justify-between gap-3 rounded-xl border border-dashed px-3 py-2.5 text-left transition-colors"
+          >
+            <span className="text-foreground min-w-0 truncate font-mono text-sm font-semibold tabular-nums">
+              {summary}
+            </span>
+            <Icons.ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-[min(420px,calc(100vw-2rem))] p-0">
+          <Command>
+            <CommandInput placeholder={t("allocation:eligibleHoldings.searchPlaceholder")} />
+            <CommandList className="max-h-[min(60vh,360px)]">
+              <CommandEmpty>{t("allocation:eligibleHoldings.noMatches")}</CommandEmpty>
+              {groupedHoldings.map((group) => (
+                <CommandGroup key={group.key} heading={groupLabel(group.key, t)}>
+                  {group.holdings.map((holding) => {
+                    const selected = !excludedAssetIds.has(holding.assetId);
+                    return (
+                      <CommandItem
+                        key={holding.assetId}
+                        value={`${holding.symbol} ${holding.name ?? ""}`}
+                        onSelect={() => onToggle(holding.assetId)}
+                        aria-label={t("allocation:eligibleHoldings.rowLabel", {
+                          symbol: holding.symbol,
+                          name: holding.name ?? "",
+                          state: t(
+                            selected
+                              ? "allocation:eligibleHoldings.selected"
+                              : "allocation:eligibleHoldings.notSelected",
+                          ),
+                        })}
+                        className="gap-2"
+                      >
+                        <SelectionMark selected={selected} />
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-mono text-xs font-semibold">
+                            {holding.symbol}
+                          </span>
+                          {holding.name && (
+                            <span className="text-muted-foreground block truncate text-xs">
+                              {holding.name}
+                            </span>
+                          )}
+                        </span>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              ))}
+            </CommandList>
+            <CommandSeparator />
+            <div className="text-muted-foreground flex items-center justify-between px-3 py-2 font-mono text-[11px]">
+              <span className="tabular-nums">
+                {t("allocation:eligibleHoldings.selectedCount", {
+                  selected: selectedCount,
+                  total: eligibleHoldings.length,
+                })}
+              </span>
+              <span className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={onSelectAll}
+                  className="hover:text-foreground rounded px-1.5 py-0.5 transition-colors"
+                >
+                  {t("allocation:eligibleHoldings.selectAll")}
+                </button>
+                <button
+                  type="button"
+                  onClick={onClear}
+                  className="hover:text-foreground rounded px-1.5 py-0.5 transition-colors"
+                >
+                  {t("allocation:eligibleHoldings.clear")}
+                </button>
+              </span>
+            </div>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {selectedCount === 0 && (
+        <p className="text-destructive mt-2 font-mono text-xs">
+          {t("allocation:eligibleHoldings.emptyGuidance")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/allocation-targets/components/eligible-holdings.ts
+++ b/apps/frontend/src/pages/allocation-targets/components/eligible-holdings.ts
@@ -4,6 +4,8 @@ export interface EligibleHolding {
   assetId: string;
   symbol: string;
   name?: string | null;
+  currency: string;
+  exchangeMic?: string | null;
   instrumentType?: string | null;
 }
 
@@ -26,6 +28,8 @@ export function getEligibleHoldings(holdings: Holding[]): EligibleHolding[] {
           assetId: instrument.id,
           symbol: instrument.symbol,
           name: instrument.name,
+          currency: instrument.currency,
+          exchangeMic: instrument.exchangeMic,
           instrumentType: instrument.instrumentType,
         },
       ];

--- a/apps/frontend/src/pages/allocation-targets/components/eligible-holdings.ts
+++ b/apps/frontend/src/pages/allocation-targets/components/eligible-holdings.ts
@@ -1,0 +1,73 @@
+import type { Holding } from "@/lib/types";
+
+export interface EligibleHolding {
+  assetId: string;
+  symbol: string;
+  name?: string | null;
+  instrumentType?: string | null;
+}
+
+const GROUP_ORDER = ["EQUITY", "BOND", "CRYPTO", "OPTION", "METAL", "FX"];
+
+function compareText(a: string, b: string): number {
+  const left = a.toLowerCase();
+  const right = b.toLowerCase();
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function getEligibleHoldings(holdings: Holding[]): EligibleHolding[] {
+  const rows = holdings
+    .filter((holding) => holding.holdingType.toLowerCase() !== "cash")
+    .flatMap((holding): EligibleHolding[] => {
+      const instrument = holding.instrument;
+      if (!instrument?.id) return [];
+      return [
+        {
+          assetId: instrument.id,
+          symbol: instrument.symbol,
+          name: instrument.name,
+          instrumentType: instrument.instrumentType,
+        },
+      ];
+    })
+    .sort(
+      (a, b) =>
+        compareText(a.symbol, b.symbol) ||
+        compareText(a.name ?? "", b.name ?? "") ||
+        compareText(a.assetId, b.assetId),
+    );
+
+  const unique = new Map<string, EligibleHolding>();
+  for (const row of rows) {
+    if (!unique.has(row.assetId)) unique.set(row.assetId, row);
+  }
+  return [...unique.values()];
+}
+
+function groupKey(row: EligibleHolding): string {
+  const key = row.instrumentType?.trim().toUpperCase();
+  return key && GROUP_ORDER.includes(key) ? key : "OTHER";
+}
+
+function groupSortKey(key: string): [number, string] {
+  const index = GROUP_ORDER.indexOf(key);
+  return [index === -1 ? GROUP_ORDER.length : index, key];
+}
+
+export function groupEligibleHoldings(
+  holdings: EligibleHolding[],
+): { key: string; holdings: EligibleHolding[] }[] {
+  const grouped = new Map<string, EligibleHolding[]>();
+  for (const holding of holdings) {
+    const key = groupKey(holding);
+    grouped.set(key, [...(grouped.get(key) ?? []), holding]);
+  }
+
+  return [...grouped.entries()]
+    .sort(([a], [b]) => {
+      const [aOrder, aName] = groupSortKey(a);
+      const [bOrder, bName] = groupSortKey(b);
+      return aOrder - bOrder || compareText(aName, bName);
+    })
+    .map(([key, rows]) => ({ key, holdings: rows }));
+}

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.test.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HoldingType } from "@/lib/constants";
+import type { AllocationTarget, DriftReport, Holding } from "@/lib/types";
+import { RebalanceTab } from "./rebalance-tab";
+
+const { useRebalancePlanMock, refetchMock } = vi.hoisted(() => ({
+  useRebalancePlanMock: vi.fn(),
+  refetchMock: vi.fn(),
+}));
+
+vi.mock("../hooks/use-rebalance", () => ({
+  useRebalancePlan: useRebalancePlanMock,
+}));
+
+if (typeof ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {
+      return undefined;
+    }
+    unobserve() {
+      return undefined;
+    }
+    disconnect() {
+      return undefined;
+    }
+  } as typeof ResizeObserver;
+}
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => undefined;
+}
+
+function holding(assetId: string, symbol: string, name: string): Holding {
+  return {
+    id: `${assetId}-holding`,
+    accountId: "account-1",
+    holdingType: HoldingType.SECURITY,
+    instrument: {
+      id: assetId,
+      symbol,
+      name,
+      currency: "USD",
+      quoteMode: "MARKET",
+      instrumentType: "EQUITY",
+    },
+  } as Holding;
+}
+
+const profile: AllocationTarget = {
+  id: "target-1",
+  name: "Balanced",
+  scopeType: "all",
+  taxonomyId: "asset_classes",
+  triggerType: "manual",
+  driftBandBps: 500,
+  bandType: "absolute",
+  relativeFactorBps: 10000,
+  rebalanceGoal: "exact_target",
+  minTradeAmount: "1",
+  wholeSharesOnly: false,
+  allowSells: true,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const driftReport: DriftReport = {
+  targetId: profile.id,
+  scopeType: "all",
+  totalValue: 1000,
+  baseCurrency: "USD",
+  maxDriftBps: 1000,
+  outOfBandCount: 1,
+  rows: [
+    {
+      categoryId: "equity",
+      categoryName: "Equity",
+      color: "#355c4c",
+      currentBps: 9000,
+      targetBps: 10000,
+      driftBps: -1000,
+      currentValue: 900,
+      targetValue: 1000,
+      valueDelta: 100,
+      effectiveBandBps: 500,
+      status: "underweight",
+      isRequired: true,
+      isZeroCurrent: false,
+      isCash: false,
+    },
+  ],
+  deployableCash: 100,
+};
+
+const holdings = [
+  holding("asset-z", "AAA", "Alpha fund"),
+  holding("asset-m", "MMM", "Middle fund"),
+  holding("asset-a", "ZZZ", "Zed fund"),
+];
+
+function renderRebalance() {
+  return render(
+    <RebalanceTab
+      profile={profile}
+      driftReport={driftReport}
+      accountScope={{ type: "all" }}
+      holdings={holdings}
+      availableCash={100}
+      sourceVersion="source-1"
+      isSourceLoading={false}
+    />,
+  );
+}
+
+describe("RebalanceTab eligible holdings production flow", () => {
+  beforeEach(() => {
+    refetchMock.mockReset().mockResolvedValue({ error: null });
+    useRebalancePlanMock.mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      refetch: refetchMock,
+    });
+  });
+
+  it("hides the selector outside Cash Flow Only and restores its selection", async () => {
+    const user = userEvent.setup();
+    renderRebalance();
+
+    const trigger = () => screen.getByRole("button", { name: /Eligible holdings/ });
+    await user.click(trigger());
+    await user.click(screen.getByRole("option", { name: /AAA.*selected/i }));
+    expect(trigger()).toHaveTextContent("2 of 3 selected");
+
+    await user.click(screen.getByRole("button", { name: /Sell.*rebalance/i }));
+    expect(screen.queryByRole("button", { name: /Eligible holdings/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Cash-flow.*only/i }));
+    expect(trigger()).toHaveTextContent("2 of 3 selected");
+  });
+
+  it("omits a full allowlist and passes a sorted partial allowlist when calculating", async () => {
+    const user = userEvent.setup();
+    renderRebalance();
+
+    const initialParams = useRebalancePlanMock.mock.lastCall?.[0] as {
+      eligibleAssetIds?: string[];
+    };
+    expect(initialParams.eligibleAssetIds).toBeUndefined();
+
+    await user.click(screen.getByRole("button", { name: /Calculate plan/ }));
+    await waitFor(() => expect(refetchMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: /Eligible holdings/ }));
+    await user.click(screen.getByRole("option", { name: /AAA.*selected/i }));
+    const partialParams = useRebalancePlanMock.mock.lastCall?.[0] as {
+      eligibleAssetIds?: string[];
+    };
+    expect(partialParams.eligibleAssetIds).toEqual(["asset-a", "asset-m"]);
+
+    await user.click(screen.getByRole("button", { name: /Calculate plan/ }));
+    await waitFor(() => expect(refetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not calculate from Enter with an empty selection", async () => {
+    const user = userEvent.setup();
+    renderRebalance();
+
+    await user.click(screen.getByRole("button", { name: /Eligible holdings/ }));
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+    expect(screen.getByRole("button", { name: /Calculate plan/ })).toBeDisabled();
+    expect(refetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -2,6 +2,7 @@ import type {
   AccountScope,
   AllocationTarget,
   DriftReport,
+  Holding,
   RebalancePlan,
   RebalanceWarning,
   ScenarioMode,
@@ -24,11 +25,13 @@ import type { TFunction } from "i18next";
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { useEligibleHoldingsSelection } from "../hooks/use-eligible-holdings";
 import { useRebalancePlan } from "../hooks/use-rebalance";
 import {
   allocationTargetColorForRow,
   buildAllocationTargetColorMap,
 } from "./allocation-target-colors";
+import { EligibleHoldingsSelector } from "./eligible-holdings-selector";
 import { accountScopeKey } from "./target-scope";
 
 // Drift direction colors — clay for overweight (+), slate-blue for underweight (−).
@@ -486,7 +489,7 @@ function ModeSwitch({
 
 // ── Cash deploy controls (left panel) ─────────────────────────────────────────
 
-function PlannerInput({
+export function PlannerInput({
   description,
   cashValue,
   availableCash,
@@ -496,6 +499,8 @@ function PlannerInput({
   hasPlan,
   isCalculating,
   isSourceLoading,
+  hasEligibleHoldings,
+  eligibleHoldingsSelector,
 }: {
   description: string;
   cashValue: string;
@@ -506,6 +511,8 @@ function PlannerInput({
   hasPlan: boolean;
   isCalculating: boolean;
   isSourceLoading: boolean;
+  hasEligibleHoldings: boolean;
+  eligibleHoldingsSelector: ReactNode;
 }) {
   const { t } = useTranslation();
   const amountFormatting = useAmountFormatting();
@@ -524,7 +531,13 @@ function PlannerInput({
   ];
   const activePreset = presets.find((p) => Math.abs(p.value - deploy) <= 0.5 + limit * 0.001)?.id;
 
-  const canCalculate = !isCalculating && !isSourceLoading && limit > 0 && deploy > 0 && !overBudget;
+  const canCalculate =
+    !isCalculating &&
+    !isSourceLoading &&
+    limit > 0 &&
+    deploy > 0 &&
+    !overBudget &&
+    hasEligibleHoldings;
 
   return (
     <div className="flex h-full flex-col">
@@ -597,6 +610,8 @@ function PlannerInput({
           {t("allocation:planner.exceedsAvailableCash")}
         </p>
       )}
+
+      {eligibleHoldingsSelector}
 
       <div className="mt-auto pt-4 sm:pt-5">
         <Button
@@ -1336,6 +1351,7 @@ interface RebalanceTabProps {
   profile: AllocationTarget | null;
   driftReport: DriftReport | null;
   accountScope: AccountScope;
+  holdings: Holding[];
   availableCash: number;
   sourceVersion: string;
   isSourceLoading: boolean;
@@ -1345,6 +1361,7 @@ export function RebalanceTab({
   profile,
   driftReport,
   accountScope,
+  holdings,
   availableCash,
   sourceVersion,
   isSourceLoading,
@@ -1360,6 +1377,14 @@ export function RebalanceTab({
   const tradesRef = useRef<HTMLDivElement>(null);
   const currency = driftReport?.baseCurrency ?? "USD";
   const inputContextKey = `${profile?.id ?? "no-profile"}:${accountScopeKey(accountScope)}:${currency}`;
+  const {
+    excludedAssetIds,
+    eligibleAssetIds: canonicalEligibleAssetIds,
+    hasEligibleHoldings,
+    toggle: toggleEligibleAsset,
+    selectAll: selectAllEligibleAssets,
+    clear: clearEligibleAssets,
+  } = useEligibleHoldingsSelection(holdings, inputContextKey);
   const cashValue =
     cashDraft?.key === inputContextKey
       ? cashDraft.value
@@ -1375,6 +1400,7 @@ export function RebalanceTab({
     filter: accountScope,
     scenarioMode,
     sourceKey,
+    eligibleAssetIds: scenarioMode === "cash_flow_only" ? canonicalEligibleAssetIds : undefined,
   });
   const cachedPlan = planQuery.data ?? null;
   const hasStalePlan = !!cachedPlan && cachedPlan.sourceKey !== sourceKey;
@@ -1395,6 +1421,10 @@ export function RebalanceTab({
     if (!profile) return;
     if (!sourceReady) {
       toast.error(t("allocation:toast.dataLoading"));
+      return;
+    }
+    if (!hasEligibleHoldings && !isSellMode) {
+      toast.error(t("allocation:eligibleHoldings.emptyGuidance"));
       return;
     }
     if (availableCashLimit <= 0 && !isSellMode) {
@@ -1471,6 +1501,18 @@ export function RebalanceTab({
                 hasPlan={!!plan || hasStalePlan}
                 isCalculating={isCalculating}
                 isSourceLoading={!sourceReady}
+                hasEligibleHoldings={isSellMode || hasEligibleHoldings}
+                eligibleHoldingsSelector={
+                  scenarioMode === "cash_flow_only" ? (
+                    <EligibleHoldingsSelector
+                      holdings={holdings}
+                      excludedAssetIds={excludedAssetIds}
+                      onToggle={toggleEligibleAsset}
+                      onSelectAll={selectAllEligibleAssets}
+                      onClear={clearEligibleAssets}
+                    />
+                  ) : null
+                }
               />
             </div>
             <div className="px-4 py-4 sm:px-5 sm:py-5">

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-eligible-holdings.test.ts
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-eligible-holdings.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HoldingType } from "@/lib/constants";
+import type { Holding } from "@/lib/types";
+import { useEligibleHoldingsSelection } from "./use-eligible-holdings";
+
+function holding(assetId: string, symbol: string): Holding {
+  return {
+    id: assetId,
+    accountId: "account-1",
+    holdingType: HoldingType.SECURITY,
+    instrument: {
+      id: assetId,
+      symbol,
+      name: `${symbol} name`,
+      currency: "USD",
+      quoteMode: "MARKET",
+    },
+  } as Holding;
+}
+
+describe("useEligibleHoldingsSelection", () => {
+  it("starts all current instruments selected and omits a full allowlist", () => {
+    const { result } = renderHook(() =>
+      useEligibleHoldingsSelection([holding("asset-b", "B"), holding("asset-a", "A")], "context-a"),
+    );
+
+    expect(result.current.selectedAssetIds).toEqual(["asset-a", "asset-b"]);
+    expect(result.current.eligibleAssetIds).toBeUndefined();
+  });
+
+  it("preserves exclusions for refreshes, prunes removals, selects additions, and resets context", () => {
+    const { result, rerender } = renderHook(
+      ({ holdings, contextKey }: { holdings: Holding[]; contextKey: string }) =>
+        useEligibleHoldingsSelection(holdings, contextKey),
+      {
+        initialProps: {
+          holdings: [holding("asset-a", "A"), holding("asset-b", "B")],
+          contextKey: "context-a",
+        },
+      },
+    );
+
+    act(() => result.current.toggle("asset-b"));
+    expect(result.current.eligibleAssetIds).toEqual(["asset-a"]);
+
+    rerender({
+      holdings: [holding("asset-a", "A"), holding("asset-c", "C")],
+      contextKey: "context-a",
+    });
+    expect(result.current.selectedAssetIds).toEqual(["asset-a", "asset-c"]);
+    expect(result.current.eligibleAssetIds).toBeUndefined();
+
+    rerender({
+      holdings: [holding("asset-a", "A"), holding("asset-c", "C")],
+      contextKey: "context-b",
+    });
+    expect(result.current.selectedAssetIds).toEqual(["asset-a", "asset-c"]);
+    expect(result.current.eligibleAssetIds).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-eligible-holdings.ts
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-eligible-holdings.ts
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from "react";
+import { canonicalizeEligibleAssetIds } from "@/adapters";
+import type { Holding } from "@/lib/types";
+import { getEligibleHoldings, type EligibleHolding } from "../components/eligible-holdings";
+
+const EMPTY_EXCLUSIONS = new Set<string>();
+
+export interface EligibleHoldingsSelection {
+  eligibleHoldings: EligibleHolding[];
+  excludedAssetIds: ReadonlySet<string>;
+  selectedAssetIds: string[];
+  eligibleAssetIds?: string[];
+  hasEligibleHoldings: boolean;
+  toggle: (assetId: string) => void;
+  selectAll: () => void;
+  clear: () => void;
+}
+
+export function useEligibleHoldingsSelection(
+  holdings: Holding[],
+  contextKey: string,
+): EligibleHoldingsSelection {
+  const eligibleHoldings = useMemo(() => getEligibleHoldings(holdings), [holdings]);
+  const availableAssetIds = useMemo(
+    () => new Set(eligibleHoldings.map((holding) => holding.assetId)),
+    [eligibleHoldings],
+  );
+  const [selection, setSelection] = useState(() => ({
+    contextKey,
+    excludedAssetIds: EMPTY_EXCLUSIONS,
+  }));
+
+  useEffect(() => {
+    setSelection((current) =>
+      current.contextKey === contextKey
+        ? current
+        : { contextKey, excludedAssetIds: EMPTY_EXCLUSIONS },
+    );
+  }, [contextKey]);
+
+  useEffect(() => {
+    setSelection((current) => {
+      if (current.contextKey !== contextKey) return current;
+      const next = new Set(
+        [...current.excludedAssetIds].filter((assetId) => availableAssetIds.has(assetId)),
+      );
+      if (
+        next.size === current.excludedAssetIds.size &&
+        [...next].every((assetId) => current.excludedAssetIds.has(assetId))
+      ) {
+        return current;
+      }
+      return { contextKey, excludedAssetIds: next };
+    });
+  }, [availableAssetIds, contextKey]);
+
+  const excludedAssetIds =
+    selection.contextKey === contextKey ? selection.excludedAssetIds : EMPTY_EXCLUSIONS;
+  const selectedAssetIds = useMemo(
+    () =>
+      eligibleHoldings
+        .map((holding) => holding.assetId)
+        .filter((assetId) => !excludedAssetIds.has(assetId)),
+    [eligibleHoldings, excludedAssetIds],
+  );
+  const eligibleAssetIds =
+    selectedAssetIds.length === eligibleHoldings.length && eligibleHoldings.length > 0
+      ? undefined
+      : canonicalizeEligibleAssetIds(selectedAssetIds);
+
+  function toggle(assetId: string) {
+    setSelection((current) => {
+      const next = new Set(
+        current.contextKey === contextKey ? current.excludedAssetIds : EMPTY_EXCLUSIONS,
+      );
+      if (next.has(assetId)) next.delete(assetId);
+      else next.add(assetId);
+      return { contextKey, excludedAssetIds: next };
+    });
+  }
+
+  return {
+    eligibleHoldings,
+    excludedAssetIds,
+    selectedAssetIds,
+    eligibleAssetIds,
+    hasEligibleHoldings: selectedAssetIds.length > 0,
+    toggle,
+    selectAll: () => setSelection({ contextKey, excludedAssetIds: EMPTY_EXCLUSIONS }),
+    clear: () => setSelection({ contextKey, excludedAssetIds: availableAssetIds }),
+  };
+}

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-rebalance.test.tsx
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-rebalance.test.tsx
@@ -1,0 +1,85 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+
+import type { RebalancePlan } from "@/lib/types";
+import { useRebalancePlan } from "./use-rebalance";
+
+const { calculateRebalancePlanMock } = vi.hoisted(() => ({
+  calculateRebalancePlanMock: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  calculateRebalancePlan: calculateRebalancePlanMock,
+  canonicalizeEligibleAssetIds: (assetIds?: readonly string[]) =>
+    assetIds === undefined ? undefined : [...new Set(assetIds)].sort(),
+}));
+
+const plan: RebalancePlan = {
+  targetId: "target-1",
+  availableCash: 100,
+  cashUsed: 100,
+  cashRemaining: 0,
+  maxDriftBpsBefore: 100,
+  maxDriftBpsAfter: 0,
+  trades: [],
+  warnings: [],
+  afterBpsByCategory: {},
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return Wrapper;
+}
+
+describe("useRebalancePlan eligibility cache", () => {
+  it("separates allowlists in the cache and reuses an exact canonical input", async () => {
+    calculateRebalancePlanMock.mockReset().mockResolvedValue(plan);
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ eligibleAssetIds }: { eligibleAssetIds?: string[] }) =>
+        useRebalancePlan({
+          targetId: "target-1",
+          cash: 100,
+          filter: { type: "all" },
+          scenarioMode: "cash_flow_only",
+          sourceKey: "source-1",
+          eligibleAssetIds,
+        }),
+      {
+        initialProps: { eligibleAssetIds: ["asset-z", "asset-a", "asset-z"] },
+        wrapper,
+      },
+    );
+
+    let firstResult: unknown;
+    await act(async () => {
+      firstResult = (await result.current.refetch()).data;
+    });
+    expect(firstResult).toBeDefined();
+    expect(calculateRebalancePlanMock).toHaveBeenCalledTimes(1);
+    expect(calculateRebalancePlanMock).toHaveBeenLastCalledWith(
+      "target-1",
+      100,
+      { type: "all" },
+      "cash_flow_only",
+      ["asset-a", "asset-z"],
+    );
+    rerender({ eligibleAssetIds: ["asset-b"] });
+    expect(result.current.data).toBeUndefined();
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(calculateRebalancePlanMock).toHaveBeenCalledTimes(2);
+
+    rerender({ eligibleAssetIds: ["asset-z", "asset-a"] });
+    await waitFor(() => expect(result.current.data).toEqual(firstResult));
+    expect(calculateRebalancePlanMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-rebalance.ts
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-rebalance.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { calculateRebalancePlan } from "@/adapters";
+import { calculateRebalancePlan, canonicalizeEligibleAssetIds } from "@/adapters";
 import { accountScopeKey } from "../components/target-scope";
 import type { AccountScope, RebalancePlan, ScenarioMode } from "@/lib/types";
 
@@ -11,6 +11,8 @@ export interface RebalancePlanParams {
   scenarioMode: ScenarioMode;
   /** Snapshot of the portfolio source (available cash + holdings version) at calc time, for staleness detection. */
   sourceKey: string;
+  /** Canonical optional allowlist of asset IDs eligible for buys. */
+  eligibleAssetIds?: readonly string[];
 }
 
 export interface CachedRebalancePlan {
@@ -25,6 +27,8 @@ export interface CachedRebalancePlan {
  * navigating away from the rebalance view and back shows it without recomputing.
  */
 export function useRebalancePlan(params: RebalancePlanParams) {
+  const eligibleAssetIds = canonicalizeEligibleAssetIds(params.eligibleAssetIds);
+
   return useQuery({
     queryKey: [
       "rebalance-plan",
@@ -32,6 +36,7 @@ export function useRebalancePlan(params: RebalancePlanParams) {
       accountScopeKey(params.filter),
       params.scenarioMode,
       params.cash,
+      eligibleAssetIds ?? null,
     ],
     queryFn: async (): Promise<CachedRebalancePlan> => {
       const plan = await calculateRebalancePlan(
@@ -39,6 +44,7 @@ export function useRebalancePlan(params: RebalancePlanParams) {
         params.cash,
         params.filter,
         params.scenarioMode,
+        eligibleAssetIds,
       );
       return { plan, sourceKey: params.sourceKey };
     },

--- a/apps/frontend/src/pages/insights/overview/overview-page.tsx
+++ b/apps/frontend/src/pages/insights/overview/overview-page.tsx
@@ -351,6 +351,7 @@ export function OverviewPage({
           profile={effectiveTarget ?? null}
           driftReport={driftReport ?? null}
           accountScope={accountFilter}
+          holdings={holdings}
           availableCash={availableCash}
           sourceVersion={rebalanceSourceVersion}
           isSourceLoading={holdingsLoading || driftLoading || !driftReport}

--- a/apps/server/src/api/allocation_targets.rs
+++ b/apps/server/src/api/allocation_targets.rs
@@ -208,6 +208,8 @@ struct CalculatePlanBody {
     #[serde(default)]
     scenario_mode: ScenarioMode,
     filter: AccountScope,
+    #[serde(default)]
+    eligible_asset_ids: Option<Vec<String>>,
 }
 
 fn resolve_rebalance_input(
@@ -216,6 +218,7 @@ fn resolve_rebalance_input(
     available_cash: Decimal,
     scenario_mode: ScenarioMode,
     filter: &AccountScope,
+    eligible_asset_ids: Option<Vec<String>>,
 ) -> ApiResult<CalculateRebalancePlanInput> {
     let base_currency = state.base_currency.read().unwrap().clone();
     let resolved = state
@@ -229,6 +232,7 @@ fn resolve_rebalance_input(
         base_currency,
         aggregated_account_id: resolved.scope_id,
         scenario_mode,
+        eligible_asset_ids,
     })
 }
 
@@ -242,6 +246,7 @@ async fn calculate_plan(
         body.available_cash,
         body.scenario_mode,
         &body.filter,
+        body.eligible_asset_ids,
     )?;
     let plan = state.rebalance_service.calculate_plan(input).await?;
     Ok(Json(plan))

--- a/apps/tauri/src/commands/allocation_targets.rs
+++ b/apps/tauri/src/commands/allocation_targets.rs
@@ -240,6 +240,7 @@ fn resolve_rebalance_input(
     available_cash: Decimal,
     scenario_mode: ScenarioMode,
     filter: AccountScopeInput,
+    eligible_asset_ids: Option<Vec<String>>,
 ) -> Result<CalculateRebalancePlanInput, String> {
     let filter = filter.into_account_filter()?;
     let base_currency = state.get_base_currency();
@@ -258,6 +259,7 @@ fn resolve_rebalance_input(
         base_currency,
         aggregated_account_id: resolved.scope_id,
         scenario_mode,
+        eligible_asset_ids,
     })
 }
 
@@ -268,6 +270,7 @@ pub async fn calculate_rebalance_plan(
     available_cash: Decimal,
     scenario_mode: Option<ScenarioMode>,
     filter: AccountScopeInput,
+    eligible_asset_ids: Option<Vec<String>>,
 ) -> Result<RebalancePlan, String> {
     let input = resolve_rebalance_input(
         &state,
@@ -275,6 +278,7 @@ pub async fn calculate_rebalance_plan(
         available_cash,
         scenario_mode.unwrap_or_default(),
         filter,
+        eligible_asset_ids,
     )?;
     state
         .rebalance_service()

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -1690,6 +1690,7 @@ pub async fn get_snapshot_by_date(
             pricing_mode: asset.quote_mode.as_db_str().to_string(),
             preferred_provider: asset.preferred_provider(),
             exchange_mic: asset.instrument_exchange_mic.clone(),
+            instrument_type: asset.instrument_type.clone(),
             classifications: None,
         };
 

--- a/crates/core/src/exports.rs
+++ b/crates/core/src/exports.rs
@@ -459,6 +459,7 @@ mod tests {
                 quote_mode: "MARKET".to_string(),
                 isin: Some("US0378331005".to_string()),
                 exchange_mic: Some("XNAS".to_string()),
+                instrument_type: None,
                 classifications: None,
             }),
             asset_kind: Some(AssetKind::Investment),

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -1578,6 +1578,7 @@ mod tests {
                 pricing_mode: "MARKET".to_string(),
                 preferred_provider: None,
                 exchange_mic: None,
+                instrument_type: None,
                 classifications: None,
             }),
             asset_kind: None,

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -408,6 +408,10 @@ pub struct CalculateRebalancePlanInput {
     pub aggregated_account_id: String,
     #[serde(default)]
     pub scenario_mode: ScenarioMode,
+    /// Optional instrument-level allowlist for buy candidates in CashFlowOnly mode.
+    /// `None` preserves the legacy behavior; an empty list is invalid in that mode.
+    #[serde(default)]
+    pub eligible_asset_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -147,6 +147,7 @@ impl RebalanceService {
         price_by_asset: &HashMap<String, Decimal>,
         quantity_by_asset: &HashMap<String, Decimal>,
         whole_shares_only: bool,
+        eligible_asset_ids: Option<&HashSet<String>>,
     ) -> (Vec<AssetCandidate>, Vec<RebalanceWarning>) {
         // Group contributions by asset_id (instrument ID).
         let mut by_asset: HashMap<&str, Vec<&HoldingAllocationContribution>> = HashMap::new();
@@ -161,6 +162,10 @@ impl RebalanceService {
         asset_ids.sort_unstable();
 
         for asset_id in asset_ids {
+            if eligible_asset_ids.is_some_and(|eligible| !eligible.contains(asset_id)) {
+                continue;
+            }
+
             let contribs = &by_asset[asset_id];
             // Skip cash holdings.
             if contribs.iter().all(|c| c.holding_type == HoldingType::Cash) {
@@ -367,6 +372,26 @@ impl RebalanceServiceTrait for RebalanceService {
             ));
         }
 
+        let eligible_asset_ids = if matches!(
+            input.scenario_mode,
+            crate::portfolio::allocation_targets::ScenarioMode::CashFlowOnly
+        ) {
+            match input.eligible_asset_ids.as_ref() {
+                Some(ids) if ids.is_empty() => {
+                    return Err(CoreError::Validation(
+                        crate::errors::ValidationError::InvalidInput(
+                            "eligible_asset_ids must contain at least one asset in cash-flow-only mode"
+                                .to_string(),
+                        ),
+                    ));
+                }
+                Some(ids) => Some(ids.iter().cloned().collect::<HashSet<_>>()),
+                None => None,
+            }
+        } else {
+            None
+        };
+
         // Load profile early — needed for taxonomy_id before cash calculation.
         let profile = self
             .allocation_target_service
@@ -517,6 +542,7 @@ impl RebalanceServiceTrait for RebalanceService {
             &price_by_asset,
             &quantity_by_asset,
             profile.whole_shares_only,
+            eligible_asset_ids.as_ref(),
         );
         classification_warnings.extend(Self::tagged_cash_warnings(
             &profile.taxonomy_id,
@@ -719,6 +745,7 @@ mod tests {
                 pricing_mode: "auto".to_string(),
                 preferred_provider: None,
                 exchange_mic: None,
+                instrument_type: None,
                 classifications: None,
             }),
             asset_kind: None,
@@ -1151,6 +1178,7 @@ mod tests {
             base_currency: "USD".to_string(),
             aggregated_account_id: "agg".to_string(),
             scenario_mode: ScenarioMode::CashFlowOnly,
+            eligible_asset_ids: None,
         }
     }
 
@@ -1184,6 +1212,7 @@ mod tests {
             &price_by_asset,
             &quantity_by_asset,
             false,
+            None,
         );
 
         assert!(warnings.is_empty());
@@ -1216,6 +1245,7 @@ mod tests {
             &price_by_asset,
             &quantity_by_asset,
             false,
+            None,
         );
 
         assert!(warnings.is_empty());
@@ -1530,6 +1560,176 @@ mod tests {
             plan.trades.iter().any(|t| t.category_id == "equity"),
             "should suggest buying equity"
         );
+    }
+
+    #[tokio::test]
+    async fn eligible_asset_ids_limit_cash_flow_buy_candidates_without_changing_drift_inputs() {
+        let total = dec!(10000);
+        let h_vti = make_holding("asset-vti", "VTI", dec!(50), dec!(5000));
+        let h_bnd = make_holding("asset-bnd", "BND", dec!(100), dec!(5000));
+        let h_unclassified = make_holding("asset-unclassified", "XYZ", dec!(10), dec!(1000));
+        let rows = vec![
+            make_drift_row("equity", 5000, 7000, total),
+            make_drift_row("bond", 5000, 3000, total),
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![
+                make_contribution(&h_vti, "equity", dec!(5000)),
+                make_contribution(&h_bnd, "bond", dec!(5000)),
+                make_contribution(&h_unclassified, "__UNKNOWN__", dec!(1000)),
+            ]),
+            vec![
+                make_cash_holding(dec!(200), "USD"),
+                h_vti,
+                h_bnd,
+                h_unclassified,
+            ],
+        );
+
+        let legacy_plan = svc.calculate_plan(make_input(dec!(200))).await.unwrap();
+        let mut full_allowlist_input = make_input(dec!(200));
+        full_allowlist_input.eligible_asset_ids = Some(vec![
+            "asset-vti".to_string(),
+            "asset-bnd".to_string(),
+            "asset-unclassified".to_string(),
+        ]);
+        let full_allowlist_plan = svc.calculate_plan(full_allowlist_input).await.unwrap();
+        assert_eq!(
+            serde_json::to_value(legacy_plan).unwrap(),
+            serde_json::to_value(full_allowlist_plan).unwrap(),
+            "omitting eligibility must preserve the legacy plan",
+        );
+
+        let mut input = make_input(dec!(200));
+        input.eligible_asset_ids = Some(vec![
+            "asset-vti".to_string(),
+            "asset-vti".to_string(),
+            "unknown-asset".to_string(),
+        ]);
+        let plan = svc.calculate_plan(input).await.unwrap();
+
+        assert!(plan.trades.iter().all(|trade| {
+            trade.action != "buy" || trade.asset_id.as_deref() == Some("asset-vti")
+        }));
+        assert!(plan.trades.iter().any(|trade| {
+            trade.action == "buy" && trade.asset_id.as_deref() == Some("asset-vti")
+        }));
+        assert_eq!(
+            plan.trades
+                .iter()
+                .filter(|trade| {
+                    trade.action == "buy" && trade.asset_id.as_deref() == Some("asset-vti")
+                })
+                .count(),
+            1,
+            "duplicate allowlist IDs must not duplicate trades",
+        );
+        assert!(plan
+            .warnings
+            .iter()
+            .all(|warning| warning.kind != RebalanceWarningKind::UnclassifiedAsset));
+        assert_eq!(plan.max_drift_bps_before, 2000);
+    }
+
+    #[tokio::test]
+    async fn eligible_allowlist_without_category_candidate_keeps_no_buy_candidate_warning() {
+        let total = dec!(10000);
+        let holding = make_holding("asset-vti", "VTI", dec!(50), dec!(5000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 5000, 7000, total)], total),
+            make_contributions(vec![make_contribution(&holding, "equity", dec!(5000))]),
+            vec![make_cash_holding(dec!(500), "USD"), holding],
+        );
+        let mut input = make_input(dec!(500));
+        input.eligible_asset_ids = Some(vec!["asset-not-held".to_string()]);
+
+        let plan = svc.calculate_plan(input).await.unwrap();
+
+        assert!(plan
+            .warnings
+            .iter()
+            .any(|warning| warning.kind == RebalanceWarningKind::NoBuyCandidate));
+    }
+
+    #[tokio::test]
+    async fn empty_cash_flow_allowlist_is_rejected() {
+        let mut input = make_input(dec!(0));
+        input.eligible_asset_ids = Some(vec![]);
+        let err = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![], Decimal::ZERO),
+            make_contributions(vec![]),
+            vec![],
+        )
+        .calculate_plan(input)
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("eligible_asset_ids"));
+    }
+
+    #[tokio::test]
+    async fn allowlist_is_ignored_for_sell_to_rebalance() {
+        let total = dec!(10000);
+        let h_vti = make_holding("asset-vti", "VTI", dec!(40), dec!(4000));
+        let h_bnd = make_holding("asset-bnd", "BND", dec!(60), dec!(6000));
+        let svc = make_service(
+            make_sell_profile(RebalanceGoal::ExactTarget),
+            make_report(
+                vec![
+                    make_drift_row("equity", 4000, 7000, total),
+                    make_drift_row("bond", 6000, 3000, total),
+                ],
+                total,
+            ),
+            make_contributions(vec![
+                make_contribution(&h_vti, "equity", dec!(4000)),
+                make_contribution(&h_bnd, "bond", dec!(6000)),
+            ]),
+            vec![make_cash_holding(dec!(0), "USD"), h_vti, h_bnd],
+        );
+
+        let mut input = make_input_with_mode(dec!(0), ScenarioMode::SellToRebalance);
+        input.eligible_asset_ids = Some(vec!["asset-vti".to_string()]);
+        let plan = svc.calculate_plan(input).await.unwrap();
+
+        assert!(plan
+            .trades
+            .iter()
+            .any(|trade| trade.action == "sell" && trade.asset_id.as_deref() == Some("asset-bnd")));
+    }
+
+    #[tokio::test]
+    async fn allowlist_is_ignored_for_hybrid_mode() {
+        let total = dec!(10000);
+        let h_vti = make_holding("asset-vti", "VTI", dec!(40), dec!(4000));
+        let h_bnd = make_holding("asset-bnd", "BND", dec!(60), dec!(6000));
+        let svc = make_service(
+            make_sell_profile(RebalanceGoal::ExactTarget),
+            make_report(
+                vec![
+                    make_drift_row("equity", 4000, 7000, total),
+                    make_drift_row("bond", 6000, 3000, total),
+                ],
+                total,
+            ),
+            make_contributions(vec![
+                make_contribution(&h_vti, "equity", dec!(4000)),
+                make_contribution(&h_bnd, "bond", dec!(6000)),
+            ]),
+            vec![make_cash_holding(dec!(500), "USD"), h_vti, h_bnd],
+        );
+
+        let mut input = make_input_with_mode(dec!(500), ScenarioMode::Hybrid);
+        input.eligible_asset_ids = Some(vec!["asset-bnd".to_string()]);
+        let plan = svc.calculate_plan(input).await.unwrap();
+
+        assert!(plan.trades.iter().any(|trade| {
+            trade.action == "buy" && trade.asset_id.as_deref() == Some("asset-vti")
+        }));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use std::collections::VecDeque;
 
 // Import Lot from its definition
-use crate::assets::{AssetClassifications, AssetKind};
+use crate::assets::{AssetClassifications, AssetKind, InstrumentType};
 use crate::portfolio::snapshot::Lot;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -30,6 +30,8 @@ pub struct Instrument {
     pub pricing_mode: String,
     pub preferred_provider: Option<String>,
     pub exchange_mic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instrument_type: Option<InstrumentType>,
 
     // Taxonomy-based classifications
     pub classifications: Option<AssetClassifications>,
@@ -162,6 +164,8 @@ pub struct HoldingListInstrument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exchange_mic: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub instrument_type: Option<InstrumentType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub classifications: Option<AssetClassifications>,
 }
 
@@ -227,6 +231,7 @@ impl From<Holding> for HoldingListItem {
                 quote_mode: instrument.pricing_mode,
                 isin,
                 exchange_mic: instrument.exchange_mic,
+                instrument_type: instrument.instrument_type,
                 classifications,
             }
         });

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -293,6 +293,7 @@ impl HoldingsService {
                             pricing_mode: asset.quote_mode.as_db_str().to_string(),
                             preferred_provider: asset.preferred_provider(),
                             exchange_mic: asset.instrument_exchange_mic.clone(),
+                            instrument_type: asset.instrument_type.clone(),
                             classifications: None,
                         };
 
@@ -430,6 +431,7 @@ impl HoldingsService {
                 pricing_mode: "MANUAL".to_string(),
                 preferred_provider: None,
                 exchange_mic: None,
+                instrument_type: None,
                 classifications: None,
             };
 
@@ -1679,6 +1681,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 pricing_mode: asset.quote_mode.as_db_str().to_string(),
                 preferred_provider: asset.preferred_provider(),
                 exchange_mic: asset.instrument_exchange_mic.clone(),
+                instrument_type: asset.instrument_type.clone(),
                 classifications: None,
             };
 
@@ -4034,6 +4037,7 @@ mod tests {
                 pricing_mode: "MARKET".to_string(),
                 preferred_provider: None,
                 exchange_mic: None,
+                instrument_type: None,
                 classifications: None,
             }),
             asset_kind: None,

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -502,6 +502,7 @@ mod tests {
                 pricing_mode: "MARKET".to_string(),
                 preferred_provider: None,
                 exchange_mic: None,
+                instrument_type: None,
                 classifications: None,
             })
         } else {


### PR DESCRIPTION
## Description

Adds an **Eligible holdings** selector to the Cash Flow Only rebalance workflow.

- selects all unique non-cash holdings by default and supports search, grouping, individual selection, Select all, and Clear
- keeps exclusions session-only and resets them when the planning context changes
- sends a canonical asset allowlist through web and Tauri only when the selection is partial
- restricts Cash Flow Only buy candidates without changing current allocation, drift, sell behavior, or other rebalance modes
- exposes canonical instrument types on holdings and adds localized selector copy
- adds frontend, adapter parity, and core service coverage

Closes #1141.

### Verification

- `pnpm lint` (0 errors; existing warnings remain)
- focused frontend tests: 44 passed
- `cargo test -p wealthfolio-core portfolio::allocation_targets`: 123 passed
- `cargo fmt --all -- --check`
- focused Prettier check

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
