### PR TITLE
fix: preserve no-flow TWR provenance

### DIFF
--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -751,6 +751,18 @@ impl PerformanceService {
         flow_basis: ExternalFlowBasis,
     ) -> DailyExternalFlow {
         let date = curr_point.valuation_date;
+        if curr_point.external_flow_source == ValuationExternalFlowSource::NoFlow
+            && curr_point.external_inflow_base.is_zero()
+            && curr_point.external_outflow_base.is_zero()
+        {
+            return DailyExternalFlow {
+                date,
+                inflow: Decimal::ZERO,
+                outflow: Decimal::ZERO,
+                source: ValuationExternalFlowSource::NoFlow,
+            };
+        }
+
         let cash_flow = match flow_basis {
             ExternalFlowBasis::AccountCurrency => {
                 curr_point.net_contribution - prev_point.net_contribution
@@ -9020,6 +9032,45 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("inferred from net contribution")));
+    }
+
+    #[test]
+    fn daily_external_flows_keep_no_flow_as_neutral() {
+        let prev = valuation("2026-05-01", dec!(100), dec!(100), dec!(100), dec!(100));
+        let curr = valuation("2027-05-01", dec!(110), dec!(100), dec!(110), dec!(100));
+
+        for basis in [
+            ExternalFlowBasis::BaseCurrency,
+            ExternalFlowBasis::AccountCurrency,
+        ] {
+            let flow = PerformanceService::daily_external_flows(&prev, &curr, basis);
+
+            assert_eq!(flow.inflow, Decimal::ZERO);
+            assert_eq!(flow.outflow, Decimal::ZERO);
+            assert_eq!(flow.source, ExternalFlowSource::NoFlow);
+        }
+    }
+
+    #[test]
+    fn no_flow_rows_do_not_warn_about_inferred_cash_flows() {
+        let history = vec![
+            valuation("2026-05-01", dec!(100), dec!(100), dec!(100), dec!(100)),
+            valuation("2027-05-01", dec!(110), dec!(100), dec!(110), dec!(100)),
+        ];
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            true,
+        )
+        .expect("performance should compute");
+
+        assert!(result
+            .data_quality
+            .warnings
+            .iter()
+            .all(|warning| !warning.contains("inferred from net contribution")));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Closes #1485.

Preserves a zero-valued `NoFlow` valuation row as neutral provenance instead of relabeling it as `NetContributionFallback`. This prevents healthy quiet days from showing the warning that cash flows were inferred from unavailable gross data.

Adds regression coverage for both flow bases and the user-visible performance warning.

## Verification

- `cargo test -p wealthfolio-core`
- `cargo clippy -p wealthfolio-core --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).