### PR TITLE
fix(charts): keep donut center label when the selected slice disappears

### DIFF
--- a/apps/frontend/src/pages/holdings/components/drillable-account-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/drillable-account-chart.tsx
@@ -132,6 +132,15 @@ export function DrillableAccountChart({
 
   const data = isAtRoot ? groupedData : drilledData;
 
+  // The selection points at an account/group, not at a position — reset it when the set
+  // changes instead of pointing at a different one.
+  const entryKey = data.map((item) => item.id).join("|");
+  const [renderedEntryKey, setRenderedEntryKey] = useState(entryKey);
+  if (entryKey !== renderedEntryKey) {
+    setRenderedEntryKey(entryKey);
+    setActiveIndex(0);
+  }
+
   const handleSectionClick = (
     sectionData: { name: string; value: number; currency: string },
     index: number,

--- a/apps/frontend/src/pages/holdings/components/drillable-donut-chart.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/drillable-donut-chart.test.tsx
@@ -1,0 +1,61 @@
+import { render } from "@/test/render";
+import type { TaxonomyAllocation } from "@/lib/types";
+import { DonutChart } from "@wealthfolio/ui";
+import { describe, expect, it } from "vitest";
+import { DrillableDonutChart } from "./drillable-donut-chart";
+
+function regions(categories: TaxonomyAllocation["categories"]): TaxonomyAllocation {
+  return {
+    taxonomyId: "regions",
+    taxonomyName: "Regions",
+    color: "#8b7ec8",
+    categories,
+  } as TaxonomyAllocation;
+}
+
+const AMERICAS = {
+  categoryId: "R20",
+  categoryName: "Americas",
+  color: "#8b7ec8",
+  value: 638300,
+  percentage: 100,
+} as TaxonomyAllocation["categories"][number];
+
+describe("DrillableDonutChart", () => {
+  it("renders the center label for a single category", () => {
+    const { container } = render(
+      <DrillableDonutChart title="Regions" allocation={regions([AMERICAS])} baseCurrency="USD" />,
+    );
+    expect(container.textContent).toContain("Americas");
+  });
+});
+
+describe("DonutChart center label", () => {
+  const one = [{ name: "Americas", value: 638300, currency: "USD" }];
+  const two = [...one, { name: "Europe", value: 425533, currency: "USD" }];
+
+  it("labels the selected slice", () => {
+    const { container } = render(<DonutChart data={two} activeIndex={1} />);
+    expect(container.textContent).toContain("Europe");
+  });
+
+  // A selected slice can disappear while the chart stays mounted (asset re-classified,
+  // account scope narrowed, background refetch). The label must survive that.
+  it("falls back to a valid slice when the selection is past the end of the data", () => {
+    const { container } = render(<DonutChart data={one} activeIndex={1} />);
+    expect(container.textContent).toContain("Americas");
+  });
+
+  it("keeps a label after the data shrinks below the selected index", () => {
+    const { container, rerender } = render(<DonutChart data={two} activeIndex={1} />);
+    expect(container.textContent).toContain("Europe");
+
+    rerender(<DonutChart data={one} activeIndex={1} />);
+    expect(container.textContent).toContain("Americas");
+  });
+
+  it("renders no label when there is no data", () => {
+    const { container } = render(<DonutChart data={[]} activeIndex={0} />);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/apps/frontend/src/pages/holdings/components/drillable-donut-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/drillable-donut-chart.tsx
@@ -82,6 +82,15 @@ export function DrillableDonutChart({
 
   const data = isAtRoot ? rootData : drilledData;
 
+  // The selection points at a category, not at a position — reset it when the categories
+  // change (re-classification, account-scope change) instead of pointing at a new one.
+  const categoryKey = data.map((item) => item.id).join("|");
+  const [renderedCategoryKey, setRenderedCategoryKey] = useState(categoryKey);
+  if (categoryKey !== renderedCategoryKey) {
+    setRenderedCategoryKey(categoryKey);
+    setActiveIndex(0);
+  }
+
   const handleSectionClick = (
     sectionData: { name: string; value: number; currency: string },
     index: number,

--- a/packages/ui/src/components/common/donut-chart.tsx
+++ b/packages/ui/src/components/common/donut-chart.tsx
@@ -117,6 +117,14 @@ export const DonutChart: React.FC<DonutChartProps> = ({
   const { isBalanceHidden } = useBalancePrivacy();
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
 
+  // Hovering points at a slice, not at a position: drop it when the slices change.
+  const sliceKey = data.map((item) => item.name).join("|");
+  const [renderedSliceKey, setRenderedSliceKey] = useState(sliceKey);
+  if (sliceKey !== renderedSliceKey) {
+    setRenderedSliceKey(sliceKey);
+    setHoverIndex(null);
+  }
+
   const handlePieEnter = (_: React.MouseEvent, index: number) => {
     setHoverIndex(index);
   };
@@ -126,7 +134,9 @@ export const DonutChart: React.FC<DonutChartProps> = ({
   };
 
   const totalValue = useMemo(() => data.reduce((acc, item) => acc + item.value, 0), [data]);
-  const displayIndex = hoverIndex ?? activeIndex;
+  // Clamp: the selected index outlives the data it was picked from (re-classification,
+  // account-scope change, refetch), and an out-of-range index blanks the center label.
+  const displayIndex = Math.min(hoverIndex ?? activeIndex, data.length - 1);
   const activeData = data[displayIndex];
 
   const tooltipFormatter = (


### PR DESCRIPTION
Fixes #1495 where the `/insights` Regions card rendering an arc with no name, value, or percentage.

## Problem

`DonutChart` looked its center label up by index with no range check:

    const displayIndex = hoverIndex ?? activeIndex;
    const activeData = data[displayIndex];

`ChartCenterLabel` bails out on an undefined `activeData`, but `<Pie>` still draws the arc — so
the card shows a chart with no label, and no active-slice ring either (the out-of-range
`activeIndex` means recharts renders no active shape).

The index lives in `DrillableDonutChart` / `DrillableAccountChart` and was only reset on
drill-down and breadcrumb navigation, never when the allocation itself changed. Select a slice,
then let the data shrink below that index while the page stays mounted — re-classify an asset,
narrow the account scope, or hit a background refetch — and the card stays blank until it
remounts. A portfolio with a single category (one holding, one region) is the worst case: any
previously selected index is dead.

## Change

- `packages/ui/src/components/common/donut-chart.tsx` — clamp `displayIndex` to
  `data.length - 1`, and drop `hoverIndex` when the slice set changes.
- `apps/frontend/src/pages/holdings/components/drillable-donut-chart.tsx`,
  `drillable-account-chart.tsx` — reset `activeIndex` when the category/account identities
  change, so the selection resets instead of silently sliding onto a different category.

Reset is done with the render-phase "adjust state when props change" pattern, not an effect.

## Tests

`apps/frontend/src/pages/holdings/components/drillable-donut-chart.test.tsx` — 5 cases: single
category renders a label, selected slice is labelled, an out-of-range selection falls back to a
valid slice, the label survives the data shrinking below the selected index, and an empty chart
still renders no label. The out-of-range and shrink cases fail without this fix.

## Verification

- New unit tests pass; `pages/holdings` + `pages/allocation-targets` suites pass (32 tests).
- `pnpm type-check` clean, `pnpm lint` clean (0 errors).
- Full frontend suite: 1426 passed. 7 pre-existing failures in `src/addons/iframe/*` (present on
  a clean tree, Blob/fetch jsdom env), plus one load-dependent flake in
  `custom-provider-form.test.tsx` that passes on its own.
- End-to-end against a real server + seeded DB in a container: reproduced the blank card via the
  click-then-reclassify sequence, then confirmed the card renders `Americas / (100.00%)` after
  the fix, with the selection resetting to the first slice rather than sliding.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
