### PR TITLE
fix(allocation): Account for the unclassified remainder in category drill-downs

### DIFF
--- a/apps/frontend/src/i18n/locales/de/common.json
+++ b/apps/frontend/src/i18n/locales/de/common.json
@@ -364,5 +364,6 @@
   "navStyle": {
     "sidebar": "Seitenleiste",
     "floating": "Schwebeleiste"
-  }
+  },
+  "allocation_other_in_category": "Andere {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/de/common.json
+++ b/apps/frontend/src/i18n/locales/de/common.json
@@ -365,5 +365,5 @@
     "sidebar": "Seitenleiste",
     "floating": "Schwebeleiste"
   },
-  "allocation_other_in_category": "Andere {{category}}"
+  "allocation_other_in_category": "Sonstige ({{category}})"
 }

--- a/apps/frontend/src/i18n/locales/de/common.json
+++ b/apps/frontend/src/i18n/locales/de/common.json
@@ -363,5 +363,6 @@
   "navStyle": {
     "sidebar": "Seitenleiste",
     "floating": "Schwebeleiste"
-  }
+  },
+  "allocation_other_in_category": "Andere {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/en/common.json
+++ b/apps/frontend/src/i18n/locales/en/common.json
@@ -364,5 +364,6 @@
   "navStyle": {
     "sidebar": "Sidebar",
     "floating": "Floating Bar"
-  }
+  },
+  "allocation_other_in_category": "Other {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/en/common.json
+++ b/apps/frontend/src/i18n/locales/en/common.json
@@ -363,5 +363,6 @@
   "navStyle": {
     "sidebar": "Sidebar",
     "floating": "Floating Bar"
-  }
+  },
+  "allocation_other_in_category": "Other {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/es/common.json
+++ b/apps/frontend/src/i18n/locales/es/common.json
@@ -379,5 +379,5 @@
     "sidebar": "Barra lateral",
     "floating": "Barra flotante"
   },
-  "allocation_other_in_category": "Otro {{category}}"
+  "allocation_other_in_category": "Otros ({{category}})"
 }

--- a/apps/frontend/src/i18n/locales/es/common.json
+++ b/apps/frontend/src/i18n/locales/es/common.json
@@ -378,5 +378,6 @@
   "navStyle": {
     "sidebar": "Barra lateral",
     "floating": "Barra flotante"
-  }
+  },
+  "allocation_other_in_category": "Otro {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/es/common.json
+++ b/apps/frontend/src/i18n/locales/es/common.json
@@ -363,5 +363,6 @@
   "navStyle": {
     "sidebar": "Barra lateral",
     "floating": "Barra flotante"
-  }
+  },
+  "allocation_other_in_category": "Otro {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/fr/common.json
+++ b/apps/frontend/src/i18n/locales/fr/common.json
@@ -378,5 +378,6 @@
   "navStyle": {
     "sidebar": "Barre latérale",
     "floating": "Barre flottante"
-  }
+  },
+  "allocation_other_in_category": "Autre {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/fr/common.json
+++ b/apps/frontend/src/i18n/locales/fr/common.json
@@ -379,5 +379,5 @@
     "sidebar": "Barre latérale",
     "floating": "Barre flottante"
   },
-  "allocation_other_in_category": "Autre {{category}}"
+  "allocation_other_in_category": "Autres ({{category}})"
 }

--- a/apps/frontend/src/i18n/locales/fr/common.json
+++ b/apps/frontend/src/i18n/locales/fr/common.json
@@ -363,5 +363,6 @@
   "navStyle": {
     "sidebar": "Barre latérale",
     "floating": "Barre flottante"
-  }
+  },
+  "allocation_other_in_category": "Autre {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/it/common.json
+++ b/apps/frontend/src/i18n/locales/it/common.json
@@ -378,5 +378,6 @@
   "navStyle": {
     "sidebar": "Barra laterale",
     "floating": "Barra flottante"
-  }
+  },
+  "allocation_other_in_category": "Altri ({{category}})"
 }

--- a/apps/frontend/src/i18n/locales/ja/common.json
+++ b/apps/frontend/src/i18n/locales/ja/common.json
@@ -355,5 +355,6 @@
   "navStyle": {
     "sidebar": "サイドバー",
     "floating": "フローティングバー"
-  }
+  },
+  "allocation_other_in_category": "その他の{{category}}"
 }

--- a/apps/frontend/src/i18n/locales/ja/common.json
+++ b/apps/frontend/src/i18n/locales/ja/common.json
@@ -354,5 +354,6 @@
   "navStyle": {
     "sidebar": "サイドバー",
     "floating": "フローティングバー"
-  }
+  },
+  "allocation_other_in_category": "その他の{{category}}"
 }

--- a/apps/frontend/src/i18n/locales/ko/common.json
+++ b/apps/frontend/src/i18n/locales/ko/common.json
@@ -355,5 +355,6 @@
   "navStyle": {
     "sidebar": "사이드바",
     "floating": "플로팅 바"
-  }
+  },
+  "allocation_other_in_category": "기타 {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/ko/common.json
+++ b/apps/frontend/src/i18n/locales/ko/common.json
@@ -354,5 +354,6 @@
   "navStyle": {
     "sidebar": "사이드바",
     "floating": "플로팅 바"
-  }
+  },
+  "allocation_other_in_category": "기타 {{category}}"
 }

--- a/apps/frontend/src/i18n/locales/pt/common.json
+++ b/apps/frontend/src/i18n/locales/pt/common.json
@@ -378,5 +378,6 @@
   "navStyle": {
     "sidebar": "Barra lateral",
     "floating": "Barra flutuante"
-  }
+  },
+  "allocation_other_in_category": "Outros ({{category}})"
 }

--- a/apps/frontend/src/i18n/locales/zh/common.json
+++ b/apps/frontend/src/i18n/locales/zh/common.json
@@ -355,5 +355,6 @@
   "navStyle": {
     "sidebar": "侧边栏",
     "floating": "浮动栏"
-  }
+  },
+  "allocation_other_in_category": "其他{{category}}"
 }

--- a/apps/frontend/src/i18n/locales/zh/common.json
+++ b/apps/frontend/src/i18n/locales/zh/common.json
@@ -354,5 +354,6 @@
   "navStyle": {
     "sidebar": "侧边栏",
     "floating": "浮动栏"
-  }
+  },
+  "allocation_other_in_category": "其他{{category}}"
 }

--- a/apps/frontend/src/lib/allocation-children.test.ts
+++ b/apps/frontend/src/lib/allocation-children.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { CategoryAllocation } from "@/lib/types";
+import { isResidualCategoryId, namedChildren } from "./allocation-children";
+
+const residualName = (name: string) => `Other ${name}`;
+
+const fixedIncome: CategoryAllocation = {
+  categoryId: "FIXED_INCOME",
+  categoryName: "Fixed Income",
+  color: "#d14d41",
+  value: 2000,
+  percentage: 20,
+  children: [
+    {
+      categoryId: "FI_MUNICIPAL",
+      categoryName: "Municipal Bonds",
+      color: "#d14d41",
+      value: 1200,
+      percentage: 12,
+      children: [],
+    },
+    {
+      categoryId: "FIXED_INCOME:__residual__",
+      categoryName: "Other Fixed Income",
+      color: "#d14d41",
+      value: 800,
+      percentage: 8,
+      children: [],
+    },
+  ],
+};
+
+describe("namedChildren", () => {
+  it("renames the residual row after its parent, leaving real categories alone", () => {
+    const children = namedChildren(fixedIncome, residualName);
+
+    expect(children.map((c) => c.categoryName)).toEqual(["Municipal Bonds", "Other Fixed Income"]);
+    expect(children[1].value).toBe(800);
+    expect(children.reduce((sum, c) => sum + c.value, 0)).toBe(2000);
+  });
+
+  it("uses the localized parent name, not the backend fallback", () => {
+    const [, residual] = namedChildren(fixedIncome, (name) => `Autre ${name}`);
+
+    expect(residual.categoryName).toBe("Autre Fixed Income");
+    expect(residual.categoryId).toBe("FIXED_INCOME:__residual__");
+  });
+
+  it("returns an empty list for a leaf category", () => {
+    expect(namedChildren({ ...fixedIncome, children: [] }, residualName)).toEqual([]);
+    expect(namedChildren({ ...fixedIncome, children: undefined }, residualName)).toEqual([]);
+  });
+
+  it("recognizes residual ids", () => {
+    expect(isResidualCategoryId("FIXED_INCOME:__residual__")).toBe(true);
+    expect(isResidualCategoryId("FI_MUNICIPAL")).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/allocation-children.test.ts
+++ b/apps/frontend/src/lib/allocation-children.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CategoryAllocation } from "@/lib/types";
-import { isResidualCategoryId, namedChildren } from "./allocation-children";
+import { namedChildren } from "./allocation-children";
 
 const residualName = (name: string) => `Other ${name}`;
 
@@ -26,6 +26,7 @@ const fixedIncome: CategoryAllocation = {
       value: 800,
       percentage: 8,
       children: [],
+      isResidual: true,
     },
   ],
 };
@@ -46,13 +47,17 @@ describe("namedChildren", () => {
     expect(residual.categoryId).toBe("FIXED_INCOME:__residual__");
   });
 
+  it("leaves a child alone when the id looks residual but the flag is absent", () => {
+    const [child] = namedChildren(
+      { ...fixedIncome, children: [{ ...fixedIncome.children![1], isResidual: undefined }] },
+      () => "RENAMED",
+    );
+
+    expect(child.categoryName).toBe("Other Fixed Income");
+  });
+
   it("returns an empty list for a leaf category", () => {
     expect(namedChildren({ ...fixedIncome, children: [] }, residualName)).toEqual([]);
     expect(namedChildren({ ...fixedIncome, children: undefined }, residualName)).toEqual([]);
-  });
-
-  it("recognizes residual ids", () => {
-    expect(isResidualCategoryId("FIXED_INCOME:__residual__")).toBe(true);
-    expect(isResidualCategoryId("FI_MUNICIPAL")).toBe(false);
   });
 });

--- a/apps/frontend/src/lib/allocation-children.ts
+++ b/apps/frontend/src/lib/allocation-children.ts
@@ -1,25 +1,23 @@
 import type { CategoryAllocation } from "@/lib/types";
 
-/** Mirrors `RESIDUAL_CATEGORY_SUFFIX` in `crates/core/src/portfolio/allocation/allocation_service.rs`. */
-const RESIDUAL_SUFFIX = ":__residual__";
-
 /**
- * A residual row holds the part of a category carrying no sub-category assignment (e.g. holdings
+ * A residual child holds the part of a category carrying no sub-category assignment (e.g. holdings
  * classified as "Fixed Income" but no bond type). The backend emits it so drill-downs always
- * account for their parent, naming it in English for consumers that don't know the marker.
+ * account for their parent, flagging it with `isResidual` and naming it in English for consumers
+ * that render the raw response.
  */
-export function isResidualCategoryId(categoryId: string): boolean {
-  return categoryId.endsWith(RESIDUAL_SUFFIX);
+export function namedChild(
+  parent: CategoryAllocation,
+  child: CategoryAllocation,
+  residualName: (categoryName: string) => string,
+): CategoryAllocation {
+  return child.isResidual ? { ...child, categoryName: residualName(parent.categoryName) } : child;
 }
 
 /** Drill-down children of a category, with any residual row renamed in the user's language. */
 export function namedChildren(
-  category: CategoryAllocation,
+  parent: CategoryAllocation,
   residualName: (categoryName: string) => string,
 ): CategoryAllocation[] {
-  return (category.children ?? []).map((child) =>
-    isResidualCategoryId(child.categoryId)
-      ? { ...child, categoryName: residualName(category.categoryName) }
-      : child,
-  );
+  return (parent.children ?? []).map((child) => namedChild(parent, child, residualName));
 }

--- a/apps/frontend/src/lib/allocation-children.ts
+++ b/apps/frontend/src/lib/allocation-children.ts
@@ -1,0 +1,25 @@
+import type { CategoryAllocation } from "@/lib/types";
+
+/** Mirrors `RESIDUAL_CATEGORY_SUFFIX` in `crates/core/src/portfolio/allocation/allocation_service.rs`. */
+const RESIDUAL_SUFFIX = ":__residual__";
+
+/**
+ * A residual row holds the part of a category carrying no sub-category assignment (e.g. holdings
+ * classified as "Fixed Income" but no bond type). The backend emits it so drill-downs always
+ * account for their parent, naming it in English for consumers that don't know the marker.
+ */
+export function isResidualCategoryId(categoryId: string): boolean {
+  return categoryId.endsWith(RESIDUAL_SUFFIX);
+}
+
+/** Drill-down children of a category, with any residual row renamed in the user's language. */
+export function namedChildren(
+  category: CategoryAllocation,
+  residualName: (categoryName: string) => string,
+): CategoryAllocation[] {
+  return (category.children ?? []).map((child) =>
+    isResidualCategoryId(child.categoryId)
+      ? { ...child, categoryName: residualName(category.categoryName) }
+      : child,
+  );
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1907,6 +1907,7 @@ export interface CategoryAllocation {
   value: number; // Base currency value
   percentage: number; // 0-100
   children?: CategoryAllocation[]; // Child allocations for drill-down
+  isResidual?: boolean; // True for the synthetic "rest of the parent" drill-down child
 }
 
 export interface TaxonomyAllocation {

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { getHoldingsByAllocation } from "@/adapters";
-import { namedChildren } from "@/lib/allocation-children";
+import { namedChild, namedChildren } from "@/lib/allocation-children";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { HoldingType } from "@/lib/constants";
 import type {
@@ -70,10 +70,9 @@ export function AllocationDetailSheet({
       // If not a top-level, search children to find the parent
       if (!category && categoryId) {
         for (const parent of allocation.categories) {
-          childMatch = namedChildren(parent, residualName).find(
-            (child) => child.categoryId === categoryId,
-          );
-          if (childMatch) {
+          const match = parent.children?.find((child) => child.categoryId === categoryId);
+          if (match) {
+            childMatch = namedChild(parent, match, residualName);
             category = parent;
             break;
           }

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
 import { getHoldingsByAllocation } from "@/adapters";
+import { namedChildren } from "@/lib/allocation-children";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { HoldingType } from "@/lib/constants";
 import type {
@@ -53,6 +54,11 @@ export function AllocationDetailSheet({
   const [selectedColor, setSelectedColor] = useState<string | null>(null);
   const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
 
+  const residualName = useCallback(
+    (categoryName: string) => t("common:allocation_other_in_category", { category: categoryName }),
+    [t],
+  );
+
   // Set initial category when sheet opens
   useEffect(() => {
     if (isOpen && allocation?.categories?.length) {
@@ -64,7 +70,9 @@ export function AllocationDetailSheet({
       // If not a top-level, search children to find the parent
       if (!category && categoryId) {
         for (const parent of allocation.categories) {
-          childMatch = parent.children?.find((child) => child.categoryId === categoryId);
+          childMatch = namedChildren(parent, residualName).find(
+            (child) => child.categoryId === categoryId,
+          );
           if (childMatch) {
             category = parent;
             break;
@@ -90,7 +98,7 @@ export function AllocationDetailSheet({
         }
       }
     }
-  }, [isOpen, initialCategoryId, allocation?.categories]);
+  }, [isOpen, initialCategoryId, allocation?.categories, residualName]);
 
   const taxonomyId = allocation?.taxonomyId ?? "";
   const categoryId = selectedCategoryId ?? "";
@@ -282,7 +290,7 @@ export function AllocationDetailSheet({
                           <div
                             className={`bg-muted/30 ${!(isLast && isExpanded) ? "border-t" : ""}`}
                           >
-                            {category.children!.map((child, childIdx) => {
+                            {namedChildren(category, residualName).map((child, childIdx) => {
                               const isChildSelected = selectedCategoryId === child.categoryId;
 
                               return (

--- a/apps/frontend/src/pages/holdings/components/drillable-donut-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/drillable-donut-chart.tsx
@@ -1,5 +1,6 @@
 import { AllocationBreadcrumb } from "@/components/allocation-breadcrumb";
 import { useDrillDownState } from "@/hooks/use-drill-down-state";
+import { namedChildren } from "@/lib/allocation-children";
 import type { TaxonomyAllocation, CategoryAllocation } from "@/lib/types";
 import {
   Card,
@@ -68,7 +69,9 @@ export function DrillableDonutChart({
 
     if (!category?.children?.length) return [];
 
-    return category.children
+    return namedChildren(category, (name) =>
+      t("common:allocation_other_in_category", { category: name }),
+    )
       .filter((child) => child.value > 0)
       .map((child) => ({
         id: child.categoryId,
@@ -78,7 +81,7 @@ export function DrillableDonutChart({
         color: child.color,
       }))
       .sort((a, b) => b.value - a.value);
-  }, [path, allocation, baseCurrency]);
+  }, [path, allocation, baseCurrency, t]);
 
   const data = isAtRoot ? rootData : drilledData;
 

--- a/apps/frontend/src/pages/insights/overview/allocation-derivations.ts
+++ b/apps/frontend/src/pages/insights/overview/allocation-derivations.ts
@@ -5,6 +5,7 @@ import type {
   CurrentValuationSummary,
   Holding,
 } from "@/lib/types";
+import { namedChildren } from "@/lib/allocation-children";
 import type { FormattingApi } from "@wealthfolio/ui";
 
 /** Cycling palette built from the theme chart tokens (retargeted to the allocation palette). */
@@ -218,10 +219,12 @@ export interface BreakdownNode {
 /**
  * Build a colored breakdown tree from a taxonomy's categories. Top-level nodes get distinct
  * theme chart colors; descendants inherit their parent's color so each branch reads as one family.
+ * `residualName` labels the unassigned remainder of a category (see `withResidualChild`).
  */
 export function buildBreakdownTree(
   categories: CategoryAllocation[] | undefined,
   total: number,
+  residualName: (categoryName: string) => string,
   depth = 0,
   inheritedColor?: string,
 ): BreakdownNode[] {
@@ -231,6 +234,7 @@ export function buildBreakdownTree(
     .sort((a, b) => b.value - a.value)
     .map((c, index) => {
       const color = depth === 0 ? paletteColor(index) : (inheritedColor ?? paletteColor(index));
+      const children = namedChildren(c, residualName);
       return {
         id: c.categoryId,
         name: c.categoryName,
@@ -238,8 +242,8 @@ export function buildBreakdownTree(
         percentage: total > 0 ? (c.value / total) * 100 : 0,
         color,
         depth,
-        children: c.children?.length
-          ? buildBreakdownTree(c.children, total, depth + 1, color)
+        children: children.length
+          ? buildBreakdownTree(children, total, residualName, depth + 1, color)
           : undefined,
       };
     });

--- a/apps/frontend/src/pages/insights/overview/portfolio-explorer.tsx
+++ b/apps/frontend/src/pages/insights/overview/portfolio-explorer.tsx
@@ -100,12 +100,13 @@ function taxonomyLens(
   label: string,
   unit: string,
   allocation: TaxonomyAllocation | undefined,
+  residualName: (categoryName: string) => string,
 ): Lens {
   return {
     key,
     label,
     unit,
-    nodes: buildBreakdownTree(allocation?.categories, sumOfCategories(allocation)),
+    nodes: buildBreakdownTree(allocation?.categories, sumOfCategories(allocation), residualName),
     allocation,
   };
 }
@@ -146,12 +147,15 @@ export function PortfolioExplorer({
   const accountValues = accountValuations ?? performance;
 
   const lenses = useMemo<Lens[]>(() => {
+    const residualName = (categoryName: string) =>
+      t("common:allocation_other_in_category", { category: categoryName });
     const list: Lens[] = [
       taxonomyLens(
         "allocation",
         t("insights:insights.explorer.lens_allocation"),
         t("insights:insights.explorer.unit_categories"),
         allocations?.assetClasses,
+        residualName,
       ),
       accountsLens(
         t("insights:insights.explorer.lens_accounts"),
@@ -163,24 +167,28 @@ export function PortfolioExplorer({
         t("insights:insights.explorer.lens_sectors"),
         t("insights:insights.explorer.unit_sectors"),
         allocations?.sectors,
+        residualName,
       ),
       taxonomyLens(
         "regions",
         t("insights:insights.explorer.lens_regions"),
         t("insights:insights.explorer.unit_regions"),
         allocations?.regions,
+        residualName,
       ),
       taxonomyLens(
         "risk",
         t("insights:insights.explorer.lens_risk"),
         t("insights:insights.explorer.unit_levels"),
         allocations?.riskCategory,
+        residualName,
       ),
       taxonomyLens(
         "security",
         t("insights:insights.explorer.lens_security"),
         t("insights:insights.explorer.unit_types"),
         allocations?.securityTypes,
+        residualName,
       ),
       {
         key: "currency",
@@ -198,6 +206,7 @@ export function PortfolioExplorer({
             taxonomy.taxonomyName,
             t("insights:insights.explorer.unit_groups"),
             taxonomy,
+            residualName,
           ),
         );
       }

--- a/apps/frontend/src/pages/insights/overview/portfolio-explorer.tsx
+++ b/apps/frontend/src/pages/insights/overview/portfolio-explorer.tsx
@@ -98,12 +98,13 @@ function taxonomyLens(
   label: string,
   unit: string,
   allocation: TaxonomyAllocation | undefined,
+  residualName: (categoryName: string) => string,
 ): Lens {
   return {
     key,
     label,
     unit,
-    nodes: buildBreakdownTree(allocation?.categories, sumOfCategories(allocation)),
+    nodes: buildBreakdownTree(allocation?.categories, sumOfCategories(allocation), residualName),
     allocation,
   };
 }
@@ -133,12 +134,15 @@ export function PortfolioExplorer({
   const accountValues = accountValuations ?? performance;
 
   const lenses = useMemo<Lens[]>(() => {
+    const residualName = (categoryName: string) =>
+      t("common:allocation_other_in_category", { category: categoryName });
     const list: Lens[] = [
       taxonomyLens(
         "allocation",
         t("insights:insights.explorer.lens_allocation"),
         t("insights:insights.explorer.unit_categories"),
         allocations?.assetClasses,
+        residualName,
       ),
       {
         key: "accounts",
@@ -151,24 +155,28 @@ export function PortfolioExplorer({
         t("insights:insights.explorer.lens_sectors"),
         t("insights:insights.explorer.unit_sectors"),
         allocations?.sectors,
+        residualName,
       ),
       taxonomyLens(
         "regions",
         t("insights:insights.explorer.lens_regions"),
         t("insights:insights.explorer.unit_regions"),
         allocations?.regions,
+        residualName,
       ),
       taxonomyLens(
         "risk",
         t("insights:insights.explorer.lens_risk"),
         t("insights:insights.explorer.unit_levels"),
         allocations?.riskCategory,
+        residualName,
       ),
       taxonomyLens(
         "security",
         t("insights:insights.explorer.lens_security"),
         t("insights:insights.explorer.unit_types"),
         allocations?.securityTypes,
+        residualName,
       ),
       {
         key: "currency",
@@ -186,6 +194,7 @@ export function PortfolioExplorer({
             taxonomy.taxonomyName,
             t("insights:insights.explorer.unit_groups"),
             taxonomy,
+            residualName,
           ),
         );
       }

--- a/crates/core/src/portfolio/allocation/allocation_model.rs
+++ b/crates/core/src/portfolio/allocation/allocation_model.rs
@@ -20,6 +20,11 @@ pub struct CategoryAllocation {
     /// Child category allocations (for drill-down). Only populated for rolled-up categories.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub children: Vec<CategoryAllocation>,
+    /// True for the synthetic child holding the part of a parent that carries no sub-category
+    /// assignment. Consumers should label it after its parent rather than trusting
+    /// `category_name`, which is an English fallback.
+    #[serde(default)]
+    pub is_residual: bool,
 }
 
 /// Allocation breakdown for a single taxonomy.

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -31,6 +31,18 @@ const RESIDUAL_TOLERANCE_BPS: i32 = 75;
 /// `source` written by auto-classification (`crates/core/src/assets/auto_classification.rs`).
 const AUTO_SOURCE: &str = "AUTO";
 
+/// Suffix marking the drill-down child that holds the part of a rolled-up category carrying no
+/// sub-category assignment (e.g. holdings classified as "Fixed Income" but no bond type). Without
+/// it a category's children silently understate their parent, and a UI dividing by the children it
+/// received reports the largest one as 100%. The id is `<parent id><suffix>`; consumers that need
+/// the parent strip the suffix. Callers render their own label — `category_name` is an English
+/// fallback for consumers that do not know the marker.
+pub const RESIDUAL_CATEGORY_SUFFIX: &str = ":__residual__";
+
+/// Residual shares below this fraction of the parent are rounding noise, not an unassigned
+/// remainder — weights are stored in basis points, so a real remainder is far larger.
+const RESIDUAL_CHILD_MIN_SHARE: Decimal = dec!(0.0001);
+
 #[derive(Debug, Clone)]
 struct HoldingTaxonomyShare {
     category_id: String,
@@ -642,7 +654,15 @@ impl AllocationService {
                     Decimal::ZERO
                 };
 
-                let children = children_map.remove(&cat_id).unwrap_or_default();
+                let mut children = children_map.remove(&cat_id).unwrap_or_default();
+                Self::push_residual_child(
+                    &mut children,
+                    &cat_id,
+                    &name,
+                    &color,
+                    value,
+                    total_value,
+                );
 
                 CategoryAllocation {
                     category_id: cat_id,
@@ -667,6 +687,42 @@ impl AllocationService {
             color: taxonomy_color.to_string(),
             categories: allocations,
         }
+    }
+
+    /// Appends the residual child for a rolled-up category: the part of its value that carries no
+    /// sub-category assignment. No-op for leaf categories (nothing to understate) and for
+    /// categories whose children already account for the whole value.
+    fn push_residual_child(
+        children: &mut Vec<CategoryAllocation>,
+        category_id: &str,
+        category_name: &str,
+        color: &str,
+        value: Decimal,
+        total_value: Decimal,
+    ) {
+        if children.is_empty() {
+            return;
+        }
+        let assigned: Decimal = children.iter().map(|child| child.value).sum();
+        let residual = value - assigned;
+        if residual <= value * RESIDUAL_CHILD_MIN_SHARE {
+            return;
+        }
+
+        let percentage = if total_value > Decimal::ZERO {
+            (residual / total_value * dec!(100)).round_dp(2)
+        } else {
+            Decimal::ZERO
+        };
+
+        children.push(CategoryAllocation {
+            category_id: format!("{category_id}{RESIDUAL_CATEGORY_SUFFIX}"),
+            category_name: format!("Other {category_name}"),
+            color: color.to_string(),
+            value: residual,
+            percentage,
+            children: Vec::new(),
+        });
     }
 
     /// Builds a map from each category to its top-level ancestor.
@@ -983,14 +1039,24 @@ impl AllocationService {
             ),
         };
 
-        let (category_name, category_color) = if category_id == "__UNKNOWN__" {
+        // A residual id addresses the part of its parent that carries no sub-category assignment;
+        // everything below resolves against the parent, then filters down to those holdings.
+        let residual_parent_id = category_id.strip_suffix(RESIDUAL_CATEGORY_SUFFIX);
+        let lookup_id = residual_parent_id.unwrap_or(category_id);
+
+        let (category_name, category_color) = if lookup_id == "__UNKNOWN__" {
             ("Unknown".to_string(), "#878580".to_string())
         } else {
             categories
                 .iter()
-                .find(|c| c.id == category_id)
+                .find(|c| c.id == lookup_id)
                 .map(|c| (c.name.clone(), c.color.clone()))
-                .unwrap_or_else(|| (category_id.to_string(), taxonomy_color.clone()))
+                .unwrap_or_else(|| (lookup_id.to_string(), taxonomy_color.clone()))
+        };
+        let category_name = if residual_parent_id.is_some() {
+            format!("Other {category_name}")
+        } else {
+            category_name
         };
 
         if holdings.is_empty() {
@@ -1031,8 +1097,15 @@ impl AllocationService {
 
             let matched_share: Decimal = shares
                 .into_iter()
-                .filter(|share| {
-                    share.category_id == category_id || share.assigned_category_id == category_id
+                .filter(|share| match residual_parent_id {
+                    // Residual: assigned to the parent itself, with no sub-category to roll up.
+                    Some(parent) => {
+                        share.category_id == parent && share.assigned_category_id == parent
+                    }
+                    None => {
+                        share.category_id == category_id
+                            || share.assigned_category_id == category_id
+                    }
                 })
                 .map(|share| share.share)
                 .sum();
@@ -1960,6 +2033,211 @@ mod tests {
             "Expected Americas = 400 (leaf US only), got {}",
             americas.value
         );
+    }
+
+    #[test]
+    fn top_level_only_assignments_become_a_residual_child() {
+        let svc = svc();
+        // MUNI carries a sub-class; TBILL is classified as Fixed Income and nothing finer.
+        let holdings = vec![
+            make_holding("MUNI", dec!(1200)),
+            make_holding("TBILL", dec!(800)),
+        ];
+        let categories = vec![
+            make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+            make_category_for_taxonomy("asset_classes", "FI_MUNICIPAL", Some("FIXED_INCOME")),
+        ];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([
+            (
+                "MUNI".to_string(),
+                vec![make_assignment(
+                    "MUNI",
+                    "asset_classes",
+                    "FI_MUNICIPAL",
+                    10000,
+                )],
+            ),
+            (
+                "TBILL".to_string(),
+                vec![make_assignment(
+                    "TBILL",
+                    "asset_classes",
+                    "FIXED_INCOME",
+                    10000,
+                )],
+            ),
+        ]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(2000),
+            true,
+            &HashMap::new(),
+        );
+
+        let fixed_income = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "FIXED_INCOME")
+            .expect("Fixed Income category missing");
+        let residual = fixed_income
+            .children
+            .iter()
+            .find(|c| c.category_id == format!("FIXED_INCOME{RESIDUAL_CATEGORY_SUFFIX}"))
+            .expect("residual child missing");
+
+        assert_eq!(residual.value, dec!(800));
+        assert_eq!(residual.percentage, dec!(40));
+        assert_eq!(residual.category_name, "Other FIXED_INCOME");
+        // The whole point: children now account for the parent.
+        let children_total: Decimal = fixed_income.children.iter().map(|c| c.value).sum();
+        assert_eq!(children_total, fixed_income.value);
+    }
+
+    #[test]
+    fn no_residual_child_when_children_cover_the_parent() {
+        let svc = svc();
+        let holdings = vec![make_holding("MUNI", dec!(1200))];
+        let categories = vec![
+            make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+            make_category_for_taxonomy("asset_classes", "FI_MUNICIPAL", Some("FIXED_INCOME")),
+        ];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([(
+            "MUNI".to_string(),
+            vec![make_assignment(
+                "MUNI",
+                "asset_classes",
+                "FI_MUNICIPAL",
+                10000,
+            )],
+        )]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1200),
+            true,
+            &HashMap::new(),
+        );
+
+        let fixed_income = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "FIXED_INCOME")
+            .expect("Fixed Income category missing");
+
+        assert_eq!(fixed_income.children.len(), 1);
+        assert_eq!(fixed_income.children[0].category_id, "FI_MUNICIPAL");
+    }
+
+    #[test]
+    fn leaf_categories_get_no_residual_child() {
+        let svc = svc();
+        let holdings = vec![make_holding("VOO", dec!(1000))];
+        let categories = vec![make_category_for_taxonomy("asset_classes", "EQUITY", None)];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([(
+            "VOO".to_string(),
+            vec![make_assignment("VOO", "asset_classes", "EQUITY", 10000)],
+        )]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1000),
+            true,
+            &HashMap::new(),
+        );
+
+        let equity = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "EQUITY")
+            .expect("Equity category missing");
+        assert!(equity.children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn holdings_by_allocation_returns_only_the_residual_holdings() {
+        let holdings = vec![
+            make_holding("MUNI", dec!(1200)),
+            make_holding("TBILL", dec!(800)),
+        ];
+        let taxonomies = StaticTaxonomies {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy: make_taxonomy("asset_classes", "Asset Classes", true),
+                categories: vec![
+                    make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+                    make_category_for_taxonomy(
+                        "asset_classes",
+                        "FI_MUNICIPAL",
+                        Some("FIXED_INCOME"),
+                    ),
+                ],
+            }],
+            assignments_by_asset: HashMap::from([
+                (
+                    "MUNI".to_string(),
+                    vec![make_assignment(
+                        "MUNI",
+                        "asset_classes",
+                        "FI_MUNICIPAL",
+                        10000,
+                    )],
+                ),
+                (
+                    "TBILL".to_string(),
+                    vec![make_assignment(
+                        "TBILL",
+                        "asset_classes",
+                        "FIXED_INCOME",
+                        10000,
+                    )],
+                ),
+            ]),
+        };
+        let svc = AllocationService::new(Arc::new(NoopHoldings), Arc::new(taxonomies));
+
+        let residual = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                &format!("FIXED_INCOME{RESIDUAL_CATEGORY_SUFFIX}"),
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+        let parent = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "FIXED_INCOME",
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        // The residual holds the top-level-only holding, not the whole class.
+        assert_eq!(residual.total_value, dec!(800));
+        assert_eq!(residual.holdings.len(), 1);
+        assert_eq!(residual.holdings[0].symbol, "TBILL");
+        assert_eq!(residual.category_name, "Other FIXED_INCOME");
+        assert_eq!(parent.total_value, dec!(2000));
+        assert_eq!(parent.holdings.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -31,16 +31,16 @@ const RESIDUAL_TOLERANCE_BPS: i32 = 75;
 /// `source` written by auto-classification (`crates/core/src/assets/auto_classification.rs`).
 const AUTO_SOURCE: &str = "AUTO";
 
-/// Suffix marking the drill-down child that holds the part of a rolled-up category carrying no
-/// sub-category assignment (e.g. holdings classified as "Fixed Income" but no bond type). Without
-/// it a category's children silently understate their parent, and a UI dividing by the children it
-/// received reports the largest one as 100%. The id is `<parent id><suffix>`; consumers that need
-/// the parent strip the suffix. Callers render their own label — `category_name` is an English
-/// fallback for consumers that do not know the marker.
+/// Suffix on the id of the drill-down child that holds the part of a rolled-up category carrying
+/// no sub-category assignment (e.g. holdings classified as "Fixed Income" but no bond type).
+/// Without that child a category's children silently understate their parent, and a UI dividing by
+/// the children it received reports the largest one as 100%. The id is `<parent id><suffix>` so the
+/// holdings query can address exactly those holdings; to recognize such a child, read
+/// `CategoryAllocation::is_residual` rather than matching this suffix.
 pub const RESIDUAL_CATEGORY_SUFFIX: &str = ":__residual__";
 
-/// Residual shares below this fraction of the parent are rounding noise, not an unassigned
-/// remainder — weights are stored in basis points, so a real remainder is far larger.
+/// Residual shares below one basis point of the parent are rounding noise, not an unassigned
+/// remainder — weights are stored in basis points, so a real remainder is at least this large.
 const RESIDUAL_CHILD_MIN_SHARE: Decimal = dec!(0.0001);
 
 #[derive(Debug, Clone)]
@@ -621,16 +621,10 @@ impl AllocationService {
                             value: *value,
                             percentage,
                             children: Vec::new(),
+                            is_residual: false,
                         },
                     );
                 }
-            }
-            for children in children_map.values_mut() {
-                children.sort_by(|a, b| {
-                    b.value
-                        .cmp(&a.value)
-                        .then_with(|| a.category_id.cmp(&b.category_id))
-                });
             }
         }
 
@@ -663,6 +657,11 @@ impl AllocationService {
                     value,
                     total_value,
                 );
+                children.sort_by(|a, b| {
+                    b.value
+                        .cmp(&a.value)
+                        .then_with(|| a.category_id.cmp(&b.category_id))
+                });
 
                 CategoryAllocation {
                     category_id: cat_id,
@@ -671,6 +670,7 @@ impl AllocationService {
                     value,
                     percentage,
                     children,
+                    is_residual: false,
                 }
             })
             .collect();
@@ -705,7 +705,7 @@ impl AllocationService {
         }
         let assigned: Decimal = children.iter().map(|child| child.value).sum();
         let residual = value - assigned;
-        if residual <= value * RESIDUAL_CHILD_MIN_SHARE {
+        if residual < value * RESIDUAL_CHILD_MIN_SHARE {
             return;
         }
 
@@ -722,6 +722,7 @@ impl AllocationService {
             value: residual,
             percentage,
             children: Vec::new(),
+            is_residual: true,
         });
     }
 
@@ -2094,9 +2095,77 @@ mod tests {
         assert_eq!(residual.value, dec!(800));
         assert_eq!(residual.percentage, dec!(40));
         assert_eq!(residual.category_name, "Other FIXED_INCOME");
+        assert!(residual.is_residual);
+        assert!(!fixed_income.is_residual);
         // The whole point: children now account for the parent.
         let children_total: Decimal = fixed_income.children.iter().map(|c| c.value).sum();
         assert_eq!(children_total, fixed_income.value);
+    }
+
+    #[test]
+    fn residual_child_is_sorted_with_its_siblings() {
+        let svc = svc();
+        // The remainder (1800) outweighs the sub-classified holding (200).
+        let holdings = vec![
+            make_holding("MUNI", dec!(200)),
+            make_holding("TBILL", dec!(1800)),
+        ];
+        let categories = vec![
+            make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+            make_category_for_taxonomy("asset_classes", "FI_MUNICIPAL", Some("FIXED_INCOME")),
+        ];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([
+            (
+                "MUNI".to_string(),
+                vec![make_assignment(
+                    "MUNI",
+                    "asset_classes",
+                    "FI_MUNICIPAL",
+                    10000,
+                )],
+            ),
+            (
+                "TBILL".to_string(),
+                vec![make_assignment(
+                    "TBILL",
+                    "asset_classes",
+                    "FIXED_INCOME",
+                    10000,
+                )],
+            ),
+        ]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(2000),
+            true,
+            &HashMap::new(),
+        );
+
+        let fixed_income = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "FIXED_INCOME")
+            .expect("Fixed Income category missing");
+
+        // Children stay ordered by value; consumers that don't re-sort render them as given.
+        let order: Vec<&str> = fixed_income
+            .children
+            .iter()
+            .map(|c| c.category_id.as_str())
+            .collect();
+        assert_eq!(
+            order,
+            vec![
+                format!("FIXED_INCOME{RESIDUAL_CATEGORY_SUFFIX}").as_str(),
+                "FI_MUNICIPAL"
+            ]
+        );
     }
 
     #[test]

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -31,6 +31,18 @@ const RESIDUAL_TOLERANCE_BPS: i32 = 75;
 /// `source` written by auto-classification (`crates/core/src/assets/auto_classification.rs`).
 const AUTO_SOURCE: &str = "AUTO";
 
+/// Suffix marking the drill-down child that holds the part of a rolled-up category carrying no
+/// sub-category assignment (e.g. holdings classified as "Fixed Income" but no bond type). Without
+/// it a category's children silently understate their parent, and a UI dividing by the children it
+/// received reports the largest one as 100%. The id is `<parent id><suffix>`; consumers that need
+/// the parent strip the suffix. Callers render their own label — `category_name` is an English
+/// fallback for consumers that do not know the marker.
+pub const RESIDUAL_CATEGORY_SUFFIX: &str = ":__residual__";
+
+/// Residual shares below this fraction of the parent are rounding noise, not an unassigned
+/// remainder — weights are stored in basis points, so a real remainder is far larger.
+const RESIDUAL_CHILD_MIN_SHARE: Decimal = dec!(0.0001);
+
 #[derive(Debug, Clone)]
 struct HoldingTaxonomyShare {
     category_id: String,
@@ -642,7 +654,15 @@ impl AllocationService {
                     Decimal::ZERO
                 };
 
-                let children = children_map.remove(&cat_id).unwrap_or_default();
+                let mut children = children_map.remove(&cat_id).unwrap_or_default();
+                Self::push_residual_child(
+                    &mut children,
+                    &cat_id,
+                    &name,
+                    &color,
+                    value,
+                    total_value,
+                );
 
                 CategoryAllocation {
                     category_id: cat_id,
@@ -667,6 +687,42 @@ impl AllocationService {
             color: taxonomy_color.to_string(),
             categories: allocations,
         }
+    }
+
+    /// Appends the residual child for a rolled-up category: the part of its value that carries no
+    /// sub-category assignment. No-op for leaf categories (nothing to understate) and for
+    /// categories whose children already account for the whole value.
+    fn push_residual_child(
+        children: &mut Vec<CategoryAllocation>,
+        category_id: &str,
+        category_name: &str,
+        color: &str,
+        value: Decimal,
+        total_value: Decimal,
+    ) {
+        if children.is_empty() {
+            return;
+        }
+        let assigned: Decimal = children.iter().map(|child| child.value).sum();
+        let residual = value - assigned;
+        if residual <= value * RESIDUAL_CHILD_MIN_SHARE {
+            return;
+        }
+
+        let percentage = if total_value > Decimal::ZERO {
+            (residual / total_value * dec!(100)).round_dp(2)
+        } else {
+            Decimal::ZERO
+        };
+
+        children.push(CategoryAllocation {
+            category_id: format!("{category_id}{RESIDUAL_CATEGORY_SUFFIX}"),
+            category_name: format!("Other {category_name}"),
+            color: color.to_string(),
+            value: residual,
+            percentage,
+            children: Vec::new(),
+        });
     }
 
     /// Builds a map from each category to its top-level ancestor.
@@ -983,14 +1039,24 @@ impl AllocationService {
             ),
         };
 
-        let (category_name, category_color) = if category_id == "__UNKNOWN__" {
+        // A residual id addresses the part of its parent that carries no sub-category assignment;
+        // everything below resolves against the parent, then filters down to those holdings.
+        let residual_parent_id = category_id.strip_suffix(RESIDUAL_CATEGORY_SUFFIX);
+        let lookup_id = residual_parent_id.unwrap_or(category_id);
+
+        let (category_name, category_color) = if lookup_id == "__UNKNOWN__" {
             ("Unknown".to_string(), "#878580".to_string())
         } else {
             categories
                 .iter()
-                .find(|c| c.id == category_id)
+                .find(|c| c.id == lookup_id)
                 .map(|c| (c.name.clone(), c.color.clone()))
-                .unwrap_or_else(|| (category_id.to_string(), taxonomy_color.clone()))
+                .unwrap_or_else(|| (lookup_id.to_string(), taxonomy_color.clone()))
+        };
+        let category_name = if residual_parent_id.is_some() {
+            format!("Other {category_name}")
+        } else {
+            category_name
         };
 
         if holdings.is_empty() {
@@ -1031,8 +1097,15 @@ impl AllocationService {
 
             let matched_share: Decimal = shares
                 .into_iter()
-                .filter(|share| {
-                    share.category_id == category_id || share.assigned_category_id == category_id
+                .filter(|share| match residual_parent_id {
+                    // Residual: assigned to the parent itself, with no sub-category to roll up.
+                    Some(parent) => {
+                        share.category_id == parent && share.assigned_category_id == parent
+                    }
+                    None => {
+                        share.category_id == category_id
+                            || share.assigned_category_id == category_id
+                    }
                 })
                 .map(|share| share.share)
                 .sum();
@@ -1959,6 +2032,211 @@ mod tests {
             "Expected Americas = 400 (leaf US only), got {}",
             americas.value
         );
+    }
+
+    #[test]
+    fn top_level_only_assignments_become_a_residual_child() {
+        let svc = svc();
+        // MUNI carries a sub-class; TBILL is classified as Fixed Income and nothing finer.
+        let holdings = vec![
+            make_holding("MUNI", dec!(1200)),
+            make_holding("TBILL", dec!(800)),
+        ];
+        let categories = vec![
+            make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+            make_category_for_taxonomy("asset_classes", "FI_MUNICIPAL", Some("FIXED_INCOME")),
+        ];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([
+            (
+                "MUNI".to_string(),
+                vec![make_assignment(
+                    "MUNI",
+                    "asset_classes",
+                    "FI_MUNICIPAL",
+                    10000,
+                )],
+            ),
+            (
+                "TBILL".to_string(),
+                vec![make_assignment(
+                    "TBILL",
+                    "asset_classes",
+                    "FIXED_INCOME",
+                    10000,
+                )],
+            ),
+        ]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(2000),
+            true,
+            &HashMap::new(),
+        );
+
+        let fixed_income = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "FIXED_INCOME")
+            .expect("Fixed Income category missing");
+        let residual = fixed_income
+            .children
+            .iter()
+            .find(|c| c.category_id == format!("FIXED_INCOME{RESIDUAL_CATEGORY_SUFFIX}"))
+            .expect("residual child missing");
+
+        assert_eq!(residual.value, dec!(800));
+        assert_eq!(residual.percentage, dec!(40));
+        assert_eq!(residual.category_name, "Other FIXED_INCOME");
+        // The whole point: children now account for the parent.
+        let children_total: Decimal = fixed_income.children.iter().map(|c| c.value).sum();
+        assert_eq!(children_total, fixed_income.value);
+    }
+
+    #[test]
+    fn no_residual_child_when_children_cover_the_parent() {
+        let svc = svc();
+        let holdings = vec![make_holding("MUNI", dec!(1200))];
+        let categories = vec![
+            make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+            make_category_for_taxonomy("asset_classes", "FI_MUNICIPAL", Some("FIXED_INCOME")),
+        ];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([(
+            "MUNI".to_string(),
+            vec![make_assignment(
+                "MUNI",
+                "asset_classes",
+                "FI_MUNICIPAL",
+                10000,
+            )],
+        )]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1200),
+            true,
+            &HashMap::new(),
+        );
+
+        let fixed_income = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "FIXED_INCOME")
+            .expect("Fixed Income category missing");
+
+        assert_eq!(fixed_income.children.len(), 1);
+        assert_eq!(fixed_income.children[0].category_id, "FI_MUNICIPAL");
+    }
+
+    #[test]
+    fn leaf_categories_get_no_residual_child() {
+        let svc = svc();
+        let holdings = vec![make_holding("VOO", dec!(1000))];
+        let categories = vec![make_category_for_taxonomy("asset_classes", "EQUITY", None)];
+        let assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::from([(
+            "VOO".to_string(),
+            vec![make_assignment("VOO", "asset_classes", "EQUITY", 10000)],
+        )]);
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1000),
+            true,
+            &HashMap::new(),
+        );
+
+        let equity = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "EQUITY")
+            .expect("Equity category missing");
+        assert!(equity.children.is_empty());
+    }
+
+    #[tokio::test]
+    async fn holdings_by_allocation_returns_only_the_residual_holdings() {
+        let holdings = vec![
+            make_holding("MUNI", dec!(1200)),
+            make_holding("TBILL", dec!(800)),
+        ];
+        let taxonomies = StaticTaxonomies {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy: make_taxonomy("asset_classes", "Asset Classes", true),
+                categories: vec![
+                    make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+                    make_category_for_taxonomy(
+                        "asset_classes",
+                        "FI_MUNICIPAL",
+                        Some("FIXED_INCOME"),
+                    ),
+                ],
+            }],
+            assignments_by_asset: HashMap::from([
+                (
+                    "MUNI".to_string(),
+                    vec![make_assignment(
+                        "MUNI",
+                        "asset_classes",
+                        "FI_MUNICIPAL",
+                        10000,
+                    )],
+                ),
+                (
+                    "TBILL".to_string(),
+                    vec![make_assignment(
+                        "TBILL",
+                        "asset_classes",
+                        "FIXED_INCOME",
+                        10000,
+                    )],
+                ),
+            ]),
+        };
+        let svc = AllocationService::new(Arc::new(NoopHoldings), Arc::new(taxonomies));
+
+        let residual = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                &format!("FIXED_INCOME{RESIDUAL_CATEGORY_SUFFIX}"),
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+        let parent = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "FIXED_INCOME",
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        // The residual holds the top-level-only holding, not the whole class.
+        assert_eq!(residual.total_value, dec!(800));
+        assert_eq!(residual.holdings.len(), 1);
+        assert_eq!(residual.holdings[0].symbol, "TBILL");
+        assert_eq!(residual.category_name, "Other FIXED_INCOME");
+        assert_eq!(parent.total_value, dec!(2000));
+        assert_eq!(parent.holdings.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -529,6 +529,7 @@ mod tests {
             value,
             percentage: rust_decimal::Decimal::ZERO,
             children: vec![],
+            is_residual: false,
         }
     }
 


### PR DESCRIPTION

Fixes #1497 .

A rolled-up category only emitted children for sub-category assignments, so
holdings classified at the top level alone (e.g. "Fixed Income" with no bond
type) added to the parent's value but produced no child row. Every drill-down
then divided by the children it received: a class worth 2,000 with a single
1,200 sub-class reported that sub-class as 100%.

### Changes

- `aggregate_by_taxonomy` appends a residual child, `<parentId>:__residual__`,
  holding the difference — children now always account for their parent.
- `get_holdings_by_allocation` resolves that id by matching shares assigned to
  the parent with no sub-category to roll up, so the row addresses real holdings
  instead of falling back to the whole class.
- The backend names the row in English for consumers that don't know the marker;
  the UI substitutes a localized label (`common:allocation_other_in_category`,
  all 7 locales).

Fixes the donut drill-down, the Insights breakdown tree, and the allocation
detail sheet.

### Why in the backend

The omission is silent, and three consumers hit it independently. A frontend
helper would have to be remembered by every future consumer; a residual emitted
once cannot be missed. It also lets the holdings query answer the residual id
exactly — a frontend-only fix has to open the parent, listing sub-classified
holdings that don't belong to the row clicked.

### Testing

- 4 new Rust tests (residual added / not added when children cover the parent /
  leaf categories / residual holdings query returns only top-level-only holdings)
- Frontend: `type-check` clean, full suite passes, 4 new tests for the label helper
- Verified end-to-end against a running server: parent = sub-class + residual,
  donut drill-down reads 59.10% instead of 100.00%, and the residual row lists
  only the top-level-classified holdings

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
