### PR TITLE
fix(insights): keep account names reachable in the Accounts breakdown

### DIFF
--- a/apps/frontend/src/pages/insights/overview/allocation-derivations.test.ts
+++ b/apps/frontend/src/pages/insights/overview/allocation-derivations.test.ts
@@ -161,4 +161,41 @@ describe("allocation dashboard derivations", () => {
     expect(nodes[0].children?.[0].name).toBe("Taxable");
     expect(nodes[0].children?.[0].value).toBe(125);
   });
+
+  it("keeps a single-account group as an expandable group carrying the account name", () => {
+    const nodes = accountTreeWeights(
+      [{ accountId: "taxable", totalValue: 100, totalValueBase: 100, fxRateToBase: 1 }],
+      [account("taxable", "Fidelity Brokerage", "taxable")],
+    );
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe("taxable");
+    expect(nodes[0].children).toHaveLength(1);
+    expect(nodes[0].children?.[0].name).toBe("Fidelity Brokerage");
+    expect(nodes[0].children?.[0].value).toBe(100);
+  });
+
+  it("renders an ungrouped account as a flat row named after the account", () => {
+    const nodes = accountTreeWeights(
+      [{ accountId: "solo", totalValue: 100, totalValueBase: 100, fxRateToBase: 1 }],
+      [account("solo", "Schwab IRA")],
+    );
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].name).toBe("Schwab IRA");
+    expect(nodes[0].children).toBeUndefined();
+  });
+
+  it("keeps same-named ungrouped accounts as separate rows", () => {
+    const nodes = accountTreeWeights(
+      [
+        { accountId: "a", totalValue: 100, totalValueBase: 100, fxRateToBase: 1 },
+        { accountId: "b", totalValue: 50, totalValueBase: 50, fxRateToBase: 1 },
+      ],
+      [account("a", "Checking"), account("b", "Checking")],
+    );
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes.map((n) => n.value)).toEqual([100, 50]);
+  });
 });

--- a/apps/frontend/src/pages/insights/overview/allocation-derivations.ts
+++ b/apps/frontend/src/pages/insights/overview/allocation-derivations.ts
@@ -293,6 +293,7 @@ export function currencyLensItems(holdings: Holding[]): LensItem[] {
 
 /**
  * Nested account breakdown: account groups at the top level, individual accounts as children.
+ * A group stays a group at any member count, so its accounts are always reachable underneath.
  * Ungrouped accounts (no `account.group`) appear as flat top-level rows. Values come from real
  * per-account valuations (holdings are aggregated under a single id in "all" scope).
  */
@@ -303,7 +304,12 @@ export function accountTreeWeights(
   const accountMap = new Map(accounts.map((a) => [a.id, a]));
   const groups = new Map<
     string,
-    { name: string; value: number; accounts: { id: string; name: string; value: number }[] }
+    {
+      name: string;
+      groupName: string | null;
+      value: number;
+      accounts: { id: string; name: string; value: number }[];
+    }
   >();
   let total = 0;
   for (const v of valuations) {
@@ -315,8 +321,15 @@ export function accountTreeWeights(
         : num(v.totalValue) * (num(v.fxRateToBase) || 1);
     if (value <= 0) continue;
     total += value;
-    const key = account.group || account.name;
-    const group = groups.get(key) ?? { name: key, value: 0, accounts: [] };
+    const groupName = account.group?.trim() || null;
+    // Ungrouped accounts key by id so two accounts sharing a name stay separate rows.
+    const key = groupName ? `grp:${groupName}` : `acct:${account.id}`;
+    const group = groups.get(key) ?? {
+      name: groupName ?? account.name,
+      groupName,
+      value: 0,
+      accounts: [],
+    };
     group.value += value;
     group.accounts.push({ id: account.id, name: account.name, value });
     groups.set(key, group);
@@ -325,15 +338,15 @@ export function accountTreeWeights(
     .sort((a, b) => b.value - a.value)
     .map((group, index) => {
       const color = paletteColor(index);
-      const nested = group.accounts.length > 1;
+      const isGroup = group.groupName != null;
       return {
-        id: `grp:${group.name}`,
+        id: isGroup ? `grp:${group.groupName}` : group.accounts[0].id,
         name: group.name,
         value: group.value,
         percentage: total > 0 ? (group.value / total) * 100 : 0,
         color,
         depth: 0,
-        children: nested
+        children: isGroup
           ? group.accounts
               .sort((a, b) => b.value - a.value)
               .map((acc) => ({

--- a/apps/frontend/src/pages/insights/overview/portfolio-explorer.tsx
+++ b/apps/frontend/src/pages/insights/overview/portfolio-explorer.tsx
@@ -36,6 +36,8 @@ interface Lens {
   label: string;
   unit: string;
   nodes: BreakdownNode[];
+  /** Underlying item count when it differs from the top-level row count (grouped rows). */
+  count?: number;
   /** Taxonomy backing the lens; when present, leaf rows open the detail sheet. */
   allocation?: TaxonomyAllocation;
 }
@@ -108,6 +110,17 @@ function taxonomyLens(
   };
 }
 
+/** Accounts lens: rows are groups, so the count has to reach through to the accounts. */
+function accountsLens(label: string, unit: string, nodes: BreakdownNode[]): Lens {
+  return {
+    key: "accounts",
+    label,
+    unit,
+    nodes,
+    count: nodes.reduce((s, n) => s + (n.children?.length ?? 1), 0),
+  };
+}
+
 export function PortfolioExplorer({
   allocations,
   holdings,
@@ -140,12 +153,11 @@ export function PortfolioExplorer({
         t("insights:insights.explorer.unit_categories"),
         allocations?.assetClasses,
       ),
-      {
-        key: "accounts",
-        label: t("insights:insights.explorer.lens_accounts"),
-        unit: t("insights:insights.explorer.unit_accounts"),
-        nodes: accountTreeWeights(accountValues, scopedAccounts),
-      },
+      accountsLens(
+        t("insights:insights.explorer.lens_accounts"),
+        t("insights:insights.explorer.unit_accounts"),
+        accountTreeWeights(accountValues, scopedAccounts),
+      ),
       taxonomyLens(
         "sectors",
         t("insights:insights.explorer.lens_sectors"),
@@ -334,8 +346,8 @@ export function PortfolioExplorer({
           <div className="mb-3.5 flex items-baseline justify-between gap-3.5">
             <span className="text-[13.5px] font-bold">{active.label}</span>
             <span className="text-muted-foreground text-[12.5px] tabular-nums">
-              <PrivacyAmount value={total} currency={currency} /> · {active.nodes.length}{" "}
-              {active.unit}
+              <PrivacyAmount value={total} currency={currency} /> ·{" "}
+              {active.count ?? active.nodes.length} {active.unit}
             </span>
           </div>
           <SegmentedBar nodes={barWeights} />


### PR DESCRIPTION
Fixes #1506

## Problem

The Insights **Breakdown → Accounts** lens keyed each row by
`account.group || account.name` and attached children only when a group ended up
with more than one account carrying a positive valuation. The lens is fed the
active-account list, so a group whose other members are inactive arrives with a
single entry and renders as a bare, non-expandable row labelled with the *group*
name — the account's own name appears nowhere in the breakdown. Keying ungrouped
accounts by name also merged two distinct accounts sharing a name into one row.

## Change

Group identity and account identity are now tracked separately in
`accountTreeWeights`:

- Rows key by `grp:<group>` when the account has a group, and by `acct:<id>`
  when it does not.
- **A group is a group at any member count** and always carries its accounts as
  children, so a group down to one in-scope account is expandable and shows the
  real account name.
- An ungrouped account stays a flat top-level row under its own name, and two
  same-named ungrouped accounts stay distinct rows.

The card header had the same conflation: it counted top-level rows while
labelling them "accounts". The Accounts lens now reports the number of
underlying accounts.

## Before / after with test data

```
before                                after
  taxable       62.4%   $124,000      ▸ taxable                62.4%   $124,000
  Schwab IRA    37.6%    $74,800          └ Fidelity Brokerage 62.4%   $124,000
  $198,800 · 2 accounts                 Schwab IRA             37.6%    $74,800
                                        $198,800 · 2 accounts
```

## Tests

Three cases added to `allocation-derivations.test.ts`:

1. a single-account group stays an expandable group whose child carries the
   account name and full value;
2. an ungrouped account renders as a flat row named after the account, with no
   children;
3. two same-named ungrouped accounts stay separate rows.

Also verified against a build with and without the change, with real data.


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
