### PR TITLE
fix(addons): translate @wealthfolio/ui strings inside the addon sandbox

### DIFF
--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -17,6 +17,7 @@ import { SandboxAddonAssetRegistry, type SandboxAddonAsset } from "./addon-sandb
 import { applyHostTheme, type AddonThemeSnapshot } from "./addon-sandbox-theme";
 import { rewriteModuleSpecifiers } from "./addon-module-rewriter";
 import type { AddonLocalizationSnapshot } from "./addon-sandbox-localization";
+import { initSandboxI18n, setSandboxLanguage } from "./addon-sandbox-i18n";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 const RUNTIME_PROTOCOL_VERSION = 1;
@@ -97,6 +98,10 @@ if (!ADDON_ID || !NONCE || !HOST_BASE_URL || !rootElement) {
 
 const root = rootElement;
 
+// Bootstrap i18next before any addon (and its `@wealthfolio/ui` components)
+// render, seeded from the bootstrap params so there is no flash of raw keys.
+initSandboxI18n(sandboxLocalization.uiLocale);
+
 function post(type: string, payload: Record<string, unknown> = {}) {
   parent.postMessage({ channel: CHANNEL, addonId: ADDON_ID, nonce: NONCE, type, ...payload }, "*");
 }
@@ -145,6 +150,7 @@ function updateSandboxLocalization(localization?: AddonLocalizationSnapshot) {
     return;
   }
   sandboxLocalization = localization;
+  setSandboxLanguage(localization.uiLocale);
   for (const listener of localizationListeners) listener();
 }
 

--- a/apps/frontend/src/addons/iframe/addon-sandbox-i18n.test.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-i18n.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { useTranslation } from "react-i18next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// i18next is a module-level singleton, so every case needs a fresh module graph.
+async function loadSandboxI18n() {
+  vi.resetModules();
+  return import("./addon-sandbox-i18n");
+}
+
+describe("addon sandbox i18n", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute("lang");
+  });
+
+  it("translates ui-namespaced keys instead of falling back to the raw key", async () => {
+    const { initSandboxI18n } = await loadSandboxI18n();
+
+    const i18n = initSandboxI18n("en");
+
+    expect(i18n.t("ui:sheet.close")).not.toBe("ui:sheet.close");
+    expect(i18n.t("ui:sheet.close")).toBe("Close");
+  });
+
+  it("seeds the requested host language", async () => {
+    const { initSandboxI18n } = await loadSandboxI18n();
+
+    const i18n = initSandboxI18n("fr");
+
+    expect(i18n.language).toBe("fr");
+    expect(i18n.t("ui:sheet.close")).not.toBe("Close");
+    expect(document.documentElement.getAttribute("lang")).toBe("fr");
+  });
+
+  it("bundles every supported locale, including ja and ko", async () => {
+    const { initSandboxI18n, setSandboxLanguage } = await loadSandboxI18n();
+    const { SUPPORTED_LOCALE_CODES } = await import("@/i18n/locales");
+
+    const i18n = initSandboxI18n("en");
+
+    for (const code of SUPPORTED_LOCALE_CODES) {
+      setSandboxLanguage(code);
+      expect(i18n.language).toBe(code);
+      // A missing bundle silently resolves through fallbackLng, so assert the
+      // resource bundle itself is present rather than just the lookup result.
+      expect(i18n.hasResourceBundle(code, "ui")).toBe(true);
+    }
+  });
+
+  it("normalizes regional codes to the base language", async () => {
+    const { initSandboxI18n } = await loadSandboxI18n();
+
+    const i18n = initSandboxI18n("fr-CA");
+
+    expect(i18n.language).toBe("fr");
+  });
+
+  it("defaults to the default locale when the host sends no language", async () => {
+    const { initSandboxI18n } = await loadSandboxI18n();
+    const { DEFAULT_LOCALE } = await import("@/i18n/locales");
+
+    const i18n = initSandboxI18n(undefined);
+
+    expect(i18n.language).toBe(DEFAULT_LOCALE);
+  });
+
+  it("follows host language changes and ignores empty updates", async () => {
+    const { initSandboxI18n, setSandboxLanguage } = await loadSandboxI18n();
+    const i18n = initSandboxI18n("en");
+
+    setSandboxLanguage("de");
+    expect(i18n.language).toBe("de");
+    expect(document.documentElement.getAttribute("lang")).toBe("de");
+
+    setSandboxLanguage(undefined);
+    expect(i18n.language).toBe("de");
+  });
+
+  it("resolves translations for useTranslation consumers without a provider", async () => {
+    // `@wealthfolio/ui` components call `useTranslation()` with no
+    // I18nextProvider above them — the sandbox instance has to be the default.
+    const { initSandboxI18n } = await loadSandboxI18n();
+    initSandboxI18n("fr");
+
+    function UiConsumer() {
+      const { t } = useTranslation();
+      return <span>{t("ui:sheet.close")}</span>;
+    }
+
+    render(<UiConsumer />);
+
+    expect(await screen.findByText("Fermer")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/addons/iframe/addon-sandbox-i18n.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-i18n.ts
@@ -1,0 +1,97 @@
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import { DEFAULT_LOCALE, SUPPORTED_LOCALE_CODES, type LocaleCode } from "@/i18n/locales";
+import deUi from "@/i18n/locales/de/ui.json";
+import enUi from "@/i18n/locales/en/ui.json";
+import esUi from "@/i18n/locales/es/ui.json";
+import frUi from "@/i18n/locales/fr/ui.json";
+import jaUi from "@/i18n/locales/ja/ui.json";
+import koUi from "@/i18n/locales/ko/ui.json";
+import zhUi from "@/i18n/locales/zh/ui.json";
+
+// The sandbox iframe renders `@wealthfolio/ui` components that call
+// `useTranslation()` against `ui:`-namespaced keys. The iframe is its own realm,
+// so it does not inherit the host's i18next instance — without one, those
+// components log `NO_I18NEXT_INSTANCE` and render raw keys ("ui:sheet.close").
+//
+// Only the `ui` namespace is bundled, and statically rather than through the
+// host's lazy `resourcesToBackend`: the sandbox runs under a strict CSP and
+// fetching locale chunks at runtime is not worth the failure mode when the
+// whole namespace is a few KB per language.
+//
+// Typed as Record<LocaleCode, …> on purpose — adding a locale to
+// SUPPORTED_LOCALES without adding it here is a type error, not a silent
+// fallback to English.
+const resources: Record<LocaleCode, { ui: Record<string, unknown> }> = {
+  de: { ui: deUi },
+  en: { ui: enUi },
+  es: { ui: esUi },
+  fr: { ui: frUi },
+  ja: { ui: jaUi },
+  ko: { ui: koUi },
+  zh: { ui: zhUi },
+};
+
+// Map regional codes (e.g. `fr-CA`) to the base language, matching the host.
+function normalizeLanguage(language: string) {
+  return language.split("-")[0];
+}
+
+function applyDocumentLanguage(language: string) {
+  // Han unification: ja/ko/zh share codepoints that render with different
+  // preferred glyphs, so the iframe document needs its own lang attribute.
+  document.documentElement.setAttribute("lang", language);
+}
+
+// A dedicated instance rather than the shared i18next default: the sandbox owns
+// its own translations, and this way initialization order can never leave it
+// silently piggybacking on someone else's config.
+const sandboxI18n = i18next.createInstance();
+
+export function initSandboxI18n(language?: string) {
+  if (sandboxI18n.isInitialized) {
+    setSandboxLanguage(language);
+    return sandboxI18n;
+  }
+
+  const initialLanguage = language ? normalizeLanguage(language) : DEFAULT_LOCALE;
+
+  // `initReactI18next` also registers this instance as react-i18next's default,
+  // so `@wealthfolio/ui` components resolve it without an I18nextProvider.
+  void sandboxI18n.use(initReactI18next).init({
+    lng: initialLanguage,
+    fallbackLng: DEFAULT_LOCALE,
+    supportedLngs: SUPPORTED_LOCALE_CODES,
+    load: "languageOnly",
+    ns: ["ui"],
+    defaultNS: "ui",
+    resources,
+    interpolation: {
+      // React already escapes values.
+      escapeValue: false,
+    },
+    react: {
+      // Resources are bundled synchronously, so there is nothing to suspend on
+      // — and suspending here would land outside the route Suspense boundary.
+      useSuspense: false,
+    },
+  });
+
+  applyDocumentLanguage(initialLanguage);
+  return sandboxI18n;
+}
+
+export function setSandboxLanguage(language?: string) {
+  if (!language) {
+    return;
+  }
+
+  const normalized = normalizeLanguage(language);
+  if (sandboxI18n.language === normalized) {
+    return;
+  }
+
+  void sandboxI18n.changeLanguage(normalized);
+  applyDocumentLanguage(normalized);
+}


### PR DESCRIPTION
## Description

The addon sandbox iframe is its own JS realm, so it never inherited the host's i18next instance. The 22 `@wealthfolio/ui` components that call `useTranslation()` against `ui:`-namespaced keys had no instance to resolve against, so they logged `NO_I18NEXT_INSTANCE` and rendered **raw keys** — an addon using a Sheet, Dialog, DateRangePicker, or faceted filter showed `ui:sheet.close` instead of "Close", for every user in every language including English.

### What changed

- **New** `addon-sandbox-i18n.ts` — a dedicated i18next instance for the sandbox, bundling only the `ui` namespace.
- `addon-sandbox-entry.tsx` — initializes it at bootstrap from the `uiLocale` param, and syncs it in the existing `updateSandboxLocalization` path (3 lines).

No new plumbing: `uiLocale` (which *is* `settings.language`) is already collected, already passed in the bootstrap params, and already pushed to the sandbox on change. This change only adds the consumer that was missing.

### Notable decisions

**Static bundling, not lazy loading.** The host uses `resourcesToBackend` to lazy-load locale JSON. The sandbox runs under a strict CSP, so runtime chunk fetches are a failure mode not worth taking for a namespace of a few KB per language.

**A dedicated instance, not the shared i18next default.** `createInstance()` means initialization order can never leave the sandbox silently piggybacking on someone else's config. `initReactI18next` still registers it as react-i18next's default, so `@wealthfolio/ui` components resolve it without needing an `I18nextProvider` — covered by a test that renders a `useTranslation()` consumer with no provider above it.

**Locale list is compile-time exhaustive.** `resources` is typed `Record<LocaleCode, …>`, so adding a locale to `SUPPORTED_LOCALES` without a matching bundle fails `tsc` naming this file, instead of silently falling back to English. Verified by temporarily adding an `it` locale:

```
src/addons/iframe/addon-sandbox-i18n.ts(26,7): error TS2741:
Property 'it' is missing in type ... but required in type 'Record<"en" | "fr" | ... | "it", ...>'
```

**`lang` on the sandbox document.** ja/ko/zh share Unicode codepoints that render with different preferred glyphs (Han unification), so the iframe document needs its own `lang` attribute for correct CJK rendering.

### Cost

+25.7 KB gzip (+3.46%) on `addon-sandbox-runtime.js`, measured by building with and without the change. All 7 locales' `ui` namespace, plus the i18next runtime.

### Testing

- 7 new tests in `addon-sandbox-i18n.test.tsx`: key resolution, host-language seeding, every supported locale bundled (asserted via `hasResourceBundle`, since a missing bundle otherwise resolves silently through `fallbackLng`), regional normalization (`fr-CA` → `fr`), default fallback, language changes, and provider-less rendering.
- `pnpm --filter frontend exec vitest run src/addons` — 118 passed (20 files)
- `tsc --noEmit` clean, `eslint` clean on changed files
- `pnpm --filter frontend build` succeeds, including `verify-addon-sandbox-runtime.mjs`

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
