### PR TITLE
Skip dust cash balances when building holdings

### DIFF
--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use chrono::NaiveDate;
-use log::{debug, info, warn};
+use log::{debug, info};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
@@ -1618,176 +1618,13 @@ pub async fn get_snapshot_by_date(
         .find(|s| s.snapshot_date == target_date)
         .ok_or_else(|| format!("No snapshot found for date {}", date))?;
 
-    // Convert snapshot to holdings format directly
+    // Keep desktop snapshot conversion aligned with the server path.
     let base_currency = state.get_base_currency();
-    let mut holdings: Vec<Holding> = Vec::new();
-
-    // Get all asset IDs from positions
-    let asset_ids: Vec<String> = snapshot
-        .positions
-        .values()
-        .map(|p| p.asset_id.clone())
-        .collect();
-
-    // Fetch asset details if we have positions
-    let assets_map: HashMap<String, wealthfolio_core::assets::Asset> = if !asset_ids.is_empty() {
-        state
-            .asset_service()
-            .get_assets_by_asset_ids(&asset_ids)
-            .await
-            .map_err(|e| format!("Failed to get asset details: {}", e))?
-            .into_iter()
-            .map(|a| (a.id.clone(), a))
-            .collect()
-    } else {
-        HashMap::new()
-    };
-
-    // Convert positions to holdings
-    for position in snapshot.positions.values() {
-        if position.quantity == Decimal::ZERO {
-            continue;
-        }
-
-        let asset = assets_map.get(&position.asset_id);
-        if asset.is_none() {
-            warn!(
-                "Asset {} not found for position in snapshot",
-                position.asset_id
-            );
-            continue;
-        }
-        let asset = asset.unwrap();
-
-        let (holding_type, id_prefix) = if asset.kind.is_alternative() {
-            (
-                wealthfolio_core::holdings::HoldingType::AlternativeAsset,
-                "ALT",
-            )
-        } else {
-            (wealthfolio_core::holdings::HoldingType::Security, "SEC")
-        };
-
-        // Extract purchase_price from metadata for alternative assets
-        let purchase_price: Option<Decimal> = asset.metadata.as_ref().and_then(|m| {
-            m.get("purchase_price").and_then(|v| {
-                if let Some(s) = v.as_str() {
-                    s.parse::<Decimal>().ok()
-                } else if let Some(n) = v.as_f64() {
-                    Decimal::try_from(n).ok()
-                } else {
-                    None
-                }
-            })
-        });
-
-        let instrument = wealthfolio_core::holdings::Instrument {
-            id: asset.id.clone(),
-            symbol: asset.display_code.clone().unwrap_or_default(),
-            name: asset.name.clone(),
-            currency: asset.quote_ccy.clone(),
-            notes: asset.notes.clone(),
-            pricing_mode: asset.quote_mode.as_db_str().to_string(),
-            preferred_provider: asset.preferred_provider(),
-            exchange_mic: asset.instrument_exchange_mic.clone(),
-            instrument_type: asset.instrument_type.clone(),
-            classifications: None,
-        };
-
-        let holding = Holding {
-            id: format!("{}-{}-{}", id_prefix, account_id, position.asset_id),
-            account_id: account_id.clone(),
-            holding_type,
-            is_closed: false,
-            instrument: Some(instrument),
-            asset_kind: Some(asset.kind.clone()),
-            quantity: position.quantity,
-            open_date: Some(position.inception_date),
-            lots: None,
-            contract_multiplier: position.contract_multiplier,
-            local_currency: position.currency.clone(),
-            base_currency: base_currency.clone(),
-            fx_rate: None,
-            market_value: wealthfolio_core::holdings::MonetaryValue::zero(),
-            cost_basis: Some(wealthfolio_core::holdings::MonetaryValue {
-                local: position.total_cost_basis,
-                base: Decimal::ZERO,
-            }),
-            price: None,
-            purchase_price,
-            unrealized_gain: None,
-            unrealized_gain_pct: None,
-            realized_gain: None,
-            realized_gain_pct: None,
-            total_gain: None,
-            total_gain_pct: None,
-            income: None,
-            total_return: None,
-            total_return_pct: None,
-            return_basis: None,
-            day_change: None,
-            day_change_pct: None,
-            prev_close_value: None,
-            weight: Decimal::ZERO,
-            as_of_date: target_date,
-            metadata: asset.metadata.clone(),
-            source_account_ids: Vec::new(),
-        };
-        holdings.push(holding);
-    }
-
-    // Convert cash balances to holdings
-    for (currency, &amount) in &snapshot.cash_balances {
-        if amount == Decimal::ZERO {
-            continue;
-        }
-
-        let holding = Holding {
-            id: format!("CASH-{}-{}", account_id, currency),
-            account_id: account_id.clone(),
-            holding_type: wealthfolio_core::holdings::HoldingType::Cash,
-            is_closed: false,
-            instrument: None,
-            asset_kind: None, // Cash holdings have no asset
-            quantity: amount,
-            open_date: None,
-            lots: None,
-            contract_multiplier: Decimal::ONE,
-            local_currency: currency.clone(),
-            base_currency: base_currency.clone(),
-            fx_rate: None,
-            market_value: wealthfolio_core::holdings::MonetaryValue {
-                local: amount,
-                base: Decimal::ZERO,
-            },
-            cost_basis: Some(wealthfolio_core::holdings::MonetaryValue {
-                local: amount,
-                base: Decimal::ZERO,
-            }),
-            price: Some(Decimal::ONE),
-            purchase_price: None,
-            unrealized_gain: None,
-            unrealized_gain_pct: None,
-            realized_gain: None,
-            realized_gain_pct: None,
-            total_gain: None,
-            total_gain_pct: None,
-            income: None,
-            total_return: None,
-            total_return_pct: None,
-            return_basis: None,
-            day_change: None,
-            day_change_pct: None,
-            prev_close_value: None,
-            weight: Decimal::ZERO,
-            as_of_date: target_date,
-            metadata: None,
-            source_account_ids: Vec::new(),
-        };
-        holdings.push(holding);
-    }
-
-    Ok(holdings)
+    state
+        .holdings_service()
+        .holdings_from_snapshot(&snapshot, &base_currency)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Deletes a snapshot by date or ID.

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -419,7 +419,7 @@ impl HoldingsService {
         }
 
         for (currency, &amount) in cash_balances_map {
-            if amount == Decimal::ZERO {
+            if is_cash_dust(amount) {
                 continue;
             }
 
@@ -884,6 +884,18 @@ impl HoldingsService {
             refresh_total_return(holding);
         }
     }
+}
+
+/// Whether a snapshot cash balance is residual noise rather than money.
+///
+/// Snapshot `cash_balances` persist as serde-float JSON, and the incremental recalc
+/// modes re-seed from that f64 round-trip, so long-settled accounts accumulate
+/// balances around 1e-15. Those are non-zero, so an exact zero check emits a full
+/// cash holding that only collapses to $0 at render time. Rounding first drops the
+/// dust; genuine sub-cent balances survive, since DECIMAL_PRECISION is well below a
+/// cent.
+fn is_cash_dust(amount: Decimal) -> bool {
+    amount.round_dp(DECIMAL_PRECISION).is_zero()
 }
 
 fn gain_pct(amount: Decimal, basis: Decimal) -> Option<Decimal> {
@@ -1730,7 +1742,7 @@ impl HoldingsServiceTrait for HoldingsService {
 
         // Convert cash balances to holdings
         for (currency, &amount) in &snapshot.cash_balances {
-            if amount == Decimal::ZERO {
+            if is_cash_dust(amount) {
                 continue;
             }
 
@@ -4210,5 +4222,137 @@ mod tests {
         assert_eq!(holding.price, Some(Decimal::ONE));
         assert_eq!(holding.prev_close_value.as_ref().unwrap().local, dec!(10));
         assert_eq!(holding.prev_close_value.as_ref().unwrap().base, dec!(10));
+    }
+
+    // Snapshot cash balances round-trip through f64, so long-settled accounts keep
+    // residual balances around 1e-15. The tests below pin that such balances never
+    // become cash holdings — each one renders as a `$0` row in the Cash drill-down.
+
+    fn cash_snapshot(account_id: &str, balances: Vec<(&str, Decimal)>) -> AccountStateSnapshot {
+        AccountStateSnapshot {
+            account_id: account_id.to_string(),
+            currency: "USD".to_string(),
+            cash_balances: balances
+                .into_iter()
+                .map(|(currency, amount)| (currency.to_string(), amount))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cash_dust_is_detected_below_decimal_precision() {
+        assert!(is_cash_dust(Decimal::ZERO));
+        assert!(is_cash_dust(dec!(0.000000000000001)));
+        assert!(is_cash_dust(dec!(-0.000000000000001)));
+        assert!(!is_cash_dust(dec!(0.01)));
+        assert!(!is_cash_dust(dec!(-0.01)));
+        // DECIMAL_PRECISION is 8, well below a cent, so real sub-cent balances survive.
+        assert!(!is_cash_dust(dec!(0.00000001)));
+    }
+
+    #[test]
+    fn cash_dust_boundary_sits_just_above_half_of_decimal_precision() {
+        // `round_dp` uses banker's rounding, so the exact midpoint goes to even (zero)
+        // and the largest discarded balance is 5e-9 — half a nanodollar, either sign.
+        assert!(is_cash_dust(dec!(0.000000005)));
+        assert!(is_cash_dust(dec!(-0.000000005)));
+        assert!(!is_cash_dust(dec!(0.0000000051)));
+        assert!(!is_cash_dust(dec!(-0.0000000051)));
+    }
+
+    #[tokio::test]
+    async fn get_holdings_does_not_round_the_cash_balance_it_emits() {
+        // Only the dust *test* rounds; the balance written into the holding keeps full
+        // precision. Rounding the emitted value would be a behavior change, not a fix.
+        let account_id = "acc-1";
+        let precise = dec!(1234.567890123456789);
+        let snapshot = cash_snapshot(account_id, vec![("USD", precise)]);
+        let service = test_service(snapshot, Vec::new(), HashMap::new());
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+
+        let cash = holdings
+            .iter()
+            .find(|holding| holding.holding_type == HoldingType::Cash)
+            .expect("real balance should survive");
+        assert_eq!(cash.quantity, precise);
+        assert_eq!(cash.market_value.local, precise);
+        assert_eq!(cash.cost_basis.as_ref().unwrap().local, precise);
+    }
+
+    #[tokio::test]
+    async fn get_holdings_skips_dust_cash_balances() {
+        let account_id = "acc-1";
+        let snapshot = cash_snapshot(
+            account_id,
+            vec![
+                ("USD", dec!(0.000000000000001)),
+                ("EUR", dec!(-0.0000000000000023679074)),
+            ],
+        );
+        let service = test_service(snapshot, Vec::new(), HashMap::new());
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+
+        assert!(holdings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_holdings_keeps_real_cash_balances_alongside_dust() {
+        let account_id = "acc-1";
+        let snapshot = cash_snapshot(
+            account_id,
+            vec![
+                ("USD", dec!(2500)),
+                ("EUR", dec!(0.0000000000000092751693)),
+                // A genuine sub-cent balance is money, not noise.
+                ("GBP", dec!(0.001)),
+            ],
+        );
+        let service = test_service(snapshot, Vec::new(), HashMap::new());
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+
+        let mut cash: Vec<(String, Decimal)> = holdings
+            .iter()
+            .filter(|holding| holding.holding_type == HoldingType::Cash)
+            .map(|holding| (holding.local_currency.clone(), holding.quantity))
+            .collect();
+        cash.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(
+            cash,
+            vec![
+                ("GBP".to_string(), dec!(0.001)),
+                ("USD".to_string(), dec!(2500)),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn holdings_from_snapshot_skips_dust_cash_balances() {
+        let snapshot = cash_snapshot(
+            "acc-1",
+            vec![
+                ("USD", dec!(2500)),
+                ("EUR", dec!(0.000000000000001)),
+                ("CAD", dec!(-0.000000000000001)),
+            ],
+        );
+        let service = test_service(snapshot.clone(), Vec::new(), HashMap::new());
+
+        let holdings = service
+            .holdings_from_snapshot(&snapshot, "USD")
+            .await
+            .unwrap();
+
+        let cash: Vec<&Holding> = holdings
+            .iter()
+            .filter(|holding| holding.holding_type == HoldingType::Cash)
+            .collect();
+        assert_eq!(cash.len(), 1);
+        assert_eq!(cash[0].local_currency, "USD");
+        assert_eq!(cash[0].quantity, dec!(2500));
     }
 }

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -417,7 +417,7 @@ impl HoldingsService {
         }
 
         for (currency, &amount) in cash_balances_map {
-            if amount == Decimal::ZERO {
+            if is_cash_dust(amount) {
                 continue;
             }
 
@@ -881,6 +881,18 @@ impl HoldingsService {
             refresh_total_return(holding);
         }
     }
+}
+
+/// Whether a snapshot cash balance is residual noise rather than money.
+///
+/// Snapshot `cash_balances` persist as serde-float JSON, and the incremental recalc
+/// modes re-seed from that f64 round-trip, so long-settled accounts accumulate
+/// balances around 1e-15. Those are non-zero, so an exact zero check emits a full
+/// cash holding that only collapses to $0 at render time. Rounding first drops the
+/// dust; genuine sub-cent balances survive, since DECIMAL_PRECISION is well below a
+/// cent.
+fn is_cash_dust(amount: Decimal) -> bool {
+    amount.round_dp(DECIMAL_PRECISION).is_zero()
 }
 
 fn gain_pct(amount: Decimal, basis: Decimal) -> Option<Decimal> {
@@ -1729,7 +1741,7 @@ impl HoldingsServiceTrait for HoldingsService {
 
         // Convert cash balances to holdings
         for (currency, &amount) in &snapshot.cash_balances {
-            if amount == Decimal::ZERO {
+            if is_cash_dust(amount) {
                 continue;
             }
 
@@ -4208,5 +4220,137 @@ mod tests {
         assert_eq!(holding.price, Some(Decimal::ONE));
         assert_eq!(holding.prev_close_value.as_ref().unwrap().local, dec!(10));
         assert_eq!(holding.prev_close_value.as_ref().unwrap().base, dec!(10));
+    }
+
+    // Snapshot cash balances round-trip through f64, so long-settled accounts keep
+    // residual balances around 1e-15. The tests below pin that such balances never
+    // become cash holdings — each one renders as a `$0` row in the Cash drill-down.
+
+    fn cash_snapshot(account_id: &str, balances: Vec<(&str, Decimal)>) -> AccountStateSnapshot {
+        AccountStateSnapshot {
+            account_id: account_id.to_string(),
+            currency: "USD".to_string(),
+            cash_balances: balances
+                .into_iter()
+                .map(|(currency, amount)| (currency.to_string(), amount))
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn cash_dust_is_detected_below_decimal_precision() {
+        assert!(is_cash_dust(Decimal::ZERO));
+        assert!(is_cash_dust(dec!(0.000000000000001)));
+        assert!(is_cash_dust(dec!(-0.000000000000001)));
+        assert!(!is_cash_dust(dec!(0.01)));
+        assert!(!is_cash_dust(dec!(-0.01)));
+        // DECIMAL_PRECISION is 8, well below a cent, so real sub-cent balances survive.
+        assert!(!is_cash_dust(dec!(0.00000001)));
+    }
+
+    #[test]
+    fn cash_dust_boundary_sits_just_above_half_of_decimal_precision() {
+        // `round_dp` uses banker's rounding, so the exact midpoint goes to even (zero)
+        // and the largest discarded balance is 5e-9 — half a nanodollar, either sign.
+        assert!(is_cash_dust(dec!(0.000000005)));
+        assert!(is_cash_dust(dec!(-0.000000005)));
+        assert!(!is_cash_dust(dec!(0.0000000051)));
+        assert!(!is_cash_dust(dec!(-0.0000000051)));
+    }
+
+    #[tokio::test]
+    async fn get_holdings_does_not_round_the_cash_balance_it_emits() {
+        // Only the dust *test* rounds; the balance written into the holding keeps full
+        // precision. Rounding the emitted value would be a behavior change, not a fix.
+        let account_id = "acc-1";
+        let precise = dec!(1234.567890123456789);
+        let snapshot = cash_snapshot(account_id, vec![("USD", precise)]);
+        let service = test_service(snapshot, Vec::new(), HashMap::new());
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+
+        let cash = holdings
+            .iter()
+            .find(|holding| holding.holding_type == HoldingType::Cash)
+            .expect("real balance should survive");
+        assert_eq!(cash.quantity, precise);
+        assert_eq!(cash.market_value.local, precise);
+        assert_eq!(cash.cost_basis.as_ref().unwrap().local, precise);
+    }
+
+    #[tokio::test]
+    async fn get_holdings_skips_dust_cash_balances() {
+        let account_id = "acc-1";
+        let snapshot = cash_snapshot(
+            account_id,
+            vec![
+                ("USD", dec!(0.000000000000001)),
+                ("EUR", dec!(-0.0000000000000023679074)),
+            ],
+        );
+        let service = test_service(snapshot, Vec::new(), HashMap::new());
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+
+        assert!(holdings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_holdings_keeps_real_cash_balances_alongside_dust() {
+        let account_id = "acc-1";
+        let snapshot = cash_snapshot(
+            account_id,
+            vec![
+                ("USD", dec!(2500)),
+                ("EUR", dec!(0.0000000000000092751693)),
+                // A genuine sub-cent balance is money, not noise.
+                ("GBP", dec!(0.001)),
+            ],
+        );
+        let service = test_service(snapshot, Vec::new(), HashMap::new());
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+
+        let mut cash: Vec<(String, Decimal)> = holdings
+            .iter()
+            .filter(|holding| holding.holding_type == HoldingType::Cash)
+            .map(|holding| (holding.local_currency.clone(), holding.quantity))
+            .collect();
+        cash.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(
+            cash,
+            vec![
+                ("GBP".to_string(), dec!(0.001)),
+                ("USD".to_string(), dec!(2500)),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn holdings_from_snapshot_skips_dust_cash_balances() {
+        let snapshot = cash_snapshot(
+            "acc-1",
+            vec![
+                ("USD", dec!(2500)),
+                ("EUR", dec!(0.000000000000001)),
+                ("CAD", dec!(-0.000000000000001)),
+            ],
+        );
+        let service = test_service(snapshot.clone(), Vec::new(), HashMap::new());
+
+        let holdings = service
+            .holdings_from_snapshot(&snapshot, "USD")
+            .await
+            .unwrap();
+
+        let cash: Vec<&Holding> = holdings
+            .iter()
+            .filter(|holding| holding.holding_type == HoldingType::Cash)
+            .collect();
+        assert_eq!(cash.len(), 1);
+        assert_eq!(cash[0].local_currency, "USD");
+        assert_eq!(cash[0].quantity, dec!(2500));
     }
 }


### PR DESCRIPTION
Fixes #1519

Related to #1459 and #889

## Problem

The **Insights → Breakdown → Allocation → Cash** drawer lists a row for every account that has ever held cash, most of them rendering `$0.00`. Accounts fully liquidated years ago keep residual dust balances, which are non-zero and so emit a full cash `Holding` that only collapses to zero at render time.

This is the same defect #1459 fixed for the Net Worth breakdown, in a different code path. `b715b204` rounded before the zero check in `net_worth_service.rs`; the holdings service — which backs the Insights allocation drill-down — was never touched and still compares against exact zero.

## Change

`holdings_service.rs` builds cash holdings from `snapshot.cash_balances` at two sites, both guarded by `if amount == Decimal::ZERO { continue; }`:

- `build_live_holdings_from_snapshot` (the live `get_holdings` path)
- `holdings_from_snapshot` (the historical snapshot viewer path)

Both now call a shared `is_cash_dust` helper that rounds to `DECIMAL_PRECISION` before testing for zero. `DECIMAL_PRECISION` is 8 — well below a cent — so genuine sub-cent balances survive; only float noise is dropped.

Emitted balances are unchanged: the rounding is applied to the *test*, not to the value written into the holding. This is the same invariant `b715b204` held, reached differently — those sites already called `.round_dp` after the check, so the commit could round the emitted value while moving the call earlier. These sites have no pre-existing rounding, so rounding the emitted amount would be a new behavior change.

Cash totals, category values, and allocation percentages are identical before and after — the dust contributed nothing to them. What changes is the row count in the drill-down, and `holdingsCount` in the value strip, which was inflated by the same phantom rows.

Nothing downstream filtered these out: `compute_holdings_by_allocation_from_holdings` skips a row only when its matched *share* is `<= 0` (the share is 1 for cash — the value is never tested), and `merge_non_cash_detail_rows` deliberately keeps cash rows un-merged so each account gets its own line.

The dust itself originates in the storage layer — snapshot `cash_balances` persist as serde-float JSON and the incremental recalc modes re-seed from that `f64` round-trip, so the noise compounds across runs. That remains tracked separately, as noted in #1459.

## Tests

Six new tests in `crates/core/src/portfolio/holdings/holdings_service.rs`:

- `cash_dust_is_detected_below_decimal_precision` — unit-tests the predicate in both signs, and asserts `0.00000001` (exactly `DECIMAL_PRECISION`) is **not** dust.
- `cash_dust_boundary_sits_just_above_half_of_decimal_precision` — pins the actual discard threshold. `round_dp` uses banker's rounding, so the exact midpoint `5e-9` goes to even and is dropped while `5.1e-9` survives; both signs asserted.
- `get_holdings_skips_dust_cash_balances` — positive and negative dust yields no holdings at all.
- `get_holdings_keeps_real_cash_balances_alongside_dust` — a real balance and a genuine sub-cent balance both survive while dust in a third currency is dropped.
- `get_holdings_does_not_round_the_cash_balance_it_emits` — feeds a balance with more than 8 decimal places and asserts `quantity`, `market_value.local`, and `cost_basis.local` all keep full precision, so the unrounded-emit invariant cannot be tidied away unnoticed.
- `holdings_from_snapshot_skips_dust_cash_balances` — same for the snapshot path.

Each was mutation-tested rather than merely observed green. Reverting the fix to `amount == Decimal::ZERO` fails the three behavioral tests (the two predicate unit tests correctly still pass); additionally rounding the emitted amount fails `get_holdings_does_not_round_the_cash_balance_it_emits` with `left: 1234.56789012`, `right: 1234.567890123456789`.
## Verification

Apart from test gates, verified end-to-end against a rebuilt server image and real data

## Related site not changed

`build_cash_currency_split` in `crates/core/src/portfolio/valuation/current_account_valuation.rs` uses the same `!value.is_zero()` pattern. It aggregates per currency across all accounts, so dust only surfaces there if an entire currency consists of nothing but dust. Left alone to keep this diff scoped; worth a follow-up.
