### PR TITLE
fix(import): make amount optional for investment CSVs

### DIFF
--- a/apps/frontend/src/lib/constants.ts
+++ b/apps/frontend/src/lib/constants.ts
@@ -270,10 +270,7 @@ export const IMPORT_REQUIRED_FIELDS = [
   ImportFormat.SYMBOL,
   ImportFormat.QUANTITY,
   ImportFormat.UNIT_PRICE,
-  ImportFormat.AMOUNT,
 ] as const;
-
-export type ImportRequiredField = (typeof IMPORT_REQUIRED_FIELDS)[number];
 
 export const ExportDataType = {
   ACCOUNTS: "accounts",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -48,7 +48,7 @@ export {
 
 export type { HoldingCategoryFilterId } from "./constants";
 
-export type { ActivitySubtype, ImportRequiredField } from "./constants";
+export type { ActivitySubtype } from "./constants";
 
 export interface PortfolioWithAccounts {
   id: string;

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -8,7 +8,6 @@ import {
   CsvRowData,
   ImportFormat,
   ImportMappingData,
-  ImportRequiredField,
   type SymbolSearchResult,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -56,7 +55,7 @@ export function MappingHeaderCell({
   const displayHeader = Array.isArray(mappedHeader) ? mappedHeader[0] : mappedHeader;
   const isMapped = displayHeader ? headers.includes(displayHeader) : false;
   const isEditing = editingHeader === field || !isMapped;
-  const isRequired = requiredFields.includes(field as ImportRequiredField);
+  const isRequired = requiredFields.includes(field);
 
   return (
     <div>

--- a/apps/frontend/src/pages/activity/import/utils/activity-import-profile.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-import-profile.test.ts
@@ -18,6 +18,7 @@ describe("activity import profiles", () => {
     expect(profile).toBe(DEFAULT_ACTIVITY_IMPORT_PROFILE);
     expect(profile.assetResolutionEnabled).toBe(true);
     expect(profile.requiredMappingFields).toContain(ImportFormat.SYMBOL);
+    expect(profile.requiredMappingFields).not.toContain(ImportFormat.AMOUNT);
   });
 
   it("uses a transaction profile for cash and credit card accounts", () => {


### PR DESCRIPTION
## Description

Investment CSVs with valid BUY/SELL rows are blocked at Mapping when they have no Amount column, even if Quantity and Unit Price are supplied.

The [CSV import guide's amount rules](https://wealthfolio.app/docs/guide/csv-import/#how-amounts-are-imported) describe calculating missing BUY/SELL totals from the trade details, and the [BUY/SELL activity reference](https://github.com/wealthfolio/wealthfolio/blob/main/docs/activities/activity-types.md#trading-activities) also permits an omitted amount to be calculated. That documented approach is correct: these trades already provide the information needed to calculate their value. The unconditional mapping requirement prevents files without an Amount column from reaching the existing validation and calculation logic.

The CSV guide's required-column table still lists Amount; this PR aligns the mapping gate with its activity-specific trade rules so those files can use the documented behavior.

- make `amount` optional at the mapping stage for investment imports, where quantity and unit price are already required
- keep `amount` required for cash and credit-card transaction imports
- leave activity-specific requirements to the existing row validation in Review

Fixes #1523

## Why this works

Import mapping requirements are profile-specific. The investment profile already requires `date`, `activityType`, `symbol`, `quantity`, and `unitPrice`, so removing `amount` only stops the mapping step from demanding a redundant column for BUY and SELL rows. Those rows are validated from positive quantity and unit price values and do not require `amount`.

This does not make Amount universally optional. Review still validates every parsed row according to its activity type, so rows such as regular dividends or splits fail with an Amount error when their required value is missing. Cash and credit-card profiles also keep their separate required fields of `date`, `activityType`, and `amount`, so their mapping behavior is unchanged.

## Testing

### Automated checks

- `pnpm --filter frontend test --run src/pages/activity/import/utils/activity-import-profile.test.ts src/pages/activity/import/utils/draft-utils.test.ts src/pages/activity/import/components/mapping-table.test.tsx`
- `pnpm type-check`
- targeted ESLint
- `pnpm --filter frontend build`
- `pnpm --filter frontend build:tauri`

### CSV fixture validation

Tested six synthetic CSV files in an isolated web instance with a fresh database and separate Securities, Cash, and Credit Card accounts. All six files were also parsed successfully through the web import API.

- BUY and SELL rows with quantity and unit price but no Amount column passed Mapping and Review.
- A mixed investment file without Amount passed Mapping, while Review correctly rejected a regular dividend and a split that require Amount.
- Regular dividend and split rows with explicit Amount values passed Review.
- Cash and credit-card files kept Amount as a required mapping and accepted their profile-specific activity aliases.
- A transaction file without an Amount column was blocked at Mapping for Cash and Credit Card accounts.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

