### PR TITLE
fix(goals): make an unset pension fund return mean one rate, not three

### DIFF
--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -27,7 +27,11 @@ import type { TFunction } from "i18next";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_DC_PAYOUT_ESTIMATE_RATE } from "../lib/constants";
-import { incomeStreamMonthlyAmount, type PlannerMode } from "../lib/dashboard-math";
+import {
+  incomeStreamMonthlyAmount,
+  planAccumulationReturn,
+  type PlannerMode,
+} from "../lib/dashboard-math";
 import {
   createExpenseItem,
   expenseAgeRangeLabel,
@@ -1260,13 +1264,11 @@ export function SidebarConfigurator({
                             />
                             <LeverRow
                               label={t("goals:sidebar.income.fund_return_before_payout")}
-                              value={
-                                s.accumulationReturn ?? draft.investment.preRetirementAnnualReturn
-                              }
+                              value={s.accumulationReturn ?? planAccumulationReturn(draft)}
                               onChange={(v) => updateStream(s.id, { accumulationReturn: v })}
                               min={0}
                               max={rateSliderMaxFor(
-                                s.accumulationReturn ?? draft.investment.preRetirementAnnualReturn,
+                                s.accumulationReturn ?? planAccumulationReturn(draft),
                                 DEFAULT_RETURN_SLIDER_MAX,
                                 RATE_SLIDER_INCREMENT,
                                 MAX_RETIREMENT_RETURN,
@@ -1276,7 +1278,7 @@ export function SidebarConfigurator({
                               suffix="%"
                               format={(v) => (v * 100).toFixed(1)}
                               warning={highReturnWarning(
-                                s.accumulationReturn ?? draft.investment.preRetirementAnnualReturn,
+                                s.accumulationReturn ?? planAccumulationReturn(draft),
                               )}
                             />
                             <LeverRow

--- a/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.test.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import type { RetirementIncomeStream, RetirementPlan } from "../types";
 import {
   deriveRetirementReadiness,
+  netAnnualReturn,
+  planAccumulationReturn,
   projectedAnnualIncomeNominalAtAge,
   resolveCoverageAnnualNominalValues,
   resolveFundedProgress,
   resolvePortfolioDrawRate,
 } from "./dashboard-math";
+import { DEFAULT_DC_PAYOUT_ESTIMATE_RATE } from "./constants";
 import { DEFAULT_RETIREMENT_PLAN } from "./plan-adapter";
 
 function planWithFund(stream: Partial<RetirementIncomeStream>): RetirementPlan {
@@ -117,6 +120,29 @@ describe("retirement dashboard math", () => {
         horizonAge: 90,
       }),
     ).toMatchObject({ tone: "bad", problem: "portfolio-depletion" });
+  });
+
+  it("grows a fund with no return of its own at the plan rate net of fees", () => {
+    // The engine's fallback is `plan_accumulation_return`, which is net of the
+    // investment fee. The preview used the gross assumption, so the two
+    // disagreed by the fee drag for any fund that never set its own return.
+    const plan = planWithFund({ accumulationReturn: undefined });
+    const net = planAccumulationReturn(plan);
+
+    expect(net).toBeLessThan(plan.investment.preRetirementAnnualReturn);
+    expect(net).toBeCloseTo(
+      netAnnualReturn(
+        plan.investment.preRetirementAnnualReturn,
+        plan.investment.annualInvestmentFeeRate,
+      ),
+      12,
+    );
+
+    const balanceAt65 = 120_000 * Math.pow(1 + net, 20);
+    expect(projectedAnnualIncomeNominalAtAge(plan, 65, 65)).toBeCloseTo(
+      balanceAt65 * DEFAULT_DC_PAYOUT_ESTIMATE_RATE,
+      4,
+    );
   });
 
   it("draws fund income at the stream's payout rate, defaulting to 3.5%/yr", () => {

--- a/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts
@@ -22,6 +22,23 @@ export function boundedInflationFactor(rate: number, years: number) {
   return Math.max(0.01, Math.pow(1 + rate, Math.max(0, years)));
 }
 
+/** Mirror of the engine's `net_annual_return`: the fee comes off the assumption. */
+export function netAnnualReturn(grossReturn: number, annualFeeRate: number) {
+  return Math.max(-0.99, grossReturn - annualFeeRate);
+}
+
+/**
+ * Mirror of the engine's `plan_accumulation_return`, and the rate a fund with no
+ * `accumulationReturn` of its own grows at. The plan's stated return is gross of
+ * the investment fee everywhere the engine consumes it.
+ */
+export function planAccumulationReturn(plan: RetirementPlan) {
+  return netAnnualReturn(
+    plan.investment.preRetirementAnnualReturn,
+    plan.investment.annualInvestmentFeeRate,
+  );
+}
+
 export function projectedAnnualExpenseNominalAtAge(plan: RetirementPlan, age: number) {
   const yearsFromNow = Math.max(0, age - plan.personal.currentAge);
   return activeExpenseItems(plan.expenses, age).reduce((sum, item) => {
@@ -78,7 +95,7 @@ export function projectedAnnualIncomeNominalAtAge(
             stream,
             plan.personal.currentAge,
             retirementAge,
-            plan.investment.preRetirementAnnualReturn,
+            planAccumulationReturn(plan),
           )
         : (stream.monthlyAmount ?? 0);
     const annual = baseMonthly * 12;
@@ -99,7 +116,7 @@ export function incomeStreamMonthlyAmount(plan: RetirementPlan, stream: Retireme
       stream,
       plan.personal.currentAge,
       plan.personal.targetRetirementAge,
-      plan.investment.preRetirementAnnualReturn,
+      planAccumulationReturn(plan),
     );
   }
   return stream.monthlyAmount ?? 0;

--- a/crates/core/src/planning/retirement/engine.rs
+++ b/crates/core/src/planning/retirement/engine.rs
@@ -346,6 +346,7 @@ pub(crate) fn step_plan_pension_funds(
     balances: &mut HashMap<String, f64>,
     age: u32,
     in_fire: bool,
+    default_accumulation_return: f64,
 ) {
     for s in streams {
         let has_accumulation =
@@ -357,7 +358,10 @@ pub(crate) fn step_plan_pension_funds(
             .get(&s.id)
             .unwrap_or(&s.current_value.unwrap_or(0.0));
         if age < s.start_age {
-            let r = s.accumulation_return.unwrap_or(0.04);
+            // The same fallback `resolve_plan_dc_payouts` uses, so the balance
+            // reported as an asset and the balance the payout is derived from
+            // are the same balance.
+            let r = s.accumulation_return.unwrap_or(default_accumulation_return);
             let contributions = if in_fire {
                 0.0
             } else {
@@ -745,7 +749,13 @@ pub(crate) fn project_retirement_with_mode_cached(
             buckets = next_buckets;
         }
 
-        step_plan_pension_funds(&plan.income_streams, &mut pension_balances, age, in_fire);
+        step_plan_pension_funds(
+            &plan.income_streams,
+            &mut pension_balances,
+            age,
+            in_fire,
+            plan_accumulation_return(plan),
+        );
     }
 
     FireProjection {
@@ -1142,6 +1152,65 @@ mod tests {
 
         assert!(age_64.pension_assets > 0.0);
         assert_eq!(age_65.pension_assets, 0.0);
+    }
+
+    #[test]
+    fn an_unset_fund_return_grows_the_balance_at_the_plan_rate_net_of_fees() {
+        let mut plan = base_plan();
+        plan.personal.current_age = 60;
+        plan.personal.target_retirement_age = 65;
+        plan.personal.planning_horizon_age = 70;
+        plan.investment.monthly_contribution = 0.0;
+        plan.investment.pre_retirement_annual_return = 0.10;
+        plan.investment.annual_investment_fee_rate = 0.02;
+        plan.income_streams.push(RetirementIncomeStream {
+            id: "dc".into(),
+            label: "RRSP".into(),
+            stream_type: StreamKind::DefinedContribution,
+            start_age: 65,
+            adjust_for_inflation: false,
+            annual_growth_rate: None,
+            monthly_amount: None,
+            linked_account_id: None,
+            current_value: Some(100_000.0),
+            monthly_contribution: None,
+            accumulation_return: None,
+            payout_rate: None,
+        });
+
+        let projection = project_retirement(&plan, 5_000_000.0);
+        let reported = |age: u32| {
+            projection
+                .year_by_year
+                .iter()
+                .find(|snapshot| snapshot.age == age)
+                .unwrap_or_else(|| panic!("age {age} snapshot should exist"))
+                .pension_assets
+        };
+
+        // 8%/yr: the plan's 10% net of its 2% fee. Not the gross 10%, and not the
+        // 4% constant this used to fall back to.
+        assert!((reported(60) - 100_000.0).abs() < 1e-6);
+        assert!(
+            (reported(61) - 108_000.0).abs() < 1e-6,
+            "expected the plan's net rate, got {}",
+            reported(61)
+        );
+        assert!((reported(64) - 100_000.0 * 1.08_f64.powi(4)).abs() < 1e-6);
+
+        // And the payout is taken from that same balance carried one more year,
+        // rather than from a second balance grown at a different rate.
+        let payouts = resolve_plan_dc_payouts(
+            &plan.income_streams,
+            60,
+            65,
+            plan_accumulation_return(&plan),
+        );
+        let expected = reported(64) * 1.08 * DEFAULT_DC_PAYOUT_ESTIMATE_RATE / 12.0;
+        assert!(
+            (payouts["dc"] - expected).abs() < 1e-6,
+            "the reported balance and the payout basis must be one balance"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

A defined-contribution income stream's `accumulationReturn` is optional. When it
is absent, three different fallbacks decide how the fund grows:

- `resolve_plan_dc_payouts`
  ([`engine.rs`](https://github.com/wealthfolio/wealthfolio/blob/main/crates/core/src/planning/retirement/engine.rs))
  is called with `plan_accumulation_return(plan)` at every site — the plan's
  pre-retirement assumption **net of** `annual_investment_fee_rate`.
- `step_plan_pension_funds`, which advances the balance reported as
  `pension_assets`, uses a hardcoded `0.04`. It takes the streams and not the
  plan, so it cannot see the plan's rate at all.
- `projectedDcMonthlyPayout`
  ([`dashboard-math.ts`](https://github.com/wealthfolio/wealthfolio/blob/main/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts))
  is called with `plan.investment.preRetirementAnnualReturn` — the **gross**
  assumption.

Two consequences.

**One fund has two balances inside a single projection.** The balance reported
as `pension_assets` compounds at 4%; the balance the payout is derived from
compounds at the plan's net rate. Nothing reconciles them, so the asset figure
shown during accumulation is not the figure the income is calculated from.

**The sidebar previews a third number that is neither.** At the shipped defaults
— 5.77% assumption, 0.6% fee — a 120k fund starting at 65, twenty years out,
previews 12,897/yr where the engine will pay 11,510/yr. About 12%, entirely from
the fee never being taken off in the preview. The gap widens with the horizon
and with the fee.

### The fix

All three resolve to the same rate: the plan's assumption net of fees. That is
what the payout resolver already used, and it is the only one of the three
consistent with how the portfolio itself is projected — `plan_accumulation_return`
and `plan_retirement_return` are both net.

- `step_plan_pension_funds` takes a `default_accumulation_return` parameter
  instead of guessing. The `0.04` bore no relationship to the plan it was
  projecting.
- The frontend gains `netAnnualReturn` and `planAccumulationReturn`, mirrors of
  the engine functions of the same name, and both `projectedDcMonthlyPayout`
  call sites use them.
- The fund-return lever in the sidebar shows the rate the engine will actually
  use when the fund has not set one, rather than the gross assumption.

### Scope

Only funds with **no** `accumulationReturn` of their own change. A fund with an
explicit rate was already consistent across all three paths and is untouched.

That is also why this went unnoticed: the sidebar writes an explicit rate when a
fund is created and when a stream is switched to `dc`, so most funds carry one.
Streams that predate that behaviour, or that are created any other way, do not.
Those write paths are deliberately left alone — what they store is a product
default, not part of this defect.

### Testing

New Rust test: a fund with no rate of its own, on a plan at 10% gross with a 2%
fee, has its reported `pension_assets` compound at 8% — asserting against both
the old `0.04` and the gross `0.10` — and the payout is checked to derive from
that same balance carried one more year rather than from a second one.

New frontend test: the previewed income for a fund with no rate matches the
balance compounded at the net rate. Reverted against the unfixed code it fails
by the full 1,387/yr, so it is a real guard rather than a restatement.

`cargo test -p wealthfolio-core` (1774 pass; 3 pre-existing `addons` packaging
failures, unrelated and failing identically on a clean checkout of `main`),
`cargo clippy -p wealthfolio-core --all-targets` clean, `cargo fmt --check`,
plus `pnpm test` (1500), `pnpm type-check` and `pnpm lint:quiet`.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
