### PR TITLE
fix(goals): show a pension fund's growth mode in its collapsed summary

### DIFF
--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -1112,24 +1112,25 @@ export function SidebarConfigurator({
               const expanded = expandedIncomeId === s.id;
               const amount = incomeStreamMonthlyAmount(draft, s);
               const growthMeta =
-                s.streamType === "dc"
-                  ? t("goals:sidebar.income.balance_derived_payout")
-                  : s.annualGrowthRate !== undefined
-                    ? t("goals:sidebar.income.growth_meta", {
-                        pct: numberFormatting.formatDecimal(s.annualGrowthRate * 100, {
-                          minimumFractionDigits: 1,
-                          maximumFractionDigits: 1,
-                        }),
-                      })
-                    : s.adjustForInflation
-                      ? t("goals:sidebar.income.inflation_indexed")
-                      : t("goals:sidebar.income.fixed_nominal");
+                s.annualGrowthRate !== undefined
+                  ? t("goals:sidebar.income.growth_meta", {
+                      pct: numberFormatting.formatDecimal(s.annualGrowthRate * 100, {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      }),
+                    })
+                  : s.adjustForInflation
+                    ? t("goals:sidebar.income.inflation_indexed")
+                    : t("goals:sidebar.income.fixed_nominal");
               const meta = [
                 t("goals:sidebar.income.age_range", {
                   start: s.startAge,
                   end: draft.personal.planningHorizonAge,
                 }),
                 growthMeta,
+                ...(s.streamType === "dc"
+                  ? [t("goals:sidebar.income.balance_derived_payout")]
+                  : []),
               ].join(" · ");
 
               return (


### PR DESCRIPTION
## The problem

The retirement sidebar's income row builds its collapsed summary meta as

```ts
const growthMeta =
  s.streamType === "dc"
    ? t("goals:sidebar.income.balance_derived_payout")
    : s.annualGrowthRate !== undefined
      ? t("goals:sidebar.income.growth_meta", { ... })
      : s.adjustForInflation
        ? t("goals:sidebar.income.inflation_indexed")
        : t("goals:sidebar.income.fixed_nominal");
```

For a defined-contribution fund the payout note *replaces* the
indexed-versus-fixed line rather than joining it. The indexed/fixed toggle and
the custom-growth override are both rendered for DC streams — that block is not
gated on `streamType` — so a fund does have a growth mode. It is just only
legible with the row expanded.

## Why it matters

The mode is not decoration for a fund. `resolve_plan_income` in
`crates/core/src/planning/retirement/engine.rs` applies the same growth to a DC
stream's resolved payout as to any other stream: a custom `annual_growth_rate`
if set, otherwise inflation if `adjust_for_inflation`, otherwise flat. So the
payout rate sets a fund's first payment and the growth mode sets its slope for
the whole payout phase. At the default 2% inflation an indexed fund pays about
64% more than a fixed one 25 years into the payout phase.

It is also the field most likely to be wrong without the user knowing, because
the two ways of creating a stream disagree on purpose:

- the **Add pension fund** preset passes `adjustForInflation: false`
- the generic **Add income** button defaults to `true`

A stream created as income and later switched to a fund keeps the indexed
default — correctly, and silently. The collapsed summary is where a user would
notice which one they have, and it is the one place that does not say.

The two defaults are not the bug and this changes neither. Indexed is right for
the DB streams it was chosen for, and the toggle is present and editable.

## The change

Join the two facts instead of choosing between them, and put the growth mode
*ahead* of the payout note. The meta line is `truncate`d inside a sidebar that
is one column of a `lg:grid-cols-3` grid, so on a narrow window the trailing
segment is the one that disappears. Ordered this way the segment that survives
is the one that is invisible elsewhere while the row is collapsed; the
balance-derived note is recoverable from the fund levers in the same row.

A fund now reads `Age 67 → 95 · Inflation indexed · Balance-derived payout`
where it read `Age 67 → 95 · Balance-derived payout`.

## Scope

- Non-DC streams render byte-identically — the `growthMeta` branch they take is
  unchanged, and the spread contributes nothing.
- No new i18n keys. All four strings already existed and are translated in de,
  es, fr, ja, ko and zh.
- The reindentation in the diff is prettier's, from dropping one ternary nesting
  level.

`pnpm type-check` passes. `prettier --check` is clean on the changed file
(content-identical to `prettier` output).
