### PR TITLE
Fix Treasury securities misclassified as equity, corrupting trade amount

### DIFF
--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -426,10 +426,17 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
     Number(quantity) * Number(unitPrice) * getContractMultiplier(activity),
   );
 
-  // Securities transfers imported without a unit price (legacy / some broker
-  // exports) carry their monetary value on `amount`. Fall back to it so those
-  // rows don't render as 0 just because we no longer trust `amount` by default.
-  if (isSecTransfer && activityAmount === 0) {
+  // Bond prices are quoted as percent-of-par, not a literal per-unit dollar
+  // price, so quantity * unitPrice isn't the trade value. The backend always
+  // trusts the broker-reported `amount` for bonds (see
+  // should_use_activity_amount in holdings_calculator/economics.rs) --
+  // mirror that here instead of computing our own (wrong) total.
+  if (activity.instrumentType === InstrumentType.BOND) {
+    activityAmount = roundCurrency(getAmount(activity));
+  } else if (isSecTransfer && activityAmount === 0) {
+    // Securities transfers imported without a unit price (legacy / some broker
+    // exports) carry their monetary value on `amount`. Fall back to it so those
+    // rows don't render as 0 just because we no longer trust `amount` by default.
     const storedAmount = getAmount(activity);
     if (storedAmount !== 0) {
       activityAmount = roundCurrency(storedAmount);

--- a/crates/connect/src/broker/mapping.rs
+++ b/crates/connect/src/broker/mapping.rs
@@ -286,6 +286,29 @@ fn is_broker_bond(code: Option<&str>) -> bool {
     )
 }
 
+/// Infers bond vs equity from amount / (quantity * price): equities are
+/// ~1, percent-of-par bonds are ~0.01 -- 100x apart, so robust to rounding
+/// drift. Returns false when any input is missing or zero (e.g. a
+/// zero-price bond redemption), since that shape is indistinguishable from
+/// a fixed-NAV fund trade.
+fn infers_bond_from_amount_ratio(
+    quantity: Option<Decimal>,
+    unit_price: Option<Decimal>,
+    amount: Option<Decimal>,
+) -> bool {
+    let (Some(quantity), Some(unit_price), Some(amount)) = (quantity, unit_price, amount) else {
+        return false;
+    };
+    if quantity.is_zero() || unit_price.is_zero() || amount.is_zero() {
+        return false;
+    }
+    let naive_equity_amount = quantity * unit_price;
+    let ratio = amount / naive_equity_amount;
+    // Percent-of-par band: amount is roughly 0.5%-2% of the naive equity
+    // value (e.g. a bond price of 98.35 quoted per $100 face, not $98.35/share).
+    ratio >= Decimal::new(5, 3) && ratio <= Decimal::new(2, 2)
+}
+
 /// The instrument identity a broker payload names: its ticker and its venue.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedBrokerSymbol {
@@ -473,7 +496,25 @@ pub fn map_broker_activity(
     let symbol_type_ref = symbol_ref.and_then(|s| s.symbol_type.as_ref());
     let symbol_type_code = symbol_type_ref.and_then(|t| t.code.as_deref());
     let is_crypto = is_broker_crypto(symbol_type_code);
-    let is_bond = is_broker_bond(symbol_type_code);
+    // Options have their own pricing mechanics (contract multiplier), so
+    // they are excluded from the ratio check the same way is_broker_bond
+    // exclusions work -- this only needs to know whether an option leg is
+    // present, not the fully-resolved option_symbol computed further below.
+    let is_option_leg = option_leg_type.is_some()
+        || activity
+            .option_symbol
+            .as_ref()
+            .and_then(|s| s.ticker.as_deref())
+            .is_some_and(|t| !t.trim().is_empty());
+    let is_bond = is_broker_bond(symbol_type_code)
+        || (symbol_type_code.map(str::trim).unwrap_or("").is_empty()
+            && !is_option_leg
+            && !is_crypto
+            && infers_bond_from_amount_ratio(
+                activity.units.and_then(Decimal::from_f64).map(|d| d.abs()),
+                activity.price.and_then(Decimal::from_f64).map(|d| d.abs()),
+                activity.amount.and_then(Decimal::from_f64).map(|d| d.abs()),
+            ));
 
     // Ticker and venue come from the same normalization the holdings path uses, so
     // one instrument cannot land under two asset identities depending on which
@@ -809,6 +850,79 @@ mod tests {
         assert_eq!(mapped.amount.unwrap().round_dp(4), decimal("997.6000"));
         assert_eq!(mapped.fee.unwrap().round_dp(4), decimal("4.9000"));
         assert_eq!(mapped.tax, None);
+    }
+
+    #[test]
+    fn test_map_broker_activity_detects_bond_via_amount_ratio_when_type_code_missing() {
+        // Some institutions send no symbol_type_code at all for fixed-income
+        // securities. Without this fallback, this would be treated as a
+        // plain equity trade and its percent-of-par bond price would get
+        // multiplied straight into the amount. Numbers here are synthetic.
+        let activity = AccountUniversalActivity {
+            id: Some("act-bond-buy".to_string()),
+            activity_type: Some("BUY".to_string()),
+            symbol: Some(broker_symbol("ZZZTEST99", "")),
+            units: Some(1000.0),
+            price: Some(95.5),
+            amount: Some(955.0),
+            ..Default::default()
+        };
+
+        let mapped = map_test_activity(&activity);
+
+        let asset = mapped.asset.expect("bond activity should produce an asset");
+        assert_eq!(asset.kind.as_deref(), Some("BOND"));
+        assert_eq!(asset.instrument_type.as_deref(), Some("BOND"));
+        assert_eq!(mapped.amount.unwrap().round_dp(2), decimal("955.00"));
+        // The amount/quantity/price relationship directly confirms the
+        // pricing convention used on this trade -- unlike a heuristic
+        // guess from symbol formatting, so no review flag is needed.
+        assert_eq!(mapped.needs_review, Some(false));
+    }
+
+    #[test]
+    fn test_map_broker_activity_amount_ratio_ignores_equity_shaped_trade() {
+        // amount ~= quantity * price (ratio ~1) is the equity shape, not
+        // the bond shape (ratio ~0.01) -- must not be misdetected as a bond
+        // just because the type code happens to be missing.
+        let activity = AccountUniversalActivity {
+            id: Some("act-equity-buy".to_string()),
+            activity_type: Some("BUY".to_string()),
+            symbol: Some(broker_symbol("ZZZTEST00", "")),
+            units: Some(10.0),
+            price: Some(50.0),
+            amount: Some(500.0),
+            ..Default::default()
+        };
+
+        let mapped = map_test_activity(&activity);
+
+        let asset = mapped.asset.expect("equity activity should produce an asset");
+        assert_ne!(asset.instrument_type.as_deref(), Some("BOND"));
+    }
+
+    #[test]
+    fn test_map_broker_activity_amount_ratio_leaves_zero_price_undetected() {
+        // A bond redeemed at maturity typically carries no market price, so
+        // quantity == amount with price == 0 -- indistinguishable from a
+        // fixed-NAV fund trade shape. Left as equity rather than guessed.
+        let activity = AccountUniversalActivity {
+            id: Some("act-redemption".to_string()),
+            activity_type: Some("SELL".to_string()),
+            symbol: Some(broker_symbol("ZZZTEST99", "")),
+            units: Some(1000.0),
+            price: Some(0.0),
+            amount: Some(1000.0),
+            ..Default::default()
+        };
+
+        let mapped = map_test_activity(&activity);
+
+        let asset = mapped.asset.expect("activity should produce an asset");
+        assert_ne!(asset.instrument_type.as_deref(), Some("BOND"));
+        // Amount must stay intact regardless of the classification: a
+        // price of 0 never triggers the equity-recompute path.
+        assert_eq!(mapped.amount.unwrap().round_dp(2), decimal("1000.00"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #1544

- Some brokers (SnapTrade/Akoya) send no `symbol_type_code` at all for certain fixed-income securities. `is_broker_bond()` only recognized explicit codes, so these traded as if they were equity — and the mapper multiplied the bond's percent-of-par price straight into the trade amount instead of preserving the broker's reported amount (~100x overstatement). The asset itself was also created as `EQUITY` instead of `BOND`.
- Added a fallback bond signal based on the reported amount itself: equities report `amount ≈ quantity × price` (ratio ≈ 1), while percent-of-par bonds report `amount ≈ (quantity × price) / 100` (ratio ≈ 0.01) — a 100x gap, wide enough to stay robust to real-world rounding/fee drift. Scoped narrowly: only evaluated when the broker's type code is blank, so it never overrides an explicit classification.
- The check intentionally says nothing (leaves the activity as-is) when quantity, price, or amount is missing or zero — for example, a bond redeemed at maturity typically carries no market price, and that shape (`quantity == amount`, `price == 0`) is numerically indistinguishable from a fixed-NAV fund trade. This gap doesn't reintroduce the corruption bug, though: the amount-multiplication bug only fires when price is *nonzero*, which is exactly the case this check *can* resolve.
- Also fixed the frontend activity list (`activity-utils.ts`), which independently recomputed `quantity * unitPrice` for the "Total" column instead of reading the backend's `amount` field — meaning even correctly-classified bonds displayed a wrong or zeroed total. Now mirrors the backend's `should_use_activity_amount` logic (trust `amount` for bonds).

## Test plan
- [x] `cargo test -p wealthfolio-connect --lib broker::mapping` — all tests pass
- [x] `test_map_broker_activity_detects_bond_via_amount_ratio_when_type_code_missing` — correct BOND classification and amount preservation, no review flag
- [x] `test_map_broker_activity_amount_ratio_ignores_equity_shaped_trade` — a ratio-≈1 trade with blank type code stays equity, not misdetected as     bond
- [x] `test_map_broker_activity_amount_ratio_leaves_zero_price_undetected` — a zero-price redemption is left unclassified rather than guessed, and its amount stays intact regardless

> Description drafted by Claude Sonnet 5

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
