### PR TITLE
Fix broker sync: derive price for BUY/SELL trades with no reported price

### DIFF
--- a/crates/connect/src/broker/mapping.rs
+++ b/crates/connect/src/broker/mapping.rs
@@ -591,6 +591,25 @@ pub fn map_broker_activity(
     let unit_price = activity.price.and_then(Decimal::from_f64).map(|d| d.abs());
     let fee = activity.fee.and_then(Decimal::from_f64).map(|d| d.abs());
     let amount = activity.amount.and_then(Decimal::from_f64).map(|d| d.abs());
+
+    // Some funds (e.g. money market funds) settle at a fixed $1 NAV; brokers
+    // sometimes omit price for these trades while still reporting amount.
+    // Derive price from amount/quantity so balance math isn't zeroed out.
+    let is_plain_trade = matches!(
+        activity_type.as_str(),
+        activities::ACTIVITY_TYPE_BUY | activities::ACTIVITY_TYPE_SELL
+    ) && !is_option_activity
+        && !is_crypto
+        && !is_bond;
+    let unit_price = if is_plain_trade && unit_price.map(|p| p.is_zero()).unwrap_or(true) {
+        match (quantity, amount) {
+            (Some(q), Some(a)) if !q.is_zero() && !a.is_zero() => Some(a / q),
+            _ => unit_price,
+        }
+    } else {
+        unit_price
+    };
+
     let amount = normalized_trade_amount(
         &activity_type,
         quantity,
@@ -809,6 +828,26 @@ mod tests {
         assert_eq!(mapped.amount.unwrap().round_dp(4), decimal("997.6000"));
         assert_eq!(mapped.fee.unwrap().round_dp(4), decimal("4.9000"));
         assert_eq!(mapped.tax, None);
+    }
+
+    #[test]
+    fn test_map_broker_activity_derives_price_for_zero_price_fund_trade() {
+        // Money market funds settle at a fixed $1 NAV; SnapTrade reports
+        // units and amount for these but omits price.
+        let activity = AccountUniversalActivity {
+            id: Some("act-mmf-buy".to_string()),
+            activity_type: Some("BUY".to_string()),
+            symbol: Some(broker_symbol("AAFXX", "oef")),
+            units: Some(87.3),
+            price: None,
+            amount: Some(87.3),
+            ..Default::default()
+        };
+
+        let mapped = map_test_activity(&activity);
+
+        assert_eq!(mapped.unit_price.unwrap().round_dp(4), decimal("1.0000"));
+        assert_eq!(mapped.amount.unwrap().round_dp(4), decimal("87.3000"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #1546

- Derive `unit_price = amount / quantity` for plain BUY/SELL trades (not bond/option/crypto, which have their own pricing conventions) when price is missing but quantity and amount are both present and nonzero, instead of silently leaving price at 0.
- This is an exact recovery, not a guess — `amount` and `quantity` are both broker-reported and trustworthy; only the division to back out price was missing. No review flag needed.

## Test plan

- [x] `cargo test -p wealthfolio-connect --lib broker::mapping` — all tests pass
- [x] `test_map_broker_activity_derives_price_for_zero_price_fund_trade` — covers a fixed-NAV trade with `price: None`, confirms derived price and preserved amount

> Description drafted by Claude Sonnet 5

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
