### PR TITLE
fix(goals): preserve inherited fund returns

### DIFF
--- a/apps/frontend/src/features/goals/components/goal-lever-row.tsx
+++ b/apps/frontend/src/features/goals/components/goal-lever-row.tsx
@@ -70,6 +70,7 @@ export function GoalLeverRow({
   const [moneyInputFocused, setMoneyInputFocused] = useState(false);
   const skipNextMoneyCommitRef = useRef(false);
   const [draftValue, setDraftValue] = useState<string | null>(null);
+  const numberDraftDirtyRef = useRef(false);
   const displayValue = draftValue ?? format(value);
 
   const commitMoneyDraftValue = () => {
@@ -87,6 +88,12 @@ export function GoalLeverRow({
   };
 
   const commitDraftValue = () => {
+    if (!numberDraftDirtyRef.current) {
+      setDraftValue(null);
+      return;
+    }
+    numberDraftDirtyRef.current = false;
+
     const raw = displayValue.trim();
     if (!raw) {
       setDraftValue(null);
@@ -150,11 +157,13 @@ export function GoalLeverRow({
               inputMode={suffix === "%" ? "decimal" : "numeric"}
               value={displayValue}
               onFocus={() => {
+                numberDraftDirtyRef.current = false;
                 setDraftValue(format(value));
               }}
               onChange={(event) => {
                 const next = event.target.value;
                 if (/^-?\d*([.,]\d*)?$/.test(next)) {
+                  numberDraftDirtyRef.current = true;
                   setDraftValue(next);
                 }
               }}
@@ -166,6 +175,7 @@ export function GoalLeverRow({
                   event.currentTarget.blur();
                 }
                 if (event.key === "Escape") {
+                  numberDraftDirtyRef.current = false;
                   setDraftValue(null);
                 }
               }}

--- a/apps/frontend/src/features/goals/components/goal-lever-row.tsx
+++ b/apps/frontend/src/features/goals/components/goal-lever-row.tsx
@@ -100,7 +100,7 @@ export function GoalLeverRow({
       return;
     }
 
-    const parsed = parseFloat(raw.replace(/,/g, ""));
+    const parsed = parseFloat(raw.replace(",", "."));
     if (Number.isNaN(parsed)) {
       setDraftValue(null);
       return;

--- a/apps/frontend/src/features/goals/components/goal-lever-row.ui.test.tsx
+++ b/apps/frontend/src/features/goals/components/goal-lever-row.ui.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GoalLeverRow } from "./goal-lever-row";
+
+function renderRateLever(value: number, onChange: (value: number) => void) {
+  render(
+    <GoalLeverRow
+      label="Fund return"
+      value={value}
+      onChange={onChange}
+      min={-0.2}
+      max={0.15}
+      inputMax={0.5}
+      step={0.001}
+      suffix="%"
+      format={(next) => (next * 100).toFixed(1)}
+    />,
+  );
+}
+
+describe("GoalLeverRow number input", () => {
+  it("does not commit an untouched negative value on blur", () => {
+    const onChange = vi.fn();
+    renderRateLever(-0.006, onChange);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("commits a negative value after the user edits it", () => {
+    const onChange = vi.fn();
+    renderRateLever(-0.006, onChange);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "-2.0" } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith(-0.02);
+  });
+});

--- a/apps/frontend/src/features/goals/components/goal-lever-row.ui.test.tsx
+++ b/apps/frontend/src/features/goals/components/goal-lever-row.ui.test.tsx
@@ -41,4 +41,16 @@ describe("GoalLeverRow number input", () => {
 
     expect(onChange).toHaveBeenCalledWith(-0.02);
   });
+
+  it("treats a comma as the decimal separator", () => {
+    const onChange = vi.fn();
+    renderRateLever(-0.006, onChange);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "-2,0" } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith(-0.02);
+  });
 });

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -56,6 +56,7 @@ const DEFAULT_FEE_SLIDER_MAX = 0.03;
 const DEFAULT_VOLATILITY_SLIDER_MAX = 0.5;
 const DEFAULT_CONTRIBUTION_GROWTH_SLIDER_MAX = 0.1;
 // Keep hard caps in sync with validate_retirement_plan in crates/core/src/goals/goals_service.rs.
+const MIN_RETIREMENT_RETURN = -0.2;
 const MAX_RETIREMENT_RETURN = 0.5;
 const MAX_RETIREMENT_INFLATION = 0.2;
 const MAX_RETIREMENT_FEE = 0.1;
@@ -1267,7 +1268,7 @@ export function SidebarConfigurator({
                               label={t("goals:sidebar.income.fund_return_before_payout")}
                               value={s.accumulationReturn ?? planAccumulationReturn(draft)}
                               onChange={(v) => updateStream(s.id, { accumulationReturn: v })}
-                              min={0}
+                              min={MIN_RETIREMENT_RETURN}
                               max={rateSliderMaxFor(
                                 s.accumulationReturn ?? planAccumulationReturn(draft),
                                 DEFAULT_RETURN_SLIDER_MAX,

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -1215,11 +1215,6 @@ export function SidebarConfigurator({
                                 value === "dc"
                                   ? (s.monthlyContribution ?? 0)
                                   : s.monthlyContribution,
-                              accumulationReturn:
-                                value === "dc"
-                                  ? (s.accumulationReturn ??
-                                    draft.investment.preRetirementAnnualReturn)
-                                  : s.accumulationReturn,
                             })
                           }
                         />
@@ -1406,7 +1401,6 @@ export function SidebarConfigurator({
                   monthlyAmount: undefined,
                   currentValue: 0,
                   monthlyContribution: 0,
-                  accumulationReturn: draft.investment.preRetirementAnnualReturn,
                   adjustForInflation: false,
                 })
               }

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.ui.test.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.ui.test.tsx
@@ -61,6 +61,7 @@ describe("SidebarConfigurator pension fund returns", () => {
     saveIncomeSection();
 
     const savedPlan = onSavePlan.mock.calls[0][0];
+    expect(savedPlan.incomeStreams[0].streamType).toBe("dc");
     expect(savedPlan.incomeStreams[0].accumulationReturn).toBeUndefined();
   });
 });

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.ui.test.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.ui.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FormattingProvider } from "@wealthfolio/ui";
+import { TooltipProvider } from "@wealthfolio/ui/components/ui/tooltip";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_RETIREMENT_PLAN } from "../lib/plan-adapter";
+import type { RetirementPlan } from "../types";
+import { SidebarConfigurator } from "./sidebar-configurator";
+
+function renderConfigurator(plan: RetirementPlan, onSavePlan: (plan: RetirementPlan) => void) {
+  render(
+    <FormattingProvider locale="en-US">
+      <TooltipProvider>
+        <SidebarConfigurator
+          plan={plan}
+          currency="USD"
+          plannerMode="traditional"
+          onSavePlan={onSavePlan}
+        />
+      </TooltipProvider>
+    </FormattingProvider>,
+  );
+}
+
+function saveIncomeSection() {
+  fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
+}
+
+describe("SidebarConfigurator pension fund returns", () => {
+  it("leaves a newly added fund return unset so it inherits the plan net return", () => {
+    const onSavePlan = vi.fn<(plan: RetirementPlan) => void>();
+    renderConfigurator(structuredClone(DEFAULT_RETIREMENT_PLAN), onSavePlan);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Retirement Income" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add pension fund" }));
+    saveIncomeSection();
+
+    const savedPlan = onSavePlan.mock.calls[0][0];
+    expect(savedPlan.incomeStreams[0].accumulationReturn).toBeUndefined();
+  });
+
+  it("leaves an unset return inherited when switching an income stream to a fund", () => {
+    const onSavePlan = vi.fn<(plan: RetirementPlan) => void>();
+    const plan: RetirementPlan = {
+      ...structuredClone(DEFAULT_RETIREMENT_PLAN),
+      incomeStreams: [
+        {
+          id: "pension",
+          label: "Pension",
+          streamType: "db",
+          startAge: 65,
+          adjustForInflation: true,
+          monthlyAmount: 1_000,
+        },
+      ],
+    };
+    renderConfigurator(plan, onSavePlan);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Retirement Income" }));
+    fireEvent.click(screen.getByText("Pension").closest("button")!);
+    fireEvent.click(screen.getByRole("button", { name: "Fund" }));
+    saveIncomeSection();
+
+    const savedPlan = onSavePlan.mock.calls[0][0];
+    expect(savedPlan.incomeStreams[0].accumulationReturn).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- prevent untouched GoalLeverRow number fields from committing on blur
- allow defined-contribution fund returns down to the backend-supported -20% minimum
- parse comma-decimal number input without multiplying returns by ten
- keep newly added or converted pension funds on the plan's fee-adjusted inherited return until explicitly overridden
- add UI regression coverage for inherited, edited, comma-decimal, added, and converted fund returns

## Testing

- focused Vitest suite: 15 tests passed
- targeted ESLint
- pnpm type-check
- pnpm build
