### PR TITLE
fix(spending): use each activity's currency in Recent Activity

### DIFF
--- a/apps/frontend/src/features/spending/components/recent-activity-card.test.tsx
+++ b/apps/frontend/src/features/spending/components/recent-activity-card.test.tsx
@@ -3,15 +3,16 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RecentActivityCard } from "./recent-activity-card";
+import type { Activity } from "@/lib/types";
 
 vi.mock("@tanstack/react-query", () => ({
   useQueries: vi.fn(() => []),
 }));
 
-function renderRecentActivityCard() {
+function renderRecentActivityCard(activities: Activity[] = []) {
   return render(
     <MemoryRouter>
-      <RecentActivityCard activities={[]} categoriesMeta={new Map()} currency="USD" />
+      <RecentActivityCard activities={activities} categoriesMeta={new Map()} />
     </MemoryRouter>,
   );
 }
@@ -29,5 +30,24 @@ describe("RecentActivityCard", () => {
     expect(
       screen.queryByRole("link", { name: "Open spending settings →" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("labels each activity with its own currency, not the base currency", () => {
+    const activity: Activity = {
+      id: "1",
+      accountId: "acc-1",
+      activityDate: new Date().toISOString().slice(0, 10),
+      activityType: "WITHDRAWAL",
+      amount: "100",
+      currency: "EUR",
+      notes: "Coffee",
+    } as unknown as Activity;
+
+    renderRecentActivityCard([activity]);
+
+    const row = screen.getByText("Coffee").closest("a");
+    expect(row).toBeInTheDocument();
+    expect(row?.textContent).toContain("€");
+    expect(row?.textContent).not.toContain("$");
   });
 });

--- a/apps/frontend/src/features/spending/components/recent-activity-card.tsx
+++ b/apps/frontend/src/features/spending/components/recent-activity-card.tsx
@@ -23,13 +23,11 @@ export function RecentActivityCard({
   activities,
   accountTypeById,
   categoriesMeta,
-  currency,
   uncategorizedCount = 0,
 }: {
   activities: Activity[];
   accountTypeById?: Map<string, string>;
   categoriesMeta: CategoryMetaMap;
-  currency: string;
   uncategorizedCount?: number;
 }) {
   const formatting = useDateFormatting();
@@ -195,7 +193,7 @@ export function RecentActivityCard({
                     )}
                   >
                     {isOutflow ? "−" : "+"}
-                    <PrivacyAmount value={amount} currency={currency} />
+                    <PrivacyAmount value={amount} currency={a.currency} />
                   </div>
                 </Link>
               );

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -1076,7 +1076,6 @@ export default function SpendingTabContent() {
                   activities={activities}
                   accountTypeById={accountTypeById}
                   categoriesMeta={categoriesMeta}
-                  currency={currency}
                   uncategorizedCount={uncategorizedCount}
                 />
               </div>


### PR DESCRIPTION
## Summary

Fixes #1568 — Spending tab's Recent Activity displayed the wrong currency for transactions.

- Root cause: `RecentActivityCard` labeled every row with the global base `currency` while rendering the transaction's **native** amount (no FX conversion), so a €100 transaction showed as `−$100`.
- Fix: render each row with the activity's own `a.currency` so the amount and currency label always match. The now-unused `currency` prop was removed from `RecentActivityCard` (and its call site in `spending-tab-content.tsx`).
- Added a test asserting a EUR activity is labeled with `€`, not `$`.

## Verification

- `pnpm vitest run src/features/spending/components/recent-activity-card.test.tsx` — 2 passed
- `pnpm type-check` — clean