### PR TITLE
fix(spending): carry the selected period into "Where it went" deep links

### DIFF
--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type FC } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
@@ -48,6 +48,7 @@ import {
   monthRange,
   parseMonthKey,
 } from "../lib/month-period";
+import { spendingActivityHref } from "../lib/navigation";
 import {
   DASHBOARD_PERIOD_UPDATED_AT_STORAGE_KEY,
   INSIGHTS_PERIOD_STORAGE_KEY,
@@ -527,6 +528,17 @@ export default function SpendingTabContent() {
     persistedInsightPeriod,
     selection,
   ]);
+  // "Where it went" deep-links carry the selected period (interval or month)
+  // so the activities spending tab opens pre-filtered to the same range.
+  const activityHrefFor = useCallback(
+    (id: string) =>
+      spendingActivityHref(id, {
+        savingsHref: dashboardInsightHref.cashflow,
+        startDate: dateRange?.from ? formatDateISO(dateRange.from) : undefined,
+        endDate: dateRange?.to ? formatDateISO(dateRange.to) : undefined,
+      }),
+    [dashboardInsightHref.cashflow, dateRange],
+  );
   const accountTypeById = useMemo(
     () => new Map(accounts.map((account) => [account.id, account.accountType])),
     [accounts],
@@ -1056,7 +1068,7 @@ export default function SpendingTabContent() {
                     currency={currency}
                     themeColor={theme.deep}
                     hasNoIncludedAccounts={hasNoIncludedAccounts}
-                    savingsHref={dashboardInsightHref.cashflow}
+                    activityHrefFor={activityHrefFor}
                   />
                 ) : (
                   <CategoryRankedBar
@@ -1066,7 +1078,7 @@ export default function SpendingTabContent() {
                     themeColor={theme.deep}
                     groupRows={budget?.computed.groupRows ?? []}
                     hasNoIncludedAccounts={hasNoIncludedAccounts}
-                    savingsHref={dashboardInsightHref.cashflow}
+                    activityHrefFor={activityHrefFor}
                   />
                 )}
               </DashboardCard>
@@ -1247,18 +1259,6 @@ interface CategoryRow {
   amount: number;
 }
 
-/**
- * Deep-link for a "Where it went" node. The synthetic uncategorized bucket has
- * no real category id, so it routes to the status filter — the category filter
- * would match nothing and render an empty list.
- */
-function spendingActivityHref(id: string, savingsHref?: string): string {
-  if (id === SAVINGS_ROW_ID) return savingsHref ?? "/activities?tab=spending";
-  return id === "__uncategorized__"
-    ? "/activities?tab=spending&status=uncategorized"
-    : `/activities?tab=spending&category=${id}`;
-}
-
 function WhereItWentEmptyState({ hasNoIncludedAccounts }: { hasNoIncludedAccounts: boolean }) {
   const { t } = useTranslation();
   return (
@@ -1309,14 +1309,14 @@ function CategoryTreemapMono({
   currency,
   themeColor,
   hasNoIncludedAccounts,
-  savingsHref,
+  activityHrefFor,
 }: {
   rows: CategoryRow[];
   total: number;
   currency: string;
   themeColor: string;
   hasNoIncludedAccounts: boolean;
-  savingsHref?: string;
+  activityHrefFor: (id: string) => string;
 }) {
   const { t } = useTranslation();
   const numberFormatting = useNumberFormatting();
@@ -1369,7 +1369,7 @@ function CategoryTreemapMono({
                   currency={currency}
                   onActivate={(id) => {
                     if (id && id !== "__other__") {
-                      navigate(spendingActivityHref(id, savingsHref));
+                      navigate(activityHrefFor(id));
                     }
                   }}
                 />
@@ -1379,7 +1379,7 @@ function CategoryTreemapMono({
             onClick={(node: unknown) => {
               const id = (node as { id?: string } | null)?.id;
               if (id && id !== "__other__") {
-                navigate(spendingActivityHref(id, savingsHref));
+                navigate(activityHrefFor(id));
               }
             }}
           >
@@ -1536,7 +1536,7 @@ function CategoryRankedBar({
   themeColor,
   groupRows = [],
   hasNoIncludedAccounts,
-  savingsHref,
+  activityHrefFor,
 }: {
   rows: CategoryRow[];
   total: number;
@@ -1548,7 +1548,7 @@ function CategoryRankedBar({
    * group, the list switches to a grouped layout with collapsible group rows.
    */
   groupRows?: import("../types/budget").BudgetGroupRow[];
-  savingsHref?: string;
+  activityHrefFor: (id: string) => string;
 }) {
   const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
@@ -1687,7 +1687,7 @@ function CategoryRankedBar({
               total={total}
               currency={currency}
               themeColor={themeColor}
-              savingsHref={savingsHref}
+              activityHrefFor={activityHrefFor}
             />
           ))}
         </div>
@@ -1708,7 +1708,7 @@ function CategoryRankedBar({
           return (
             <Link
               key={r.id}
-              to={spendingActivityHref(r.id, savingsHref)}
+              to={activityHrefFor(r.id)}
               className="hover:bg-muted/40 group flex items-center gap-2.5 rounded-md px-1 py-1 transition-colors"
             >
               <span
@@ -1729,7 +1729,7 @@ function CategoryRankedBar({
         })}
         {uncategorizedAmount > 0.01 && (
           <Link
-            to="/activities?tab=spending&status=uncategorized"
+            to={activityHrefFor("__uncategorized__")}
             className="border-border/60 hover:bg-muted/40 mt-1 flex items-center gap-2.5 rounded-md border border-dashed px-2 py-1.5 transition-colors"
           >
             <Icons.AlertCircle className="text-muted-foreground h-3 w-3 shrink-0" />
@@ -1760,7 +1760,7 @@ function GroupedCategoryBlock({
   total,
   currency,
   themeColor,
-  savingsHref,
+  activityHrefFor,
 }: {
   bucket: {
     id: string;
@@ -1772,7 +1772,7 @@ function GroupedCategoryBlock({
   total: number;
   currency: string;
   themeColor: string;
-  savingsHref?: string;
+  activityHrefFor: (id: string) => string;
 }) {
   const numberFormatting = useNumberFormatting();
   const [expanded, setExpanded] = useState(false);
@@ -1823,7 +1823,7 @@ function GroupedCategoryBlock({
           {sortedCats.map((cat) => {
             const catShare = total > 0 ? (cat.amount / total) * 100 : 0;
             const isUncategorized = cat.id === "__uncategorized__";
-            const to = spendingActivityHref(cat.id, savingsHref);
+            const to = activityHrefFor(cat.id);
             const dotColor = cat.color ?? accent;
             return (
               <Link

--- a/apps/frontend/src/features/spending/lib/navigation.test.ts
+++ b/apps/frontend/src/features/spending/lib/navigation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { SAVINGS_ROW_ID } from "./category-rollup";
+import { buildCashflowUrl, spendingActivityHref } from "./navigation";
+
+describe("buildCashflowUrl", () => {
+  it("builds a category + date-range url", () => {
+    expect(
+      buildCashflowUrl({
+        categoryId: "cat_housing",
+        startDate: "2026-01-01",
+        endDate: "2026-08-28",
+      }),
+    ).toBe("/activities?tab=spending&category=cat_housing&from=2026-01-01&to=2026-08-28");
+  });
+
+  it("omits params that are not provided", () => {
+    expect(buildCashflowUrl({ categoryId: "cat_housing" })).toBe(
+      "/activities?tab=spending&category=cat_housing",
+    );
+    expect(buildCashflowUrl({})).toBe("/activities?tab=spending");
+  });
+
+  it("supports a status filter", () => {
+    expect(
+      buildCashflowUrl({ status: "uncategorized", startDate: "2026-01-01", endDate: "2026-08-28" }),
+    ).toBe("/activities?tab=spending&status=uncategorized&from=2026-01-01&to=2026-08-28");
+  });
+});
+
+describe("spendingActivityHref", () => {
+  const dates = { startDate: "2026-01-01", endDate: "2026-08-28" };
+
+  it("links a category with the selected period's date range", () => {
+    expect(spendingActivityHref("cat_housing", dates)).toBe(
+      "/activities?tab=spending&category=cat_housing&from=2026-01-01&to=2026-08-28",
+    );
+  });
+
+  it("omits from/to when no date range is given", () => {
+    expect(spendingActivityHref("cat_housing")).toBe(
+      "/activities?tab=spending&category=cat_housing",
+    );
+  });
+
+  it("routes the uncategorized bucket to the status filter with dates", () => {
+    expect(spendingActivityHref("__uncategorized__", dates)).toBe(
+      "/activities?tab=spending&status=uncategorized&from=2026-01-01&to=2026-08-28",
+    );
+  });
+
+  it("returns the savings href verbatim without date params", () => {
+    expect(
+      spendingActivityHref(SAVINGS_ROW_ID, {
+        ...dates,
+        savingsHref: "/spending/insights?stage=where&period=YTD#cashflow",
+      }),
+    ).toBe("/spending/insights?stage=where&period=YTD#cashflow");
+  });
+
+  it("falls back to the bare spending tab for the savings row without a href", () => {
+    expect(spendingActivityHref(SAVINGS_ROW_ID, dates)).toBe("/activities?tab=spending");
+  });
+
+  it("url-encodes category ids", () => {
+    expect(spendingActivityHref("cat/a&b", dates)).toBe(
+      "/activities?tab=spending&category=cat%2Fa%26b&from=2026-01-01&to=2026-08-28",
+    );
+  });
+});

--- a/apps/frontend/src/features/spending/lib/navigation.ts
+++ b/apps/frontend/src/features/spending/lib/navigation.ts
@@ -1,7 +1,10 @@
+import { SAVINGS_ROW_ID } from "./category-rollup";
+
 /** Build a spending-transactions URL with category/subcategory + date filters as query params. */
 export function buildCashflowUrl(opts: {
   categoryId?: string | null;
   subcategoryId?: string | null;
+  status?: string;
   startDate?: string;
   endDate?: string;
 }): string {
@@ -9,7 +12,26 @@ export function buildCashflowUrl(opts: {
   params.set("tab", "spending");
   if (opts.categoryId) params.set("category", opts.categoryId);
   if (opts.subcategoryId) params.set("subcategory", opts.subcategoryId);
+  if (opts.status) params.set("status", opts.status);
   if (opts.startDate) params.set("from", opts.startDate);
   if (opts.endDate) params.set("to", opts.endDate);
   return `/activities?${params.toString()}`;
+}
+
+/**
+ * Deep-link for a "Where it went" node. The synthetic uncategorized bucket has
+ * no real category id, so it routes to the status filter — the category filter
+ * would match nothing and render an empty list. The savings row links to the
+ * insights cashflow view, which carries its own period params, so `startDate`/
+ * `endDate` (ISO YYYY-MM-DD) only apply to the /activities branches.
+ */
+export function spendingActivityHref(
+  id: string,
+  opts: { savingsHref?: string; startDate?: string; endDate?: string } = {},
+): string {
+  const { savingsHref, startDate, endDate } = opts;
+  if (id === SAVINGS_ROW_ID) return savingsHref ?? buildCashflowUrl({});
+  return id === "__uncategorized__"
+    ? buildCashflowUrl({ status: "uncategorized", startDate, endDate })
+    : buildCashflowUrl({ categoryId: id, startDate, endDate });
 }

--- a/e2e/17-dashboard-spending-links.spec.ts
+++ b/e2e/17-dashboard-spending-links.spec.ts
@@ -1,0 +1,161 @@
+import { expect, Page, test } from "@playwright/test";
+import {
+  BASE_URL,
+  completeOnboardingIfNeeded,
+  gotoActivities,
+  gotoAppPath,
+  openAddActivitySheet,
+  selectAccountOption,
+  selectActivityType,
+} from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+/**
+ * Dashboard spending "Where it went" rows must deep-link to the activities
+ * spending tab with the selected period's date range (`from`/`to`), so the
+ * tab opens filtered to the same window the dashboard was showing.
+ */
+test.describe("Dashboard spending deep links", () => {
+  let page: Page;
+
+  const ACCOUNT_NAME = "Spending Link Account";
+  const ACCOUNT_CURRENCY = "CAD";
+  const WITHDRAWAL_AMOUNT = 123.45;
+  let accountId: string;
+
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const toLocalISO = (date: Date) =>
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("1. Setup: onboard and create a cash account", async () => {
+    test.setTimeout(180000);
+    await completeOnboardingIfNeeded(page);
+
+    // Spending only classifies activities from CASH / CREDIT_CARD accounts, and
+    // the account-creation UI defaults to a securities account — create via API.
+    const response = await page.request.post(`${BASE_URL}/api/v1/accounts`, {
+      data: {
+        name: ACCOUNT_NAME,
+        accountType: "CASH",
+        currency: ACCOUNT_CURRENCY,
+        isDefault: false,
+        isActive: true,
+      },
+    });
+    expect(response.ok()).toBe(true);
+    accountId = ((await response.json()) as { id: string }).id;
+  });
+
+  test("2. Create a withdrawal dated today", async () => {
+    await gotoActivities(page);
+    await openAddActivitySheet(page);
+    await selectActivityType(page, "Withdrawal");
+    // Select OUR account by name — earlier specs leave other accounts behind,
+    // and "first account in the picker" lands the withdrawal in one of those
+    // (often a securities account, whose activities spending ignores).
+    await selectAccountOption(page, ACCOUNT_NAME, ACCOUNT_CURRENCY);
+
+    // The form defaults to today's date, which lies inside every dashboard
+    // interval (MTD/YTD/...), so we don't need to touch the date field.
+    const dialog = page.getByRole("dialog", { name: "Add Activity" });
+    const amountInput = dialog.getByTestId("amount-input");
+    await expect(amountInput).toBeVisible({ timeout: 5000 });
+    await amountInput.fill(String(WITHDRAWAL_AMOUNT));
+    await amountInput.blur();
+
+    const submitButton = page.getByRole("button", { name: /Add Withdrawal/i });
+    await expect(submitButton).toBeEnabled({ timeout: 5000 });
+    await submitButton.click();
+    await expect(page.getByRole("heading", { name: "Add Activity" })).not.toBeVisible({
+      timeout: 20000,
+    });
+
+    // Fail fast if the withdrawal landed in a different account — otherwise
+    // the mistake only surfaces in test 4 as an opaque missing-row timeout.
+    const searchResponse = await page.request.post(`${BASE_URL}/api/v1/activities/search`, {
+      data: {
+        page: 0,
+        pageSize: 10,
+        accountIdFilter: [accountId],
+        activityTypeFilter: ["WITHDRAWAL"],
+      },
+    });
+    expect(searchResponse.ok()).toBe(true);
+    const { data: withdrawals } = (await searchResponse.json()) as {
+      data: { amount: string | number }[];
+    };
+    expect(withdrawals).toHaveLength(1);
+    expect(Number(withdrawals[0].amount)).toBeCloseTo(WITHDRAWAL_AMOUNT, 2);
+  });
+
+  test("3. Enroll the account for spending via API", async () => {
+    // Enroll only the account this spec created: enrolling every account
+    // would pull earlier specs' cash activities into the where-it-went
+    // rollup and make the assertions below depend on unrelated test data.
+    const updateResponse = await page.request.put(`${BASE_URL}/api/v1/spending/settings`, {
+      data: { enabled: true, accountIds: [accountId] },
+    });
+    expect(updateResponse.ok()).toBe(true);
+  });
+
+  test("4. Where-it-went row links carry the YTD date range", async () => {
+    await gotoAppPath(page, "/dashboard?tab=spending&spendingInterval=YTD");
+
+    // The withdrawal is uncategorized, so it surfaces as the uncategorized row.
+    const row = page.locator('a[href*="status=uncategorized"]').first();
+    await expect(row).toBeVisible({ timeout: 30000 });
+
+    const today = new Date();
+    const expectedFrom = `${today.getFullYear()}-01-01`;
+    const expectedTo = toLocalISO(today);
+
+    const href = await row.getAttribute("href");
+    expect(href).not.toBeNull();
+    const params = new URLSearchParams(href!.split("?")[1]);
+    expect(params.get("tab")).toBe("spending");
+    expect(params.get("status")).toBe("uncategorized");
+    expect(params.get("from")).toBe(expectedFrom);
+    expect(params.get("to")).toBe(expectedTo);
+
+    await row.click();
+    await page.waitForURL(/\/activities\?/, { timeout: 15000 });
+    const url = new URL(page.url());
+    expect(url.searchParams.get("tab")).toBe("spending");
+    expect(url.searchParams.get("status")).toBe("uncategorized");
+    expect(url.searchParams.get("from")).toBe(expectedFrom);
+    expect(url.searchParams.get("to")).toBe(expectedTo);
+
+    // The spending tab applied the filter and still shows today's withdrawal.
+    await expect(page.getByText("123.45").first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test("5. Month selection links carry that month's range", async () => {
+    const today = new Date();
+    const monthKey = `${today.getFullYear()}-${pad(today.getMonth() + 1)}`;
+    await gotoAppPath(
+      page,
+      `/dashboard?tab=spending&spendingInterval=YTD&spendingMonth=${monthKey}`,
+    );
+
+    const row = page.locator('a[href*="status=uncategorized"]').first();
+    await expect(row).toBeVisible({ timeout: 30000 });
+
+    const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+    const href = await row.getAttribute("href");
+    expect(href).not.toBeNull();
+    const params = new URLSearchParams(href!.split("?")[1]);
+    expect(params.get("from")).toBe(toLocalISO(monthStart));
+    expect(params.get("to")).toBe(toLocalISO(monthEnd));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1582 

Dashboard Spending → "Where it went" rows linked to the activities Spending tab with only the category (`/activities?tab=spending&category=cat_housing`), dropping the interval that was on screen. The tab therefore showed all-time activity for the category. Rows now append the selected period's range:

/activities?tab=spending&category=cat_housing&from=2026-01-01&to=2026-08-28

This matches the monthly bar chart on the same card, which already navigated with `from`/`to`, and requires no receiver changes — the Spending tab already parses those params. Fixes #<issue>.

## Changes

- **`features/spending/lib/navigation.ts`** — `buildCashflowUrl` gains an optional `status` param. `spendingActivityHref` moves here from `spending-tab-content.tsx`, rebuilt on top of `buildCashflowUrl` with optional `startDate`/`endDate` (ISO `YYYY-MM-DD`). Category ids are now URL-encoded via `URLSearchParams` instead of raw interpolation. The savings row still returns the insights `savingsHref` untouched — that page has its own period params.
- **`features/spending/components/spending-tab-content.tsx`** — one memoized `activityHrefFor(id)` callback closes over the resolved `dateRange` (which already accounts for both interval and month selection) and replaces the `savingsHref` string prop threaded into `CategoryRankedBar`, `CategoryTreemapMono`, and `GroupedCategoryBlock`. The previously hardcoded uncategorized link goes through the same builder, so all four link variants (flat rows, grouped rows, treemap nodes, uncategorized row) carry the range.

## Tests

- **Unit** (`features/spending/lib/navigation.test.ts`, new): `buildCashflowUrl` param emission/omission incl. `status`; `spendingActivityHref` for category with/without dates, uncategorized (status + dates), savings passthrough (no dates), and URL-encoding of ids.
- **E2E** (`e2e/17-dashboard-spending-links.spec.ts`, new): onboards, creates a cash account via API (spending only classifies CASH/CREDIT_CARD accounts), adds a withdrawal, enrolls the account for spending, then asserts the uncategorized "Where it went" row's href and post-click URL carry `from=<Jan 1>` / `to=<today>` under `spendingInterval=YTD`, and the month's full calendar range under `spendingMonth`. The spec fails without the fix. (Suite is a local gate; not in CI, like the rest of `e2e/`.)

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
