### PR TITLE
feat(spending): Implement infinite scroll for spending activities

### DIFF
--- a/apps/frontend/src/features/ai-assistant/components/thread-list.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/thread-list.tsx
@@ -1,5 +1,5 @@
 import { ThreadListPrimitive } from "@assistant-ui/react";
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -9,6 +9,7 @@ import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Input } from "@wealthfolio/ui/components/ui/input";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useRuntimeContext } from "../hooks/use-runtime-context";
 import {
   flattenThreadPages,
@@ -38,44 +39,6 @@ function useDebouncedValue<T>(value: T, delay: number): T {
   }, [value, delay]);
 
   return debouncedValue;
-}
-
-/**
- * Custom hook for intersection observer (infinite scroll trigger).
- */
-function useIntersectionObserver(
-  callback: () => void,
-  options?: {
-    enabled?: boolean;
-    rootMargin?: string;
-  },
-) {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const { enabled = true, rootMargin = "100px" } = options ?? {};
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    const element = ref.current;
-    if (!element) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          callback();
-        }
-      },
-      { rootMargin },
-    );
-
-    observer.observe(element);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [callback, enabled, rootMargin]);
-
-  return ref;
 }
 
 export const ThreadList: FC = () => {

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -18,6 +18,7 @@ import { generateId } from "@/lib/id";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { QueryKeys } from "@/lib/query-keys";
 import { formatDateISO } from "@/lib/utils";
@@ -838,22 +839,25 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const isRefreshing = isFetching && !isFetchingNextPage;
     const isMobile = useIsMobileViewport();
 
-    const loadMoreButton = hasNextPage ? (
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => fetchNextPage()}
-        disabled={isFetchingNextPage}
-      >
-        {isFetchingNextPage ? (
-          <>
+    const loadMore = useCallback(() => {
+      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+    const sentinelRef = useIntersectionObserver(loadMore, {
+      enabled: hasNextPage && !isFetchingNextPage,
+      rootMargin: "200px",
+    });
+
+    const loadMoreSentinel = hasNextPage ? (
+      <>
+        <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+        {isFetchingNextPage && (
+          <span className="text-muted-foreground flex items-center text-sm">
             <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
             {t("spending:txTab.loading")}
-          </>
-        ) : (
-          t("spending:txTab.loadMore", { count: totalCount - rows.length })
+          </span>
         )}
-      </Button>
+      </>
     ) : null;
 
     const renderRows = () =>
@@ -1000,7 +1004,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
               </div>
             )}
             {renderRows()}
-            {loadMoreButton && <div className="flex justify-center pt-1">{loadMoreButton}</div>}
+            {loadMoreSentinel && <div className="flex justify-center pt-1">{loadMoreSentinel}</div>}
           </div>
         ) : (
           <div className="rounded-md border">
@@ -1037,9 +1041,9 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
               <TableBody>{renderRows()}</TableBody>
             </Table>
 
-            {loadMoreButton && (
+            {loadMoreSentinel && (
               <div className="border-border flex items-center justify-center border-t p-3">
-                {loadMoreButton}
+                {loadMoreSentinel}
               </div>
             )}
           </div>

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -476,6 +476,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const {
       items,
       totalCount,
+      pageCount,
       isLoading,
       isFetching,
       isFetchingNextPage,
@@ -845,8 +846,16 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
 
     const sentinelRef = useIntersectionObserver(loadMore, {
       enabled: hasNextPage && !isFetchingNextPage,
-      rootMargin: "200px",
+      rootMargin: "800px",
     });
+
+    // Eagerly prefetch page 2 once the first page lands so the first scroll
+    // extension is instant; settles naturally once pageCount reaches 2.
+    useEffect(() => {
+      if (pageCount === 1 && hasNextPage && !isFetchingNextPage && !isError) {
+        fetchNextPage();
+      }
+    }, [pageCount, hasNextPage, isFetchingNextPage, isError, fetchNextPage]);
 
     const loadMoreSentinel = hasNextPage ? (
       <>

--- a/apps/frontend/src/features/spending/hooks/use-cash-activity-search.ts
+++ b/apps/frontend/src/features/spending/hooks/use-cash-activity-search.ts
@@ -47,10 +47,12 @@ export function useCashActivitySearch(
     [query.data],
   );
   const totalCount = query.data?.pages[0]?.totalCount ?? 0;
+  const pageCount = query.data?.pages.length ?? 0;
 
   return {
     items,
     totalCount,
+    pageCount,
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     isFetchingNextPage: query.isFetchingNextPage,

--- a/apps/frontend/src/hooks/use-intersection-observer.test.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useIntersectionObserver } from "./use-intersection-observer";
+
+type ObserverCallback = (entries: { isIntersecting: boolean }[]) => void;
+
+const observeMock = vi.fn();
+const disconnectMock = vi.fn();
+let observerCallback: ObserverCallback | undefined;
+let observerOptions: IntersectionObserverInit | undefined;
+
+class MockIntersectionObserver {
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    observerCallback = callback;
+    observerOptions = options;
+  }
+
+  observe = observeMock;
+  disconnect = disconnectMock;
+}
+
+function renderWithElement(
+  callback: () => void,
+  options?: Parameters<typeof useIntersectionObserver>[1],
+) {
+  const element = document.createElement("div");
+  return renderHook(() => {
+    const ref = useIntersectionObserver(callback, options);
+    // Attach the sentinel during render so the effect sees it.
+    ref.current = element;
+    return ref;
+  });
+}
+
+describe("useIntersectionObserver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    observerCallback = undefined;
+    observerOptions = undefined;
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("observes the sentinel element when enabled", () => {
+    renderWithElement(vi.fn());
+
+    expect(observeMock).toHaveBeenCalledTimes(1);
+    expect(observerOptions).toEqual({ rootMargin: "100px" });
+  });
+
+  it("invokes the callback when the sentinel intersects", () => {
+    const callback = vi.fn();
+    renderWithElement(callback);
+
+    observerCallback?.([{ isIntersecting: true }]);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    observerCallback?.([{ isIntersecting: false }]);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create an observer when disabled", () => {
+    renderWithElement(vi.fn(), { enabled: false });
+
+    expect(observeMock).not.toHaveBeenCalled();
+    expect(observerCallback).toBeUndefined();
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = renderWithElement(vi.fn());
+    expect(observeMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes a custom rootMargin to the observer", () => {
+    renderWithElement(vi.fn(), { rootMargin: "200px" });
+
+    expect(observerOptions).toEqual({ rootMargin: "200px" });
+  });
+});

--- a/apps/frontend/src/hooks/use-intersection-observer.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Custom hook for intersection observer (infinite scroll trigger).
+ */
+export function useIntersectionObserver(
+  callback: () => void,
+  options?: {
+    enabled?: boolean;
+    rootMargin?: string;
+  },
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { enabled = true, rootMargin = "100px" } = options ?? {};
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          callback();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, enabled, rootMargin]);
+
+  return ref;
+}

--- a/apps/frontend/src/i18n/locales/de/spending.json
+++ b/apps/frontend/src/i18n/locales/de/spending.json
@@ -824,10 +824,7 @@
     "deselectAllVisible": "Alle sichtbaren Transaktionen abwählen",
     "selectAllVisible": "Alle sichtbaren Transaktionen auswählen",
     "nameNotes": "Name / Notizen",
-    "loading": "Wird geladen…",
-    "loadMore": "Mehr laden ({{count}} verbleibend)",
-    "loadMore_one": "Mehr laden ({{count}} verbleibend)",
-    "loadMore_other": "Mehr laden ({{count}} verbleibend)"
+    "loading": "Wird geladen…"
   },
   "tabContent": {
     "stageWhereLabel": "Wo ich stehe",

--- a/apps/frontend/src/i18n/locales/en/spending.json
+++ b/apps/frontend/src/i18n/locales/en/spending.json
@@ -824,10 +824,7 @@
     "deselectAllVisible": "Deselect all visible transactions",
     "selectAllVisible": "Select all visible transactions",
     "nameNotes": "Name / Notes",
-    "loading": "Loading…",
-    "loadMore": "Load more ({{count}} remaining)",
-    "loadMore_one": "Load more ({{count}} remaining)",
-    "loadMore_other": "Load more ({{count}} remaining)"
+    "loading": "Loading…"
   },
   "tabContent": {
     "stageWhereLabel": "Where I am",

--- a/apps/frontend/src/i18n/locales/es/spending.json
+++ b/apps/frontend/src/i18n/locales/es/spending.json
@@ -824,10 +824,7 @@
     "deselectAllVisible": "Deseleccionar todas las transacciones visibles",
     "selectAllVisible": "Seleccionar todas las transacciones visibles",
     "nameNotes": "Nombre / Notas",
-    "loading": "Cargando…",
-    "loadMore": "Cargar más ({{count}} restantes)",
-    "loadMore_one": "Cargar más ({{count}} restante)",
-    "loadMore_other": "Cargar más ({{count}} restantes)"
+    "loading": "Cargando…"
   },
   "tabContent": {
     "stageWhereLabel": "Dónde estoy",

--- a/apps/frontend/src/i18n/locales/fr/spending.json
+++ b/apps/frontend/src/i18n/locales/fr/spending.json
@@ -824,10 +824,7 @@
     "deselectAllVisible": "Désélectionner toutes les transactions visibles",
     "selectAllVisible": "Sélectionner toutes les transactions visibles",
     "nameNotes": "Nom / Notes",
-    "loading": "Chargement…",
-    "loadMore": "Charger plus ({{count}} restantes)",
-    "loadMore_one": "Charger plus ({{count}} restante)",
-    "loadMore_other": "Charger plus ({{count}} restantes)"
+    "loading": "Chargement…"
   },
   "tabContent": {
     "stageWhereLabel": "Où j'en suis",

--- a/apps/frontend/src/i18n/locales/ja/spending.json
+++ b/apps/frontend/src/i18n/locales/ja/spending.json
@@ -815,9 +815,7 @@
     "deselectAllVisible": "表示中の取引の選択をすべて解除",
     "selectAllVisible": "表示中の取引をすべて選択",
     "nameNotes": "名前 / メモ",
-    "loading": "読み込み中…",
-    "loadMore": "さらに読み込む(残り{{count}}件)",
-    "loadMore_other": "さらに読み込む(残り{{count}}件)"
+    "loading": "読み込み中…"
   },
   "tabContent": {
     "stageWhereLabel": "現状",

--- a/apps/frontend/src/i18n/locales/ko/spending.json
+++ b/apps/frontend/src/i18n/locales/ko/spending.json
@@ -815,9 +815,7 @@
     "deselectAllVisible": "표시된 거래 모두 선택 해제",
     "selectAllVisible": "표시된 거래 모두 선택",
     "nameNotes": "이름 / 메모",
-    "loading": "불러오는 중…",
-    "loadMore": "더 불러오기 (남은 항목 {{count}}건)",
-    "loadMore_other": "더 불러오기 (남은 항목 {{count}}건)"
+    "loading": "불러오는 중…"
   },
   "tabContent": {
     "stageWhereLabel": "현재 위치",

--- a/apps/frontend/src/i18n/locales/zh/spending.json
+++ b/apps/frontend/src/i18n/locales/zh/spending.json
@@ -815,9 +815,7 @@
     "deselectAllVisible": "取消选择所有可见交易",
     "selectAllVisible": "选择所有可见交易",
     "nameNotes": "名称 / 备注",
-    "loading": "正在加载……",
-    "loadMore": "加载更多（剩余 {{count}} 项）",
-    "loadMore_other": "加载更多（剩余 {{count}} 项）"
+    "loading": "正在加载……"
   },
   "tabContent": {
     "stageWhereLabel": "我的现状",


### PR DESCRIPTION
## Summary

Addresses the infinite-scroll half of #1510. by replacing the manual "Load More" button in **Spending → Transactions** with infinite scroll, so scanning through large transaction histories no longer requires repeated clicking.

## Motivation

The Transactions tab paginates 50 rows at a time behind a "Load More" button. For accounts with a few thousand transactions — exactly the case when you're categorising spend or cleaning up notes — reaching older data means clicking through dozens of pages.

## What changed

Three commits, each a clean boundary:

### 1. `refactor(frontend): extract useIntersectionObserver into shared hooks`
The AI-assistant thread list already had a private `useIntersectionObserver` hook. Lifted it verbatim into `apps/frontend/src/hooks/use-intersection-observer.ts` and pointed `thread-list.tsx` at the shared copy. No behavior change; adds unit tests for the hook (observe/disconnect lifecycle, `enabled` gating, callback firing on intersection).

### 2. `feat(spending): replace Load More button with infinite scroll`
`spending-transactions-tab.tsx` now renders a sentinel element instead of a button:

```tsx
const loadMore = useCallback(() => {
  if (hasNextPage && !isFetchingNextPage) fetchNextPage();
}, [hasNextPage, isFetchingNextPage, fetchNextPage]);

const sentinelRef = useIntersectionObserver(loadMore, {
  enabled: hasNextPage && !isFetchingNextPage,
  rootMargin: "800px",
});
```

Swapped in at both render sites (mobile card list and desktop table footer — only one mounts at a time, so a single ref is safe). The existing spinner + `txTab.loading` label is kept while a page is in flight; the now-unused `txTab.loadMore*` keys are removed from all 7 locales.

### 3. `feat(spending): prefetch next page ahead of scroll`
Two cheap layers so scroll extensions don't stall:
- **Eager page 2:** once the first page lands, page 2 is fetched immediately, so the first scroll extension renders from cache. The effect settles naturally once `pageCount` reaches 2.
- **`rootMargin: "800px"`** (~one viewport of lead time) so every subsequent page starts fetching well before the user reaches the end.

`useCashActivitySearch` gains a `pageCount` field to drive the prefetch guard — purely additive, so the other consumer (`category-transactions-sheet.tsx`) is unaffected.


## Notes for reviewers

- No changes to the fetch layer beyond exposing `pageCount` — pagination is still the existing offset-based `useInfiniteQuery` at 50/page.
- The sentinel is `aria-hidden` and zero-height; the loading state remains announced via the existing spinner text.
- Deliberately no fallback button: `IntersectionObserver` is supported in all target webviews.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
