### PR TITLE
feat(spending): show selected and filtered balance on the Transactions tab

### DIFF
--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -61,7 +61,7 @@ import {
 } from "../lib/constants";
 import { cashActivityFlowMetadata } from "../lib/cash-activity-form-utils";
 import {
-  getTransactionDisplay,
+  computeSelectedBalance,
   isTransferCashActivity,
   stableArr,
   toRowVM,
@@ -517,20 +517,15 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
       return null;
     }, [rows, selectedRowIds]);
 
-    // Net of the checked rows, signed the same way each row renders. Selection
-    // is limited to loaded rows, so this needs no extra round-trip.
+    // Net of the checked rows. Selection is limited to loaded rows, so this
+    // needs no extra round-trip.
     const selectedBalance = useMemo(() => {
-      if (selectedRowIds.size === 0) return null;
-      const amount = rows
-        .filter((row) => selectedRowIds.has(row.activity.id))
-        .reduce((sum, row) => {
-          const account = accountById.get(row.activity.accountId);
-          const { sign, safeAmount } = getTransactionDisplay(row.activity, account?.accountType);
-          const magnitude = row.activity.convertedAmount ?? Math.abs(safeAmount);
-          if (sign === "-") return sum - magnitude;
-          if (sign === "+") return sum + magnitude;
-          return sum;
-        }, 0);
+      const amount = computeSelectedBalance(
+        rows,
+        selectedRowIds,
+        (accountId) => accountById.get(accountId)?.accountType,
+      );
+      if (amount === null) return null;
       return { amount, currency: filteredBalance?.currency ?? settings?.baseCurrency ?? "USD" };
     }, [rows, selectedRowIds, accountById, filteredBalance, settings?.baseCurrency]);
 

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -520,14 +520,10 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     // Net of the checked rows. Selection is limited to loaded rows, so this
     // needs no extra round-trip.
     const selectedBalance = useMemo(() => {
-      const amount = computeSelectedBalance(
-        rows,
-        selectedRowIds,
-        (accountId) => accountById.get(accountId)?.accountType,
-      );
+      const amount = computeSelectedBalance(rows, selectedRowIds);
       if (amount === null) return null;
       return { amount, currency: filteredBalance?.currency ?? settings?.baseCurrency ?? "USD" };
-    }, [rows, selectedRowIds, accountById, filteredBalance, settings?.baseCurrency]);
+    }, [rows, selectedRowIds, filteredBalance, settings?.baseCurrency]);
 
     const filtersActive =
       !!debouncedSearch ||

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -519,11 +519,13 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
 
     // Net of the checked rows. Selection is limited to loaded rows, so this
     // needs no extra round-trip.
-    const selectedBalance = useMemo(() => {
-      const amount = computeSelectedBalance(rows, selectedRowIds);
-      if (amount === null) return null;
-      return { amount, currency: filteredBalance?.currency ?? settings?.baseCurrency ?? "USD" };
-    }, [rows, selectedRowIds, filteredBalance, settings?.baseCurrency]);
+    // Deliberately does NOT inherit the filtered pill's currency: a selection
+    // can be single-currency while the wider filter spans several, and each
+    // pill should say what it actually measured.
+    const selectedBalance = useMemo(
+      () => computeSelectedBalance(rows, selectedRowIds, settings?.baseCurrency ?? "USD"),
+      [rows, selectedRowIds, settings?.baseCurrency],
+    );
 
     const filtersActive =
       !!debouncedSearch ||

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -61,6 +61,7 @@ import {
 } from "../lib/constants";
 import { cashActivityFlowMetadata } from "../lib/cash-activity-form-utils";
 import {
+  getTransactionDisplay,
   isTransferCashActivity,
   stableArr,
   toRowVM,
@@ -476,6 +477,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const {
       items,
       totalCount,
+      filteredBalance,
       isLoading,
       isFetching,
       isFetchingNextPage,
@@ -514,6 +516,23 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
       if (bucket === "saving") return "saving";
       return null;
     }, [rows, selectedRowIds]);
+
+    // Net of the checked rows, signed the same way each row renders. Selection
+    // is limited to loaded rows, so this needs no extra round-trip.
+    const selectedBalance = useMemo(() => {
+      if (selectedRowIds.size === 0) return null;
+      const amount = rows
+        .filter((row) => selectedRowIds.has(row.activity.id))
+        .reduce((sum, row) => {
+          const account = accountById.get(row.activity.accountId);
+          const { sign, safeAmount } = getTransactionDisplay(row.activity, account?.accountType);
+          const magnitude = row.activity.convertedAmount ?? Math.abs(safeAmount);
+          if (sign === "-") return sum - magnitude;
+          if (sign === "+") return sum + magnitude;
+          return sum;
+        }, 0);
+      return { amount, currency: filteredBalance?.currency ?? settings?.baseCurrency ?? "USD" };
+    }, [rows, selectedRowIds, accountById, filteredBalance, settings?.baseCurrency]);
 
     const filtersActive =
       !!debouncedSearch ||
@@ -926,6 +945,8 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           onClearAll={clearAllFilters}
           visibleCount={rows.length}
           totalCount={totalCount}
+          selectedBalance={selectedBalance}
+          filteredBalance={filteredBalance}
           isRefreshing={isRefreshing}
           isMobile={isMobile}
         />

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.test.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.test.tsx
@@ -25,6 +25,10 @@ vi.mock("@wealthfolio/ui", () => ({
   SheetFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 vi.mock("./amount-range-filter", () => ({
@@ -81,8 +85,8 @@ function renderFilterBar({
   );
 }
 
-const selected: FilteredBalance = { amount: -120, currency: "USD" };
-const filtered: FilteredBalance = { amount: 400, currency: "USD" };
+const selected: FilteredBalance = { amount: -120, currency: "USD", converted: false };
+const filtered: FilteredBalance = { amount: 400, currency: "USD", converted: false };
 
 describe("TransactionsFilterBar balance pills", () => {
   it("shows the selected balance whenever rows are selected", () => {
@@ -118,6 +122,38 @@ describe("TransactionsFilterBar balance pills", () => {
 
     expect(screen.queryByTestId("selected-balance")).not.toBeInTheDocument();
     expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+
+  // The rows on screen can all share a currency while an unloaded one does not,
+  // so a converted total says so rather than looking arbitrary.
+  it("marks a converted balance so the UI can disclose it", () => {
+    renderFilterBar({
+      filteredBalance: { amount: 400, currency: "EUR", converted: true },
+      filtersActive: true,
+    });
+
+    expect(screen.getByTestId("filtered-balance-converted")).toBeInTheDocument();
+  });
+
+  it("does not disclose anything when the balance was not converted", () => {
+    renderFilterBar({ filteredBalance: filtered, filtersActive: true });
+
+    expect(screen.queryByTestId("filtered-balance-converted")).not.toBeInTheDocument();
+  });
+
+  // Selection is a subset of the filter, so this is the only way the two pills
+  // can disagree: a single-currency selection inside a mixed filter.
+  it("lets the two pills show different currencies", () => {
+    renderFilterBar({
+      selectedBalance: { amount: -50, currency: "USD", converted: false },
+      filteredBalance: { amount: 400, currency: "EUR", converted: true },
+      filtersActive: true,
+    });
+
+    expect(screen.getByTestId("selected-balance")).toHaveTextContent("USD -50");
+    expect(screen.getByTestId("filtered-balance")).toHaveTextContent("EUR 400");
+    expect(screen.queryByTestId("selected-balance-converted")).not.toBeInTheDocument();
+    expect(screen.getByTestId("filtered-balance-converted")).toBeInTheDocument();
   });
 
   it("shows the filtered balance only while a filter is active", () => {

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.test.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TransactionsFilterBar } from "./transactions-filter-bar";
+import type { FilteredBalance } from "../types/cash-activity";
+
+vi.mock("@wealthfolio/ui", () => ({
+  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  FacetedFilter: () => null,
+  FacetedSearchInput: () => null,
+  Icons: {
+    ListFilter: () => null,
+    Spinner: () => null,
+  },
+  Input: () => <input />,
+  PrivacyAmount: ({ value, currency }: { value: number; currency: string }) => (
+    <span>{`${currency} ${value}`}</span>
+  ),
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("./amount-range-filter", () => ({
+  AmountRangeFilter: () => null,
+}));
+
+vi.mock("./date-range-filter", () => ({
+  DateRangeFilter: () => null,
+}));
+
+function renderFilterBar({
+  selectedBalance,
+  filteredBalance,
+  filtersActive = false,
+}: {
+  selectedBalance?: FilteredBalance | null;
+  filteredBalance?: FilteredBalance | null;
+  filtersActive?: boolean;
+}) {
+  return render(
+    <TransactionsFilterBar
+      searchInput=""
+      onSearchInputChange={vi.fn()}
+      statusFilter="all"
+      onStatusFilterChange={vi.fn()}
+      dateRange={undefined}
+      onDateRangeChange={vi.fn()}
+      selectedAccounts={new Set()}
+      onAccountsChange={vi.fn()}
+      selectedTypes={new Set()}
+      onTypesChange={vi.fn()}
+      selectedCategories={new Set()}
+      onCategoriesChange={vi.fn()}
+      selectedSubcategories={new Set()}
+      onSubcategoriesChange={vi.fn()}
+      selectedEvents={new Set()}
+      onEventsChange={vi.fn()}
+      amountRange={{ min: null, max: null }}
+      onAmountRangeChange={vi.fn()}
+      accountOptions={[]}
+      typeOptions={[]}
+      categoryOptions={[]}
+      subcategoryOptions={[]}
+      eventOptions={[]}
+      hasEvents={false}
+      filtersActive={filtersActive}
+      onClearAll={vi.fn()}
+      visibleCount={1}
+      totalCount={3}
+      selectedBalance={selectedBalance}
+      filteredBalance={filteredBalance}
+      isRefreshing={false}
+    />,
+  );
+}
+
+const selected: FilteredBalance = { amount: -120, currency: "USD" };
+const filtered: FilteredBalance = { amount: 400, currency: "USD" };
+
+describe("TransactionsFilterBar balance pills", () => {
+  it("shows the selected balance whenever rows are selected", () => {
+    renderFilterBar({ selectedBalance: selected });
+
+    expect(screen.getByTestId("selected-balance")).toHaveTextContent("Selected balance:USD -120");
+    expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+
+  it("shows the filtered balance only while a filter is active", () => {
+    renderFilterBar({ filteredBalance: filtered, filtersActive: true });
+
+    expect(screen.getByTestId("filtered-balance")).toHaveTextContent("Filtered balance:USD 400");
+    expect(screen.queryByTestId("selected-balance")).not.toBeInTheDocument();
+  });
+
+  it("hides the filtered balance when no filter is active", () => {
+    renderFilterBar({ filteredBalance: filtered, filtersActive: false });
+
+    expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+
+  it("shows both balances together", () => {
+    renderFilterBar({
+      selectedBalance: selected,
+      filteredBalance: filtered,
+      filtersActive: true,
+    });
+
+    expect(screen.getByTestId("selected-balance")).toBeInTheDocument();
+    expect(screen.getByTestId("filtered-balance")).toBeInTheDocument();
+  });
+
+  it("renders no pills when neither balance is available", () => {
+    renderFilterBar({});
+
+    expect(screen.queryByTestId("selected-balance")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.test.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.test.tsx
@@ -92,6 +92,34 @@ describe("TransactionsFilterBar balance pills", () => {
     expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
   });
 
+  // The default view: the server sends a filtered balance on every page-0
+  // request, filtered or not, so only `filtersActive` keeps that pill hidden.
+  it("shows only the selected balance when rows are selected without a filter", () => {
+    renderFilterBar({
+      selectedBalance: selected,
+      filteredBalance: filtered,
+      filtersActive: false,
+    });
+
+    expect(screen.getByTestId("selected-balance")).toBeInTheDocument();
+    expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+
+  // While a filter change is in flight the balance is briefly absent.
+  it("shows only the selected balance when the filtered balance has not loaded", () => {
+    renderFilterBar({ selectedBalance: selected, filteredBalance: null, filtersActive: true });
+
+    expect(screen.getByTestId("selected-balance")).toBeInTheDocument();
+    expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+
+  it("renders no pills while a filter is active but its balance is still loading", () => {
+    renderFilterBar({ filteredBalance: null, filtersActive: true });
+
+    expect(screen.queryByTestId("selected-balance")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("filtered-balance")).not.toBeInTheDocument();
+  });
+
   it("shows the filtered balance only while a filter is active", () => {
     renderFilterBar({ filteredBalance: filtered, filtersActive: true });
 

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
@@ -14,11 +14,12 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  PrivacyAmount,
 } from "@wealthfolio/ui";
 
 import { AmountRangeFilter, type AmountRange } from "./amount-range-filter";
 import { DateRangeFilter } from "./date-range-filter";
-import type { CashActivityStatusFilter } from "../types/cash-activity";
+import type { CashActivityStatusFilter, FilteredBalance } from "../types/cash-activity";
 
 export interface FilterOption {
   value: string;
@@ -63,6 +64,10 @@ interface TransactionsFilterBarProps {
   // Count display
   visibleCount: number;
   totalCount: number;
+  /** Net of the checked rows. `null` when nothing is selected. */
+  selectedBalance?: FilteredBalance | null;
+  /** Net over the full filtered set, all pages. `null` while loading. */
+  filteredBalance?: FilteredBalance | null;
   isRefreshing: boolean;
   isMobile?: boolean;
 }
@@ -96,6 +101,8 @@ export function TransactionsFilterBar({
   onClearAll,
   visibleCount,
   totalCount,
+  selectedBalance,
+  filteredBalance,
   isRefreshing,
   isMobile = false,
 }: TransactionsFilterBarProps) {
@@ -125,6 +132,27 @@ export function TransactionsFilterBar({
           count: totalCount,
         })
       : t("spending:filters.countZero");
+
+  // Selected covers the checked rows; filtered covers the whole result set,
+  // including pages not yet loaded. Both can be on screen at once.
+  const balancePills = (
+    <>
+      {selectedBalance && (
+        <BalancePill
+          label={t("spending:filters.selectedBalance")}
+          balance={selectedBalance}
+          testId="selected-balance"
+        />
+      )}
+      {filtersActive && filteredBalance && (
+        <BalancePill
+          label={t("spending:filters.filteredBalance")}
+          balance={filteredBalance}
+          testId="filtered-balance"
+        />
+      )}
+    </>
+  );
 
   const filterControls = (
     <>
@@ -200,6 +228,11 @@ export function TransactionsFilterBar({
             </div>
           </Button>
         </div>
+        {(selectedBalance || (filtersActive && filteredBalance)) && (
+          <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-xs tabular-nums">
+            {balancePills}
+          </div>
+        )}
         <Sheet open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
           <SheetContent side="bottom" className="rounded-t-4xl mx-1 flex h-[80vh] flex-col p-0">
             <SheetHeader className="border-border border-b px-6 py-4 text-left">
@@ -245,15 +278,42 @@ export function TransactionsFilterBar({
           {t("spending:filters.clearAll")}
         </Button>
       )}
-      <span className="text-muted-foreground ml-auto inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs tabular-nums">
-        {countLabel}
-        {isRefreshing && (
-          <Icons.Spinner
-            className="h-3 w-3 animate-spin"
-            aria-label={t("spending:filters.refreshing")}
-          />
-        )}
+      <span className="text-muted-foreground ml-auto inline-flex shrink-0 items-center gap-2 whitespace-nowrap text-xs tabular-nums">
+        {balancePills}
+        <span className="inline-flex items-center gap-1.5">
+          {countLabel}
+          {isRefreshing && (
+            <Icons.Spinner
+              className="h-3 w-3 animate-spin"
+              aria-label={t("spending:filters.refreshing")}
+            />
+          )}
+        </span>
       </span>
     </div>
+  );
+}
+
+function BalancePill({
+  label,
+  balance,
+  testId,
+}: {
+  label: string;
+  balance: FilteredBalance;
+  testId: string;
+}) {
+  return (
+    <span
+      className="bg-muted/60 text-muted-foreground inline-flex items-center gap-1 rounded px-1.5 py-0.5"
+      data-testid={testId}
+    >
+      {label}
+      <PrivacyAmount
+        className="text-foreground font-medium"
+        value={balance.amount}
+        currency={balance.currency}
+      />
+    </span>
   );
 }

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
@@ -14,6 +14,10 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   PrivacyAmount,
 } from "@wealthfolio/ui";
 
@@ -303,17 +307,43 @@ function BalancePill({
   balance: FilteredBalance;
   testId: string;
 }) {
+  const { t } = useTranslation();
+  const amount = (
+    <PrivacyAmount
+      className="text-foreground font-medium"
+      value={balance.amount}
+      currency={balance.currency}
+    />
+  );
+
   return (
     <span
       className="bg-muted/60 text-muted-foreground inline-flex items-center gap-1 rounded px-1.5 py-0.5"
       data-testid={testId}
     >
       {label}
-      <PrivacyAmount
-        className="text-foreground font-medium"
-        value={balance.amount}
-        currency={balance.currency}
-      />
+      {balance.converted ? (
+        // Say so when the total was converted. The rows on screen can all share
+        // a currency while an unloaded one does not, so without this the base
+        // currency looks arbitrary.
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="decoration-muted-foreground/50 cursor-default underline decoration-dotted underline-offset-2"
+                data-testid={`${testId}-converted`}
+              >
+                {amount}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{t("spending:filters.balanceConverted", { currency: balance.currency })}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        amount
+      )}
     </span>
   );
 }

--- a/apps/frontend/src/features/spending/hooks/use-cash-activity-search.ts
+++ b/apps/frontend/src/features/spending/hooks/use-cash-activity-search.ts
@@ -47,10 +47,14 @@ export function useCashActivitySearch(
     [query.data],
   );
   const totalCount = query.data?.pages[0]?.totalCount ?? 0;
+  // The backend only computes the balance for the first page (offset 0), which
+  // React Query refetches on every filter change.
+  const filteredBalance = query.data?.pages[0]?.filteredBalance ?? null;
 
   return {
     items,
     totalCount,
+    filteredBalance,
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     isFetchingNextPage: query.isFetchingNextPage,

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { CashActivity } from "../types/cash-activity";
 import {
   computeSelectedBalance,
+  getTransactionDisplay,
   getTransferLinkStatus,
   isTransferCashActivity,
   toRowVM,
@@ -110,67 +111,78 @@ describe("spending transaction helpers", () => {
 });
 
 describe("computeSelectedBalance", () => {
-  const cashAccount = () => "CASH";
-
-  function row(overrides: Partial<CashActivity>): TransactionRowVM {
+  function row(id: string, cashMovement: number | undefined): TransactionRowVM {
     return {
-      activity: cashActivity(overrides),
+      activity: cashActivity({ id, cashMovement }),
       category: null,
       splitCount: 0,
       needsReview: false,
     };
   }
 
-  const income = row({ id: "income", activityType: "DEPOSIT", amount: "1000", cashFlowBucket: "income" }); // prettier-ignore
-  const outflow = row({ id: "outflow", activityType: "WITHDRAWAL", amount: "400", cashFlowBucket: "spending" }); // prettier-ignore
-  const refund = row({ id: "refund", activityType: "CREDIT", subtype: "REFUND", amount: "150", cashFlowBucket: "spending" }); // prettier-ignore
-  const saving = row({ id: "saving", activityType: "TRANSFER_OUT", sourceGroupId: "x", amount: "250", cashFlowBucket: "saving" }); // prettier-ignore
-  const neutral = row({ id: "neutral", activityType: "TRANSFER_IN", sourceGroupId: "y", amount: "900", cashFlowBucket: "neutral" }); // prettier-ignore
+  // Server-signed movements: money in is positive, money out negative.
+  const income = row("income", 1000);
+  const outflow = row("outflow", -400);
+  const refund = row("refund", 150);
+  const transferIn = row("transfer-in", 900);
+  const transferOut = row("transfer-out", -900);
 
-  const all = [income, outflow, refund, saving, neutral];
+  const all = [income, outflow, refund, transferIn, transferOut];
   const idsOf = (...rows: TransactionRowVM[]) => new Set(rows.map((r) => r.activity.id));
 
   it("returns null when nothing is selected", () => {
-    expect(computeSelectedBalance(all, new Set(), cashAccount)).toBeNull();
+    expect(computeSelectedBalance(all, new Set())).toBeNull();
   });
 
   it.each([
-    ["income adds", income, 1000],
-    ["spending outflows subtract", outflow, -400],
+    ["inflows add", income, 1000],
+    ["outflows subtract", outflow, -400],
     ["refunds add", refund, 150],
-    ["savings transfers subtract", saving, -250],
-    ["neutral transfers contribute nothing", neutral, 0],
+    ["transfers in add", transferIn, 900],
+    ["transfers out subtract", transferOut, -900],
   ])("%s", (_label, selectedRow, expected) => {
-    expect(computeSelectedBalance(all, idsOf(selectedRow), cashAccount)).toBe(expected);
+    expect(computeSelectedBalance(all, idsOf(selectedRow))).toBe(expected);
   });
 
   it("nets a mixed selection", () => {
-    // 1000 - 400 + 150 - 250 + 0
-    expect(computeSelectedBalance(all, idsOf(...all), cashAccount)).toBe(500);
+    // 1000 - 400 + 150 + 900 - 900
+    expect(computeSelectedBalance(all, idsOf(...all))).toBe(750);
   });
 
   it("counts only the selected rows", () => {
-    expect(computeSelectedBalance(all, idsOf(income, outflow), cashAccount)).toBe(600);
+    expect(computeSelectedBalance(all, idsOf(income, outflow))).toBe(600);
   });
 
-  it("uses the base-currency amount so a mixed-currency selection still sums", () => {
-    const foreign = row({
-      id: "foreign",
-      activityType: "WITHDRAWAL",
-      amount: "40",
-      currency: "EUR",
-      cashFlowBucket: "spending",
-      convertedAmount: 80,
-    });
-
-    expect(computeSelectedBalance([foreign], idsOf(foreign), cashAccount)).toBe(-80);
+  // Both legs of an internal move cancel — the money never left the accounts.
+  it("nets a transfer pair to zero", () => {
+    expect(computeSelectedBalance(all, idsOf(transferIn, transferOut))).toBe(0);
   });
 
-  it("falls back to the native amount when the server did not convert", () => {
-    expect(computeSelectedBalance([outflow], idsOf(outflow), cashAccount)).toBe(-400);
+  it("ignores rows the server did not convert", () => {
+    const unconverted = row("unconverted", undefined);
+    expect(computeSelectedBalance([unconverted], idsOf(unconverted))).toBe(0);
   });
 
   it("ignores ids that are not among the loaded rows", () => {
-    expect(computeSelectedBalance(all, new Set(["not-loaded"]), cashAccount)).toBe(0);
+    expect(computeSelectedBalance(all, new Set(["not-loaded"]))).toBe(0);
+  });
+});
+
+// The balance counts transfers by direction, but the table still draws them
+// unsigned. Pinned so a later edit cannot silently repaint every transfer row.
+describe("transfer rows stay visually neutral", () => {
+  it("gives neutral rows no sign", () => {
+    const transfer = cashActivity({
+      id: "transfer",
+      activityType: "TRANSFER_IN",
+      sourceGroupId: "pair",
+      cashFlowBucket: "neutral",
+      cashMovement: 900,
+    });
+
+    const display = getTransactionDisplay(transfer, "CASH");
+
+    expect(display.sign).toBe("");
+    expect(display.isNeutral).toBe(true);
   });
 });

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
@@ -111,9 +111,19 @@ describe("spending transaction helpers", () => {
 });
 
 describe("computeSelectedBalance", () => {
-  function row(id: string, cashMovement: number | undefined): TransactionRowVM {
+  function row(
+    id: string,
+    native: number | undefined,
+    currency = "USD",
+    converted = native,
+  ): TransactionRowVM {
     return {
-      activity: cashActivity({ id, cashMovement }),
+      activity: cashActivity({
+        id,
+        currency,
+        cashMovementNative: native,
+        cashMovement: converted,
+      }),
       category: null,
       splitCount: 0,
       needsReview: false,
@@ -129,9 +139,11 @@ describe("computeSelectedBalance", () => {
 
   const all = [income, outflow, refund, transferIn, transferOut];
   const idsOf = (...rows: TransactionRowVM[]) => new Set(rows.map((r) => r.activity.id));
+  const balance = (rows: TransactionRowVM[], ids: Set<string>, base = "EUR") =>
+    computeSelectedBalance(rows, ids, base);
 
   it("returns null when nothing is selected", () => {
-    expect(computeSelectedBalance(all, new Set())).toBeNull();
+    expect(balance(all, new Set())).toBeNull();
   });
 
   it.each([
@@ -141,30 +153,96 @@ describe("computeSelectedBalance", () => {
     ["transfers in add", transferIn, 900],
     ["transfers out subtract", transferOut, -900],
   ])("%s", (_label, selectedRow, expected) => {
-    expect(computeSelectedBalance(all, idsOf(selectedRow))).toBe(expected);
+    expect(balance(all, idsOf(selectedRow))?.amount).toBe(expected);
   });
 
   it("nets a mixed selection", () => {
     // 1000 - 400 + 150 + 900 - 900
-    expect(computeSelectedBalance(all, idsOf(...all))).toBe(750);
+    expect(balance(all, idsOf(...all))?.amount).toBe(750);
   });
 
   it("counts only the selected rows", () => {
-    expect(computeSelectedBalance(all, idsOf(income, outflow))).toBe(600);
+    expect(balance(all, idsOf(income, outflow))?.amount).toBe(600);
   });
 
   // Both legs of an internal move cancel — the money never left the accounts.
   it("nets a transfer pair to zero", () => {
-    expect(computeSelectedBalance(all, idsOf(transferIn, transferOut))).toBe(0);
-  });
-
-  it("ignores rows the server did not convert", () => {
-    const unconverted = row("unconverted", undefined);
-    expect(computeSelectedBalance([unconverted], idsOf(unconverted))).toBe(0);
+    expect(balance(all, idsOf(transferIn, transferOut))?.amount).toBe(0);
   });
 
   it("ignores ids that are not among the loaded rows", () => {
-    expect(computeSelectedBalance(all, new Set(["not-loaded"]))).toBe(0);
+    expect(balance(all, new Set(["not-loaded"]))?.amount).toBe(0);
+  });
+
+  describe("currency", () => {
+    it("reports a single-currency selection in its own currency, unconverted", () => {
+      const usd = [row("a", -40, "USD", -80), row("b", -10, "USD", -20)];
+
+      expect(balance(usd, idsOf(...usd))).toEqual({
+        amount: -50,
+        currency: "USD",
+        converted: false,
+      });
+    });
+
+    it("converts a selection spanning currencies to the base currency", () => {
+      const mixed = [row("usd", -40, "USD", -80), row("gbp", -10, "GBP", -20)];
+
+      expect(balance(mixed, idsOf(...mixed))).toEqual({
+        amount: -100,
+        currency: "EUR",
+        converted: true,
+      });
+    });
+
+    it("does not mark a selection already in the base currency as converted", () => {
+      const eur = [row("a", -40, "EUR", -40)];
+
+      expect(balance(eur, idsOf(...eur))).toEqual({
+        amount: -40,
+        currency: "EUR",
+        converted: false,
+      });
+    });
+
+    // A row that moves nothing cannot change the total, so it must not drag a
+    // single-currency selection into a conversion it does not need.
+    it("ignores zero-movement rows when deciding the currency", () => {
+      const rows = [row("spend", -40, "USD", -80), row("draft", 0, "GBP", 0)];
+
+      expect(balance(rows, idsOf(...rows))).toEqual({
+        amount: -40,
+        currency: "USD",
+        converted: false,
+      });
+    });
+
+    it("treats a row the server did not convert as contributing nothing", () => {
+      const rows = [row("unconverted", undefined, "USD", undefined)];
+
+      expect(balance(rows, idsOf(...rows))).toEqual({
+        amount: 0,
+        currency: "EUR",
+        converted: false,
+      });
+    });
+
+    // Selection is always a subset of the filtered set, so the two pills can
+    // differ only this way round: a single-currency selection inside a wider
+    // multi-currency filter. Each pill reports what it actually measured.
+    it("stays in its own currency even when the wider filter is mixed", () => {
+      const loaded = [
+        row("usd-1", -40, "USD", -80),
+        row("usd-2", -10, "USD", -20),
+        row("gbp", -5, "GBP", -10),
+      ];
+
+      expect(balance(loaded, idsOf(loaded[0], loaded[1]))).toEqual({
+        amount: -50,
+        currency: "USD",
+        converted: false,
+      });
+    });
   });
 });
 

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { CashActivity } from "../types/cash-activity";
-import { getTransferLinkStatus, isTransferCashActivity, toRowVM } from "./transactions-helpers";
+import {
+  computeSelectedBalance,
+  getTransferLinkStatus,
+  isTransferCashActivity,
+  toRowVM,
+  type TransactionRowVM,
+} from "./transactions-helpers";
 
 function cashActivity(overrides: Partial<CashActivity>): CashActivity {
   return {
@@ -100,5 +106,71 @@ describe("spending transaction helpers", () => {
 
     expect(row.category).toBeNull();
     expect(row.splitCount).toBe(2);
+  });
+});
+
+describe("computeSelectedBalance", () => {
+  const cashAccount = () => "CASH";
+
+  function row(overrides: Partial<CashActivity>): TransactionRowVM {
+    return {
+      activity: cashActivity(overrides),
+      category: null,
+      splitCount: 0,
+      needsReview: false,
+    };
+  }
+
+  const income = row({ id: "income", activityType: "DEPOSIT", amount: "1000", cashFlowBucket: "income" }); // prettier-ignore
+  const outflow = row({ id: "outflow", activityType: "WITHDRAWAL", amount: "400", cashFlowBucket: "spending" }); // prettier-ignore
+  const refund = row({ id: "refund", activityType: "CREDIT", subtype: "REFUND", amount: "150", cashFlowBucket: "spending" }); // prettier-ignore
+  const saving = row({ id: "saving", activityType: "TRANSFER_OUT", sourceGroupId: "x", amount: "250", cashFlowBucket: "saving" }); // prettier-ignore
+  const neutral = row({ id: "neutral", activityType: "TRANSFER_IN", sourceGroupId: "y", amount: "900", cashFlowBucket: "neutral" }); // prettier-ignore
+
+  const all = [income, outflow, refund, saving, neutral];
+  const idsOf = (...rows: TransactionRowVM[]) => new Set(rows.map((r) => r.activity.id));
+
+  it("returns null when nothing is selected", () => {
+    expect(computeSelectedBalance(all, new Set(), cashAccount)).toBeNull();
+  });
+
+  it.each([
+    ["income adds", income, 1000],
+    ["spending outflows subtract", outflow, -400],
+    ["refunds add", refund, 150],
+    ["savings transfers subtract", saving, -250],
+    ["neutral transfers contribute nothing", neutral, 0],
+  ])("%s", (_label, selectedRow, expected) => {
+    expect(computeSelectedBalance(all, idsOf(selectedRow), cashAccount)).toBe(expected);
+  });
+
+  it("nets a mixed selection", () => {
+    // 1000 - 400 + 150 - 250 + 0
+    expect(computeSelectedBalance(all, idsOf(...all), cashAccount)).toBe(500);
+  });
+
+  it("counts only the selected rows", () => {
+    expect(computeSelectedBalance(all, idsOf(income, outflow), cashAccount)).toBe(600);
+  });
+
+  it("uses the base-currency amount so a mixed-currency selection still sums", () => {
+    const foreign = row({
+      id: "foreign",
+      activityType: "WITHDRAWAL",
+      amount: "40",
+      currency: "EUR",
+      cashFlowBucket: "spending",
+      convertedAmount: 80,
+    });
+
+    expect(computeSelectedBalance([foreign], idsOf(foreign), cashAccount)).toBe(-80);
+  });
+
+  it("falls back to the native amount when the server did not convert", () => {
+    expect(computeSelectedBalance([outflow], idsOf(outflow), cashAccount)).toBe(-400);
+  });
+
+  it("ignores ids that are not among the loaded rows", () => {
+    expect(computeSelectedBalance(all, new Set(["not-loaded"]), cashAccount)).toBe(0);
   });
 });

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.ts
@@ -113,23 +113,47 @@ export function getTransactionDisplay(
  * Net cash movement of the selected rows: positive when money entered the
  * accounts, negative when it left. Returns `null` when nothing is selected.
  *
- * The per-row signed amount is computed server-side (`cashMovement`, in the base
- * currency) by the same resolver that builds account balances, so this is a plain
- * sum — deliberately not re-derived from `getTransactionDisplay`, which drives row
- * colour and the +/- glyph and would drift from the server's rule. Rows missing a
- * `cashMovement` (the server was not asked to convert) contribute nothing.
+ * Mirrors the rule the server applies to the filtered balance. When every
+ * selected row that moves cash shares a currency, the total is that currency's
+ * own and no FX is involved; only a mixed selection converts to `baseCurrency`,
+ * and `converted` reports which happened so the UI can disclose it.
  *
- * Note this is not the same question the row signs answer: transfers count by
- * direction here, while the table still renders them unsigned as neutral.
+ * Rows contributing nothing are ignored when deciding the currency — they can't
+ * change the total, so letting one force a conversion would lose precision for
+ * no reason. The per-row amounts are computed server-side by the same resolver
+ * that builds account balances; a row the server did not convert contributes 0.
  */
 export function computeSelectedBalance(
   rows: TransactionRowVM[],
   selectedRowIds: Set<string>,
-): number | null {
+  baseCurrency: string,
+): { amount: number; currency: string; converted: boolean } | null {
   if (selectedRowIds.size === 0) return null;
-  return rows
-    .filter((row) => selectedRowIds.has(row.activity.id))
-    .reduce((sum, row) => sum + (row.activity.cashMovement ?? 0), 0);
+  const selected = rows.filter((row) => selectedRowIds.has(row.activity.id));
+
+  let sole: string | null = null;
+  let mixed = false;
+  for (const { activity } of selected) {
+    if (!activity.cashMovementNative) continue;
+    if (sole === null) sole = activity.currency;
+    else if (sole !== activity.currency) {
+      mixed = true;
+      break;
+    }
+  }
+
+  if (sole !== null && !mixed) {
+    return {
+      amount: selected.reduce((sum, row) => sum + (row.activity.cashMovementNative ?? 0), 0),
+      currency: sole,
+      converted: false,
+    };
+  }
+  return {
+    amount: selected.reduce((sum, row) => sum + (row.activity.cashMovement ?? 0), 0),
+    currency: baseCurrency,
+    converted: mixed,
+  };
 }
 
 export function toRowVM(

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.ts
@@ -110,33 +110,26 @@ export function getTransactionDisplay(
 }
 
 /**
- * Net of the selected rows, signed the same way each row renders: income and
- * refunds add, spending outflows and savings transfers subtract, neutral rows
- * contribute nothing. Returns `null` when nothing is selected.
+ * Net cash movement of the selected rows: positive when money entered the
+ * accounts, negative when it left. Returns `null` when nothing is selected.
  *
- * Rows carry `convertedAmount` (the base-currency magnitude) so a selection
- * spanning currencies still sums; the native amount is the fallback when the
- * server did not convert. Because the signs mirror the row display, selecting
- * every row of a filtered set yields the server's filtered balance.
+ * The per-row signed amount is computed server-side (`cashMovement`, in the base
+ * currency) by the same resolver that builds account balances, so this is a plain
+ * sum — deliberately not re-derived from `getTransactionDisplay`, which drives row
+ * colour and the +/- glyph and would drift from the server's rule. Rows missing a
+ * `cashMovement` (the server was not asked to convert) contribute nothing.
+ *
+ * Note this is not the same question the row signs answer: transfers count by
+ * direction here, while the table still renders them unsigned as neutral.
  */
 export function computeSelectedBalance(
   rows: TransactionRowVM[],
   selectedRowIds: Set<string>,
-  accountTypeFor: (accountId: string) => string | undefined,
 ): number | null {
   if (selectedRowIds.size === 0) return null;
   return rows
     .filter((row) => selectedRowIds.has(row.activity.id))
-    .reduce((sum, row) => {
-      const { sign, safeAmount } = getTransactionDisplay(
-        row.activity,
-        accountTypeFor(row.activity.accountId),
-      );
-      const magnitude = row.activity.convertedAmount ?? Math.abs(safeAmount);
-      if (sign === "-") return sum - magnitude;
-      if (sign === "+") return sum + magnitude;
-      return sum;
-    }, 0);
+    .reduce((sum, row) => sum + (row.activity.cashMovement ?? 0), 0);
 }
 
 export function toRowVM(

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.ts
@@ -109,6 +109,36 @@ export function getTransactionDisplay(
   return { isOutflow, isIncome, isSaving, isRefund, isNeutral, sign, safeAmount };
 }
 
+/**
+ * Net of the selected rows, signed the same way each row renders: income and
+ * refunds add, spending outflows and savings transfers subtract, neutral rows
+ * contribute nothing. Returns `null` when nothing is selected.
+ *
+ * Rows carry `convertedAmount` (the base-currency magnitude) so a selection
+ * spanning currencies still sums; the native amount is the fallback when the
+ * server did not convert. Because the signs mirror the row display, selecting
+ * every row of a filtered set yields the server's filtered balance.
+ */
+export function computeSelectedBalance(
+  rows: TransactionRowVM[],
+  selectedRowIds: Set<string>,
+  accountTypeFor: (accountId: string) => string | undefined,
+): number | null {
+  if (selectedRowIds.size === 0) return null;
+  return rows
+    .filter((row) => selectedRowIds.has(row.activity.id))
+    .reduce((sum, row) => {
+      const { sign, safeAmount } = getTransactionDisplay(
+        row.activity,
+        accountTypeFor(row.activity.accountId),
+      );
+      const magnitude = row.activity.convertedAmount ?? Math.abs(safeAmount);
+      if (sign === "-") return sum - magnitude;
+      if (sign === "+") return sum + magnitude;
+      return sum;
+    }, 0);
+}
+
 export function toRowVM(
   item: CashActivity,
   allCategories: Map<string, TaxonomyCategory>,

--- a/apps/frontend/src/features/spending/types/cash-activity.ts
+++ b/apps/frontend/src/features/spending/types/cash-activity.ts
@@ -88,12 +88,27 @@ export interface CashActivity extends Activity {
    * re-deriving a sign from `cashFlowBucket`.
    */
   cashMovement?: number;
+  /**
+   * The same signed movement in the row's own currency, unconverted. Lets a
+   * single-currency selection total exactly, with no FX rounding.
+   */
+  cashMovementNative?: number;
 }
 
 /** Net balance over the full filtered set, in the base currency. */
 export interface FilteredBalance {
   amount: number;
+  /**
+   * The currency shared by every matching row, or the base currency when they
+   * differ.
+   */
   currency: string;
+  /**
+   * True when the set spanned more than one currency and had to be FX-converted.
+   * Disclosed in the UI, because the visible rows may all share a currency while
+   * an unloaded one does not.
+   */
+  converted: boolean;
 }
 
 export interface CashActivitySearchResponse {

--- a/apps/frontend/src/features/spending/types/cash-activity.ts
+++ b/apps/frontend/src/features/spending/types/cash-activity.ts
@@ -81,9 +81,22 @@ export interface CashActivity extends Activity {
   eventId?: string | null;
   /** Transfer pair validity for effective TRANSFER_IN / TRANSFER_OUT rows. */
   transferLinkStatus?: TransferLinkStatus | null;
+  /**
+   * `|amount|` in the base currency, so rows in different currencies can be
+   * summed. Magnitude only — the display sign comes from `cashFlowBucket`.
+   */
+  convertedAmount?: number;
+}
+
+/** Net balance over the full filtered set, in the base currency. */
+export interface FilteredBalance {
+  amount: number;
+  currency: string;
 }
 
 export interface CashActivitySearchResponse {
   items: CashActivity[];
   totalCount: number;
+  /** Only present on the first page (offset 0). */
+  filteredBalance?: FilteredBalance;
 }

--- a/apps/frontend/src/features/spending/types/cash-activity.ts
+++ b/apps/frontend/src/features/spending/types/cash-activity.ts
@@ -82,10 +82,12 @@ export interface CashActivity extends Activity {
   /** Transfer pair validity for effective TRANSFER_IN / TRANSFER_OUT rows. */
   transferLinkStatus?: TransferLinkStatus | null;
   /**
-   * `|amount|` in the base currency, so rows in different currencies can be
-   * summed. Magnitude only — the display sign comes from `cashFlowBucket`.
+   * Signed cash movement in the base currency: positive when money entered the
+   * account, negative when it left. Computed server-side by the same resolver
+   * that builds account balances, so clients sum these directly rather than
+   * re-deriving a sign from `cashFlowBucket`.
    */
-  convertedAmount?: number;
+  cashMovement?: number;
 }
 
 /** Net balance over the full filtered set, in the base currency. */

--- a/apps/frontend/src/i18n/locales/de/spending.json
+++ b/apps/frontend/src/i18n/locales/de/spending.json
@@ -203,6 +203,7 @@
     "countZero": "0 Transaktionen",
     "selectedBalance": "Ausgewählter Saldo:",
     "filteredBalance": "Gefilterter Saldo:",
+    "balanceConverted": "In {{currency}} umgerechnet — dieser Filter umfasst mehrere Währungen.",
     "category": "Kategorie",
     "subcategory": "Unterkategorie",
     "event": "Ereignis",

--- a/apps/frontend/src/i18n/locales/de/spending.json
+++ b/apps/frontend/src/i18n/locales/de/spending.json
@@ -201,6 +201,8 @@
     "countLabel_one": "{{visible}} / {{total}} Transaktion",
     "countLabel_other": "{{visible}} / {{total}} Transaktionen",
     "countZero": "0 Transaktionen",
+    "selectedBalance": "Ausgewählter Saldo:",
+    "filteredBalance": "Gefilterter Saldo:",
     "category": "Kategorie",
     "subcategory": "Unterkategorie",
     "event": "Ereignis",

--- a/apps/frontend/src/i18n/locales/en/spending.json
+++ b/apps/frontend/src/i18n/locales/en/spending.json
@@ -201,6 +201,8 @@
     "countLabel_one": "{{visible}} / {{total}} transaction",
     "countLabel_other": "{{visible}} / {{total}} transactions",
     "countZero": "0 transactions",
+    "selectedBalance": "Selected balance:",
+    "filteredBalance": "Filtered balance:",
     "category": "Category",
     "subcategory": "Subcategory",
     "event": "Event",

--- a/apps/frontend/src/i18n/locales/en/spending.json
+++ b/apps/frontend/src/i18n/locales/en/spending.json
@@ -203,6 +203,7 @@
     "countZero": "0 transactions",
     "selectedBalance": "Selected balance:",
     "filteredBalance": "Filtered balance:",
+    "balanceConverted": "Converted to {{currency}} — this filter spans more than one currency.",
     "category": "Category",
     "subcategory": "Subcategory",
     "event": "Event",

--- a/apps/frontend/src/i18n/locales/es/spending.json
+++ b/apps/frontend/src/i18n/locales/es/spending.json
@@ -208,6 +208,8 @@
     "countLabel_other": "{{visible}} / {{total}} transacciones",
     "countLabel_many": "{{visible}} / {{total}} transacciones",
     "countZero": "0 transacciones",
+    "selectedBalance": "Saldo seleccionado:",
+    "filteredBalance": "Saldo filtrado:",
     "category": "Categoría",
     "subcategory": "Subcategoría",
     "event": "Evento",

--- a/apps/frontend/src/i18n/locales/es/spending.json
+++ b/apps/frontend/src/i18n/locales/es/spending.json
@@ -210,6 +210,7 @@
     "countZero": "0 transacciones",
     "selectedBalance": "Saldo seleccionado:",
     "filteredBalance": "Saldo filtrado:",
+    "balanceConverted": "Convertido a {{currency}}: este filtro abarca más de una moneda.",
     "category": "Categoría",
     "subcategory": "Subcategoría",
     "event": "Evento",

--- a/apps/frontend/src/i18n/locales/fr/spending.json
+++ b/apps/frontend/src/i18n/locales/fr/spending.json
@@ -208,6 +208,8 @@
     "countLabel_other": "{{visible}} / {{total}} transactions",
     "countLabel_many": "{{visible}} / {{total}} transactions",
     "countZero": "0 transaction",
+    "selectedBalance": "Solde sélectionné :",
+    "filteredBalance": "Solde filtré :",
     "category": "Catégorie",
     "subcategory": "Sous-catégorie",
     "event": "Événement",

--- a/apps/frontend/src/i18n/locales/fr/spending.json
+++ b/apps/frontend/src/i18n/locales/fr/spending.json
@@ -210,6 +210,7 @@
     "countZero": "0 transaction",
     "selectedBalance": "Solde sélectionné :",
     "filteredBalance": "Solde filtré :",
+    "balanceConverted": "Converti en {{currency}} — ce filtre couvre plusieurs devises.",
     "category": "Catégorie",
     "subcategory": "Sous-catégorie",
     "event": "Événement",

--- a/apps/frontend/src/i18n/locales/it/spending.json
+++ b/apps/frontend/src/i18n/locales/it/spending.json
@@ -210,6 +210,7 @@
     "countZero": "0 transazioni",
     "selectedBalance": "Saldo selezionato:",
     "filteredBalance": "Saldo filtrato:",
+    "balanceConverted": "Convertito in {{currency}} — questo filtro comprende più valute.",
     "category": "Categoria",
     "subcategory": "Sottocategoria",
     "event": "Evento",

--- a/apps/frontend/src/i18n/locales/it/spending.json
+++ b/apps/frontend/src/i18n/locales/it/spending.json
@@ -208,6 +208,8 @@
     "countLabel_many": "{{visible}} / {{total}} transazioni",
     "countLabel_other": "{{visible}} / {{total}} transazioni",
     "countZero": "0 transazioni",
+    "selectedBalance": "Saldo selezionato:",
+    "filteredBalance": "Saldo filtrato:",
     "category": "Categoria",
     "subcategory": "Sottocategoria",
     "event": "Evento",

--- a/apps/frontend/src/i18n/locales/ja/spending.json
+++ b/apps/frontend/src/i18n/locales/ja/spending.json
@@ -201,6 +201,7 @@
     "countZero": "取引0件",
     "selectedBalance": "選択中の残高:",
     "filteredBalance": "絞り込み後の残高:",
+    "balanceConverted": "{{currency}}に換算 — このフィルターは複数の通貨にまたがっています。",
     "category": "カテゴリ",
     "subcategory": "サブカテゴリ",
     "event": "イベント",

--- a/apps/frontend/src/i18n/locales/ja/spending.json
+++ b/apps/frontend/src/i18n/locales/ja/spending.json
@@ -199,6 +199,8 @@
     "countLabel_one": "取引 {{visible}} / {{total}}件",
     "countLabel_other": "取引 {{visible}} / {{total}}件",
     "countZero": "取引0件",
+    "selectedBalance": "選択中の残高:",
+    "filteredBalance": "絞り込み後の残高:",
     "category": "カテゴリ",
     "subcategory": "サブカテゴリ",
     "event": "イベント",

--- a/apps/frontend/src/i18n/locales/ko/spending.json
+++ b/apps/frontend/src/i18n/locales/ko/spending.json
@@ -201,6 +201,7 @@
     "countZero": "거래 0건",
     "selectedBalance": "선택 잔액:",
     "filteredBalance": "필터 잔액:",
+    "balanceConverted": "{{currency}}(으)로 환산 — 이 필터에는 두 가지 이상의 통화가 포함되어 있습니다.",
     "category": "카테고리",
     "subcategory": "하위 카테고리",
     "event": "이벤트",

--- a/apps/frontend/src/i18n/locales/ko/spending.json
+++ b/apps/frontend/src/i18n/locales/ko/spending.json
@@ -199,6 +199,8 @@
     "countLabel_one": "거래 {{visible}}/{{total}}건",
     "countLabel_other": "거래 {{visible}}/{{total}}건",
     "countZero": "거래 0건",
+    "selectedBalance": "선택 잔액:",
+    "filteredBalance": "필터 잔액:",
     "category": "카테고리",
     "subcategory": "하위 카테고리",
     "event": "이벤트",

--- a/apps/frontend/src/i18n/locales/pt/spending.json
+++ b/apps/frontend/src/i18n/locales/pt/spending.json
@@ -210,6 +210,7 @@
     "countZero": "0 transações",
     "selectedBalance": "Saldo selecionado:",
     "filteredBalance": "Saldo filtrado:",
+    "balanceConverted": "Convertido para {{currency}} — este filtro abrange mais de uma moeda.",
     "category": "Categoria",
     "subcategory": "Subcategoria",
     "event": "Evento",

--- a/apps/frontend/src/i18n/locales/pt/spending.json
+++ b/apps/frontend/src/i18n/locales/pt/spending.json
@@ -208,6 +208,8 @@
     "countLabel_other": "{{visible}} / {{total}} transações",
     "countLabel_many": "{{visible}} / {{total}} transações",
     "countZero": "0 transações",
+    "selectedBalance": "Saldo selecionado:",
+    "filteredBalance": "Saldo filtrado:",
     "category": "Categoria",
     "subcategory": "Subcategoria",
     "event": "Evento",

--- a/apps/frontend/src/i18n/locales/zh/spending.json
+++ b/apps/frontend/src/i18n/locales/zh/spending.json
@@ -201,6 +201,7 @@
     "countZero": "0 笔交易",
     "selectedBalance": "已选余额：",
     "filteredBalance": "筛选余额：",
+    "balanceConverted": "已换算为 {{currency}} — 此筛选包含多种货币。",
     "category": "类别",
     "subcategory": "子类别",
     "event": "事件",

--- a/apps/frontend/src/i18n/locales/zh/spending.json
+++ b/apps/frontend/src/i18n/locales/zh/spending.json
@@ -199,6 +199,8 @@
     "countLabel_one": "{{visible}} / {{total}} 笔交易",
     "countLabel_other": "{{visible}} / {{total}} 笔交易",
     "countZero": "0 笔交易",
+    "selectedBalance": "已选余额：",
+    "filteredBalance": "筛选余额：",
     "category": "类别",
     "subcategory": "子类别",
     "event": "事件",

--- a/apps/server/src/api/spending.rs
+++ b/apps/server/src/api/spending.rs
@@ -163,9 +163,11 @@ async fn search_cash_activities(
         return Ok(Json(CashActivitySearchResponse {
             items: Vec::new(),
             total_count: 0,
+            filtered_balance: None,
         }));
     }
-    let response = state.cash_activity_service.search(request).await?;
+    let base = state.base_currency.read().unwrap().clone();
+    let response = state.cash_activity_service.search(request, &base).await?;
     Ok(Json(response))
 }
 

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -632,6 +632,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
             activity_splits_repo.clone(),
             activity_events_repo.clone(),
             events_service.clone(),
+            fx_service.clone(),
         ),
     );
 

--- a/apps/tauri/src/commands/spending.rs
+++ b/apps/tauri/src/commands/spending.rs
@@ -154,11 +154,13 @@ pub async fn search_cash_activities(
         return Ok(CashActivitySearchResponse {
             items: Vec::new(),
             total_count: 0,
+            filtered_balance: None,
         });
     }
+    let base_currency = state.get_base_currency();
     state
         .cash_activity_service()
-        .search(request.unwrap_or_default())
+        .search(request.unwrap_or_default(), &base_currency)
         .await
         .map_err(|e| format!("Failed to search cash activities: {}", e))
 }

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -281,6 +281,7 @@ pub async fn initialize_context(
             activity_splits_repo.clone(),
             activity_events_repo.clone(),
             events_service.clone(),
+            fx_service.clone(),
         ),
     );
 

--- a/crates/agent-tools/src/tools/categorization_context.rs
+++ b/crates/agent-tools/src/tools/categorization_context.rs
@@ -890,6 +890,7 @@ mod tests {
             event_id: None,
             transfer_link_status: None,
             cash_movement: None,
+            cash_movement_native: None,
         }
     }
 

--- a/crates/agent-tools/src/tools/categorization_context.rs
+++ b/crates/agent-tools/src/tools/categorization_context.rs
@@ -889,6 +889,7 @@ mod tests {
             splits: Vec::new(),
             event_id: None,
             transfer_link_status: None,
+            converted_amount: None,
         }
     }
 

--- a/crates/agent-tools/src/tools/categorization_context.rs
+++ b/crates/agent-tools/src/tools/categorization_context.rs
@@ -889,7 +889,7 @@ mod tests {
             splits: Vec::new(),
             event_id: None,
             transfer_link_status: None,
-            converted_amount: None,
+            cash_movement: None,
         }
     }
 

--- a/crates/ai/src/env/test_env.rs
+++ b/crates/ai/src/env/test_env.rs
@@ -1561,6 +1561,7 @@ impl CashActivityServiceTrait for MockCashActivityService {
             wealthfolio_spending::cash_activities::CashActivitySearchResponse {
                 items,
                 total_count,
+                filtered_balance: None,
             },
         )
     }

--- a/crates/ai/tests/tool_outputs_parity.rs
+++ b/crates/ai/tests/tool_outputs_parity.rs
@@ -591,7 +591,7 @@ fn fixture_cash_activity(
         splits: Vec::new(),
         event_id: None,
         transfer_link_status: None,
-        converted_amount: None,
+        cash_movement: None,
     }
 }
 

--- a/crates/ai/tests/tool_outputs_parity.rs
+++ b/crates/ai/tests/tool_outputs_parity.rs
@@ -592,6 +592,7 @@ fn fixture_cash_activity(
         event_id: None,
         transfer_link_status: None,
         cash_movement: None,
+        cash_movement_native: None,
     }
 }
 

--- a/crates/ai/tests/tool_outputs_parity.rs
+++ b/crates/ai/tests/tool_outputs_parity.rs
@@ -591,6 +591,7 @@ fn fixture_cash_activity(
         splits: Vec::new(),
         event_id: None,
         transfer_link_status: None,
+        converted_amount: None,
     }
 }
 

--- a/crates/spending/src/activity_classification.rs
+++ b/crates/spending/src/activity_classification.rs
@@ -42,14 +42,6 @@ impl SpendingClassification {
             _ => Decimal::ZERO,
         }
     }
-
-    /// Signed contribution to a running balance, matching the sign each row
-    /// shows in the transactions table: income and refunds add, spending
-    /// outflows and savings transfers subtract, neutral rows contribute
-    /// nothing. `amount` is expected to be the absolute amount.
-    pub(crate) fn net_amount(self, amount: Decimal) -> Decimal {
-        self.income_amount(amount) - self.spending_amount(amount) - self.saving_amount(amount)
-    }
 }
 
 /// Source-group ids whose transfer has BOTH legs inside the spending-account

--- a/crates/spending/src/activity_classification.rs
+++ b/crates/spending/src/activity_classification.rs
@@ -42,6 +42,14 @@ impl SpendingClassification {
             _ => Decimal::ZERO,
         }
     }
+
+    /// Signed contribution to a running balance, matching the sign each row
+    /// shows in the transactions table: income and refunds add, spending
+    /// outflows and savings transfers subtract, neutral rows contribute
+    /// nothing. `amount` is expected to be the absolute amount.
+    pub(crate) fn net_amount(self, amount: Decimal) -> Decimal {
+        self.income_amount(amount) - self.spending_amount(amount) - self.saving_amount(amount)
+    }
 }
 
 /// Source-group ids whose transfer has BOTH legs inside the spending-account

--- a/crates/spending/src/activity_classification.rs
+++ b/crates/spending/src/activity_classification.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use chrono::NaiveDate;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use wealthfolio_core::accounts::account_types;
@@ -135,6 +136,36 @@ pub(crate) fn activity_abs_amount(activity: &Activity) -> Decimal {
 
 pub(crate) fn decimal_to_f64(amount: Decimal) -> f64 {
     amount.to_f64().unwrap_or(0.0)
+}
+
+/// Convert a native amount to the report's target currency at `as_of`.
+/// Mirrors `insight::service::fx_to_target` — same convention (one rate per
+/// report, snapshot-date style) so analytics and insight surfaces agree.
+/// Same-currency short-circuit; on FxService error, returns None so callers
+/// exclude the native amount instead of mixing currencies into the target total.
+pub(crate) fn fx_to_target(
+    fx: &dyn wealthfolio_core::fx::FxServiceTrait,
+    amount: Decimal,
+    from: &str,
+    to: &str,
+    as_of: NaiveDate,
+) -> Option<Decimal> {
+    if amount == Decimal::ZERO || from == to || from.is_empty() {
+        return Some(amount);
+    }
+    match fx.convert_currency_for_date(amount, from, to, as_of) {
+        Ok(converted) => Some(converted),
+        Err(e) => {
+            log::warn!(
+                "spending analytics FX conversion {}→{} on {} failed ({}); excluding native amount",
+                from,
+                to,
+                as_of,
+                e,
+            );
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/spending/src/analytics/service.rs
+++ b/crates/spending/src/analytics/service.rs
@@ -22,7 +22,7 @@ use crate::activity_allocations::{
 use crate::activity_assignments::ActivityTaxonomyAssignmentRepositoryTrait;
 use crate::activity_classification::{
     activity_abs_amount, classify_activity, classify_activity_for_aggregation, decimal_to_f64,
-    within_spending_transfer_groups, SpendingClassification,
+    fx_to_target, within_spending_transfer_groups, SpendingClassification,
 };
 use crate::activity_splits::ActivitySplitRepositoryTrait;
 use crate::events::EventsService;
@@ -609,36 +609,6 @@ fn classification_for(
     account_types
         .get(&activity.account_id)
         .map(|account_type| classify_activity(activity, account_type))
-}
-
-/// Convert a native amount to the report's target currency at `as_of`.
-/// Mirrors `insight::service::fx_to_target` — same convention (one rate per
-/// report, snapshot-date style) so analytics and insight surfaces agree.
-/// Same-currency short-circuit; on FxService error, returns None so callers
-/// exclude the native amount instead of mixing currencies into the target total.
-fn fx_to_target(
-    fx: &dyn wealthfolio_core::fx::FxServiceTrait,
-    amount: Decimal,
-    from: &str,
-    to: &str,
-    as_of: NaiveDate,
-) -> Option<Decimal> {
-    if amount == Decimal::ZERO || from == to || from.is_empty() {
-        return Some(amount);
-    }
-    match fx.convert_currency_for_date(amount, from, to, as_of) {
-        Ok(converted) => Some(converted),
-        Err(e) => {
-            log::warn!(
-                "spending analytics FX conversion {}→{} on {} failed ({}); excluding native amount",
-                from,
-                to,
-                as_of,
-                e,
-            );
-            None
-        }
-    }
 }
 
 // ====================== SpendingSummary (PR-style multi-period rollup) ======================

--- a/crates/spending/src/cash_activities/model.rs
+++ b/crates/spending/src/cash_activities/model.rs
@@ -150,18 +150,31 @@ pub struct CashActivity {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cash_movement: Option<f64>,
+    /// The same signed movement in the row's OWN currency, unconverted. Lets a
+    /// client total a single-currency selection exactly, with no FX rounding.
+    /// `None` when the caller did not ask for conversion.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cash_movement_native: Option<f64>,
 }
 
-/// Net balance over the FULL filtered set (not just the returned page),
-/// converted to the caller-provided base currency. Signed the way each row
-/// displays: income and refunds add, spending outflows and savings transfers
-/// subtract, neutral rows contribute nothing.
+/// Net cash movement over the FULL filtered set (not just the returned page).
+///
+/// When every matching row shares one currency the total is that currency's
+/// own, untouched by FX. Only a set spanning several currencies is converted to
+/// the base currency, and `converted` says which of the two happened so the UI
+/// can disclose it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FilteredBalance {
     pub amount: f64,
-    /// Currency the balance is denominated in (the base currency).
+    /// Currency the balance is denominated in: the currency shared by every
+    /// matching row, or the base currency when they differ.
     pub currency: String,
+    /// True when the set spanned more than one currency and the total had to be
+    /// FX-converted. The UI discloses this, because the rows the reader can see
+    /// may all share a currency while an unloaded row does not.
+    pub converted: bool,
 }
 
 /// Paginated response for cash-activity search.

--- a/crates/spending/src/cash_activities/model.rs
+++ b/crates/spending/src/cash_activities/model.rs
@@ -142,6 +142,25 @@ pub struct CashActivity {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transfer_link_status: Option<TransferLinkStatus>,
+    /// `|amount|` converted to the caller's base currency at this activity's
+    /// own date, so clients can sum rows across currencies. Magnitude only —
+    /// the display sign comes from `cash_flow_bucket`. `None` when the caller
+    /// did not ask for conversion.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub converted_amount: Option<f64>,
+}
+
+/// Net balance over the FULL filtered set (not just the returned page),
+/// converted to the caller-provided base currency. Signed the way each row
+/// displays: income and refunds add, spending outflows and savings transfers
+/// subtract, neutral rows contribute nothing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilteredBalance {
+    pub amount: f64,
+    /// Currency the balance is denominated in (the base currency).
+    pub currency: String,
 }
 
 /// Paginated response for cash-activity search.
@@ -151,4 +170,9 @@ pub struct CashActivitySearchResponse {
     pub items: Vec<CashActivity>,
     /// Total rows matching the filters (for pagination UI).
     pub total_count: usize,
+    /// Net balance over the full filtered set. Only computed for the first page
+    /// (`offset == 0`); `None` on subsequent pages.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filtered_balance: Option<FilteredBalance>,
 }

--- a/crates/spending/src/cash_activities/model.rs
+++ b/crates/spending/src/cash_activities/model.rs
@@ -142,13 +142,14 @@ pub struct CashActivity {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transfer_link_status: Option<TransferLinkStatus>,
-    /// `|amount|` converted to the caller's base currency at this activity's
-    /// own date, so clients can sum rows across currencies. Magnitude only —
-    /// the display sign comes from `cash_flow_bucket`. `None` when the caller
-    /// did not ask for conversion.
+    /// Signed cash movement for this row, converted to the caller's base
+    /// currency at the activity's own date: positive when money entered the
+    /// account, negative when it left. Computed by the same resolver that
+    /// builds account balances, so clients sum these directly instead of
+    /// re-deriving a sign. `None` when the caller did not ask for conversion.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub converted_amount: Option<f64>,
+    pub cash_movement: Option<f64>,
 }
 
 /// Net balance over the FULL filtered set (not just the returned page),

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -15,8 +15,8 @@ use wealthfolio_core::activities::{
 use super::{
     model::{
         CashActivity, CashActivityFilter, CashActivitySearchRequest, CashActivitySearchResponse,
-        CashActivitySortField, CashActivityStatusFilter, CashFlowBucket, SortDirection,
-        TransferLinkStatus,
+        CashActivitySortField, CashActivityStatusFilter, CashFlowBucket, FilteredBalance,
+        SortDirection, TransferLinkStatus,
     },
     CASH_ACTIVITY_TYPES,
 };
@@ -27,8 +27,8 @@ use crate::activity_assignments::{
     ActivityTaxonomyAssignment, ActivityTaxonomyAssignmentService, BulkCategoryAssignment,
 };
 use crate::activity_classification::{
-    activity_abs_amount, classify_activity, classify_activity_for_aggregation,
-    within_spending_transfer_groups, SpendingClassification,
+    activity_abs_amount, classify_activity, classify_activity_for_aggregation, decimal_to_f64,
+    fx_to_target, within_spending_transfer_groups, SpendingClassification,
 };
 use crate::activity_splits::{ActivitySplit, ActivitySplitRepositoryTrait, NewActivitySplit};
 use crate::error::SpendingError;
@@ -160,6 +160,7 @@ impl CashActivityService {
                     splits,
                     event_id,
                     transfer_link_status,
+                    converted_amount: None,
                 }
             })
             .collect();
@@ -167,16 +168,23 @@ impl CashActivityService {
     }
 
     /// Search/filter/paginate cash activities. Powers the spending Transactions page.
-    /// Server-side pipeline: filters → sort → paginate → join assignments for the page slice.
+    /// Server-side pipeline: filters → sort → filtered balance → paginate → join
+    /// assignments for the page slice.
+    ///
+    /// `base_currency` is the currency the filtered balance and the per-row
+    /// converted amounts are denominated in. It is injected by the app-level
+    /// callers (never sent by the client); pass an empty string to skip both.
     pub async fn search(
         &self,
         req: CashActivitySearchRequest,
+        base_currency: &str,
     ) -> Result<CashActivitySearchResponse> {
         let s = self.settings.get().await?;
         if !s.enabled || s.account_ids.is_empty() {
             return Ok(CashActivitySearchResponse {
                 items: Vec::new(),
                 total_count: 0,
+                filtered_balance: None,
             });
         }
 
@@ -186,6 +194,7 @@ impl CashActivityService {
             return Ok(CashActivitySearchResponse {
                 items: Vec::new(),
                 total_count: 0,
+                filtered_balance: None,
             });
         }
         let all_spending_account_ids: HashSet<&str> =
@@ -201,6 +210,7 @@ impl CashActivityService {
             return Ok(CashActivitySearchResponse {
                 items: Vec::new(),
                 total_count: 0,
+                filtered_balance: None,
             });
         }
 
@@ -394,6 +404,23 @@ impl CashActivityService {
 
         let total_count = activities.len();
 
+        // Net balance over the FULL filtered set — computed before pagination so
+        // it covers every matching row, not just the returned page. Only the
+        // first page carries it: page 1 is refetched on every filter change, so
+        // later pages can skip the recomputation.
+        let filtered_balance = (req.offset == 0 && !base_currency.is_empty()).then(|| {
+            let amount = activities
+                .iter()
+                .map(|a| {
+                    self.converted_net_amount(a, &account_types, &transfer_groups, base_currency)
+                })
+                .sum();
+            FilteredBalance {
+                amount: decimal_to_f64(amount),
+                currency: base_currency.to_string(),
+            }
+        });
+
         // Paginate
         let offset = req.offset.min(total_count);
         let limit = req.limit.min(MAX_CASH_ACTIVITY_SEARCH_LIMIT);
@@ -419,6 +446,8 @@ impl CashActivityService {
                 let event_id = tag_map.remove(&a.id);
                 let cash_flow_bucket = cash_flow_bucket_for(&a, &account_types, &transfer_groups);
                 let transfer_link_status = transfer_link_status_for(&a, &transfer_link_resolution);
+                let converted_amount = (!base_currency.is_empty())
+                    .then(|| decimal_to_f64(self.converted_abs_amount(&a, base_currency)));
                 CashActivity {
                     activity: a,
                     cash_flow_bucket,
@@ -426,11 +455,50 @@ impl CashActivityService {
                     splits,
                     event_id,
                     transfer_link_status,
+                    converted_amount,
                 }
             })
             .collect();
 
-        Ok(CashActivitySearchResponse { items, total_count })
+        Ok(CashActivitySearchResponse {
+            items,
+            total_count,
+            filtered_balance,
+        })
+    }
+
+    /// `|amount|` converted to `target` at the activity's own date. Falls back
+    /// to the native amount when no rate is available, so a missing rate
+    /// understates rather than drops the row.
+    fn converted_abs_amount(&self, activity: &Activity, target: &str) -> Decimal {
+        let native = activity_abs_amount(activity);
+        fx_to_target(
+            self.fx.as_ref(),
+            native,
+            &activity.currency,
+            target,
+            activity.activity_date.date_naive(),
+        )
+        .unwrap_or(native)
+    }
+
+    /// Signed contribution of one activity to the filtered balance, in
+    /// `target` currency. Sign matches what the row displays — income and
+    /// refunds add, spending outflows and savings transfers subtract, neutral
+    /// rows contribute nothing.
+    fn converted_net_amount(
+        &self,
+        activity: &Activity,
+        account_types: &HashMap<String, String>,
+        transfer_groups: &HashSet<String>,
+        target: &str,
+    ) -> Decimal {
+        let Some(account_type) = account_types.get(&activity.account_id) else {
+            return Decimal::ZERO;
+        };
+        let classification =
+            classify_activity_for_aggregation(activity, account_type, transfer_groups);
+        classification.net_amount(self.converted_abs_amount(activity, target))
     }
 
     /// Fetch explicit activity ids without applying the normal status/date/limit
@@ -489,6 +557,7 @@ impl CashActivityService {
                     splits,
                     event_id,
                     transfer_link_status,
+                    converted_amount: None,
                 }
             })
             .collect())
@@ -1053,6 +1122,10 @@ mod tests {
         Arc::new(MockFx { rate: Decimal::ONE })
     }
 
+    fn fixed_rate_fx(rate: Decimal) -> Arc<MockFx> {
+        Arc::new(MockFx { rate })
+    }
+
     #[async_trait]
     impl wealthfolio_core::fx::FxServiceTrait for MockFx {
         fn initialize(&self) -> wealthfolio_core::Result<()> {
@@ -1075,7 +1148,7 @@ mod tests {
             _: &str,
             _: chrono::NaiveDate,
         ) -> wealthfolio_core::Result<Decimal> {
-            Ok(Decimal::ONE)
+            Ok(self.rate)
         }
         fn convert_currency(
             &self,
@@ -1083,7 +1156,7 @@ mod tests {
             _: &str,
             _: &str,
         ) -> wealthfolio_core::Result<Decimal> {
-            Ok(amount)
+            Ok(amount * self.rate)
         }
         fn convert_currency_for_date(
             &self,
@@ -1092,7 +1165,7 @@ mod tests {
             _: &str,
             _: chrono::NaiveDate,
         ) -> wealthfolio_core::Result<Decimal> {
-            Ok(amount)
+            Ok(amount * self.rate)
         }
         fn get_latest_exchange_rates(
             &self,
@@ -1103,7 +1176,7 @@ mod tests {
             &self,
             _: wealthfolio_core::fx::NewExchangeRate,
         ) -> wealthfolio_core::Result<wealthfolio_core::fx::ExchangeRate> {
-            unimplemented!("PassthroughFx is read-only")
+            unimplemented!("MockFx is read-only")
         }
         async fn update_exchange_rate(
             &self,
@@ -1111,7 +1184,7 @@ mod tests {
             _: &str,
             _: Decimal,
         ) -> wealthfolio_core::Result<wealthfolio_core::fx::ExchangeRate> {
-            unimplemented!("PassthroughFx is read-only")
+            unimplemented!("MockFx is read-only")
         }
         async fn delete_exchange_rate(&self, _: &str) -> wealthfolio_core::Result<()> {
             Ok(())
@@ -1748,9 +1821,61 @@ mod tests {
             split_repo.clone(),
             activity_events,
             events,
-            Arc::new(PassthroughFx),
+            passthrough_fx(),
         );
         (service, assignment_repo, split_repo)
+    }
+
+    /// Service over an arbitrary activity set, for the search tests. Every
+    /// activity lives on the single CASH account the mocks expose.
+    fn make_search_service(
+        activities: Vec<Activity>,
+        fx: Arc<MockFx>,
+        account_type: &str,
+    ) -> CashActivityService {
+        let activity_repo = Arc::new(MockActivityRepo { activities });
+        let account_repo = Arc::new(MockAccountRepo {
+            account: account(account_type),
+        });
+        let settings = Arc::new(SpendingSettingsService::new(Arc::new(MockSettingsRepo)));
+        let assignment_service = Arc::new(ActivityTaxonomyAssignmentService::new(Arc::new(
+            MockAssignmentRepo::default(),
+        )
+            as Arc<dyn crate::activity_assignments::ActivityTaxonomyAssignmentRepositoryTrait>));
+        let split_repo = Arc::new(MockSplitRepo::default());
+        let activity_events = Arc::new(MockActivityEventsRepo);
+        let events = Arc::new(EventsService::new(
+            Arc::new(MockEventTypesRepo),
+            Arc::new(MockEventsRepo),
+            activity_repo.clone() as Arc<dyn ActivityRepositoryTrait>,
+            activity_events.clone(),
+        ));
+        CashActivityService::new(
+            activity_repo as Arc<dyn ActivityRepositoryTrait>,
+            account_repo,
+            settings,
+            assignment_service,
+            split_repo,
+            activity_events,
+            events,
+            fx,
+        )
+    }
+
+    /// `activity()` with a distinct id, so a set of them survives the search
+    /// pipeline as separate rows.
+    fn search_activity(id: &str, activity_type: &str, amount: i64) -> Activity {
+        let mut a = activity(activity_type);
+        a.id = id.to_string();
+        a.amount = Some(Decimal::new(amount, 0));
+        a
+    }
+
+    fn search_request() -> CashActivitySearchRequest {
+        CashActivitySearchRequest {
+            limit: 50,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -1887,5 +2012,114 @@ mod tests {
             .contains("Neutral transfers cannot be split"));
         assert!(assignment_repo.cleared.lock().unwrap().is_empty());
         assert!(split_repo.replaced.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn filtered_balance_signs_each_bucket_the_way_its_row_displays() {
+        // Deposit +100 income, withdrawal -40 outflow, refund credit +15,
+        // cross-boundary transfer out -25 saving, and a within-spending
+        // transfer pair contributing nothing.
+        let mut refund = search_activity("refund", "CREDIT", 15);
+        refund.subtype = Some("REFUND".to_string());
+        let mut saving = search_activity("saving", "TRANSFER_OUT", 25);
+        saving.source_group_id = Some("cross-boundary".to_string());
+        let mut internal_out = search_activity("internal-out", "TRANSFER_OUT", 500);
+        internal_out.source_group_id = Some("within".to_string());
+        let mut internal_in = search_activity("internal-in", "TRANSFER_IN", 500);
+        internal_in.source_group_id = Some("within".to_string());
+
+        let service = make_search_service(
+            vec![
+                search_activity("income", "DEPOSIT", 100),
+                search_activity("spend", "WITHDRAWAL", 40),
+                refund,
+                saving,
+                internal_out,
+                internal_in,
+            ],
+            passthrough_fx(),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "USD").await.unwrap();
+        let balance = response.filtered_balance.unwrap();
+
+        assert_eq!(response.total_count, 6);
+        assert_eq!(balance.amount, 50.0);
+        assert_eq!(balance.currency, "USD");
+    }
+
+    #[tokio::test]
+    async fn filtered_balance_covers_rows_beyond_the_requested_page() {
+        let activities: Vec<Activity> = (0..5)
+            .map(|i| search_activity(&format!("spend-{i}"), "WITHDRAWAL", 10))
+            .collect();
+        let service = make_search_service(activities, passthrough_fx(), account_types::CASH);
+
+        let response = service
+            .search(
+                CashActivitySearchRequest {
+                    limit: 2,
+                    ..search_request()
+                },
+                "USD",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.items.len(), 2);
+        assert_eq!(response.total_count, 5);
+        assert_eq!(response.filtered_balance.unwrap().amount, -50.0);
+    }
+
+    #[tokio::test]
+    async fn filtered_balance_and_row_amounts_convert_to_the_base_currency() {
+        let service = make_search_service(
+            vec![search_activity("spend", "WITHDRAWAL", 40)],
+            fixed_rate_fx(Decimal::new(2, 0)),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "EUR").await.unwrap();
+
+        assert_eq!(response.filtered_balance.unwrap().amount, -80.0);
+        // Rows carry the converted magnitude; the sign stays with the bucket.
+        assert_eq!(response.items[0].converted_amount, Some(80.0));
+    }
+
+    #[tokio::test]
+    async fn later_pages_skip_the_filtered_balance() {
+        let activities: Vec<Activity> = (0..5)
+            .map(|i| search_activity(&format!("spend-{i}"), "WITHDRAWAL", 10))
+            .collect();
+        let service = make_search_service(activities, passthrough_fx(), account_types::CASH);
+
+        let response = service
+            .search(
+                CashActivitySearchRequest {
+                    offset: 2,
+                    limit: 2,
+                    ..search_request()
+                },
+                "USD",
+            )
+            .await
+            .unwrap();
+
+        assert!(response.filtered_balance.is_none());
+    }
+
+    #[tokio::test]
+    async fn an_empty_base_currency_skips_conversion_entirely() {
+        let service = make_search_service(
+            vec![search_activity("spend", "WITHDRAWAL", 40)],
+            passthrough_fx(),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "").await.unwrap();
+
+        assert!(response.filtered_balance.is_none());
+        assert!(response.items[0].converted_amount.is_none());
     }
 }

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -11,6 +11,7 @@ use wealthfolio_core::activities::{
     Activity, ActivityRepositoryTrait, TransferPairResolution, ACTIVITY_TYPE_TRANSFER_IN,
     ACTIVITY_TYPE_TRANSFER_OUT,
 };
+use wealthfolio_core::portfolio::economic_events::ActivityEconomicsResolver;
 
 use super::{
     model::{
@@ -160,7 +161,7 @@ impl CashActivityService {
                     splits,
                     event_id,
                     transfer_link_status,
-                    converted_amount: None,
+                    cash_movement: None,
                 }
             })
             .collect();
@@ -411,9 +412,7 @@ impl CashActivityService {
         let filtered_balance = (req.offset == 0 && !base_currency.is_empty()).then(|| {
             let amount = activities
                 .iter()
-                .map(|a| {
-                    self.converted_net_amount(a, &account_types, &transfer_groups, base_currency)
-                })
+                .map(|a| self.cash_movement(a, &account_types, base_currency))
                 .sum();
             FilteredBalance {
                 amount: decimal_to_f64(amount),
@@ -446,8 +445,8 @@ impl CashActivityService {
                 let event_id = tag_map.remove(&a.id);
                 let cash_flow_bucket = cash_flow_bucket_for(&a, &account_types, &transfer_groups);
                 let transfer_link_status = transfer_link_status_for(&a, &transfer_link_resolution);
-                let converted_amount = (!base_currency.is_empty())
-                    .then(|| decimal_to_f64(self.converted_abs_amount(&a, base_currency)));
+                let cash_movement = (!base_currency.is_empty())
+                    .then(|| decimal_to_f64(self.cash_movement(&a, &account_types, base_currency)));
                 CashActivity {
                     activity: a,
                     cash_flow_bucket,
@@ -455,7 +454,7 @@ impl CashActivityService {
                     splits,
                     event_id,
                     transfer_link_status,
-                    converted_amount,
+                    cash_movement,
                 }
             })
             .collect();
@@ -467,11 +466,44 @@ impl CashActivityService {
         })
     }
 
-    /// `|amount|` converted to `target` at the activity's own date. Falls back
-    /// to the native amount when no rate is available, so a missing rate
-    /// understates rather than drops the row.
-    fn converted_abs_amount(&self, activity: &Activity, target: &str) -> Decimal {
-        let native = activity_abs_amount(activity);
+    /// Signed cash movement of one activity in `target` currency: positive when
+    /// money entered the account, negative when it left.
+    ///
+    /// The sign and magnitude come from `ActivityEconomicsResolver`, the same
+    /// resolver the holdings engine uses to build account cash balances, so this
+    /// total reconciles with the account page by construction rather than by a
+    /// parallel sign table. That also handles the cases a hand-rolled mapping
+    /// gets wrong: credit-card interest is a charge, and a security-transfer leg
+    /// moves only its fee.
+    ///
+    /// Non-POSTED rows contribute nothing — they are visible in this list but
+    /// excluded from balances, so counting them here would disagree with the
+    /// account page.
+    ///
+    /// Unlike the spending buckets, transfers count by direction instead of
+    /// washing out: a Transfer-In filter totals inflow. The FX conversion is
+    /// applied to the *signed* effect, not to `|amount|`, because those two
+    /// differ for security transfers. Falls back to the native amount when no
+    /// rate is available, so a missing rate understates rather than drops a row.
+    fn cash_movement(
+        &self,
+        activity: &Activity,
+        account_types: &HashMap<String, String>,
+        target: &str,
+    ) -> Decimal {
+        if !activity.is_posted() {
+            return Decimal::ZERO;
+        }
+        let is_credit_card = account_types
+            .get(&activity.account_id)
+            .is_some_and(|account_type| account_type == account_types::CREDIT_CARD);
+        let native = ActivityEconomicsResolver::resolve_cash_with_account_context(
+            activity,
+            Decimal::ONE,
+            is_credit_card,
+        )
+        .signed_cash_effect
+        .unwrap_or(Decimal::ZERO);
         fx_to_target(
             self.fx.as_ref(),
             native,
@@ -480,25 +512,6 @@ impl CashActivityService {
             activity.activity_date.date_naive(),
         )
         .unwrap_or(native)
-    }
-
-    /// Signed contribution of one activity to the filtered balance, in
-    /// `target` currency. Sign matches what the row displays — income and
-    /// refunds add, spending outflows and savings transfers subtract, neutral
-    /// rows contribute nothing.
-    fn converted_net_amount(
-        &self,
-        activity: &Activity,
-        account_types: &HashMap<String, String>,
-        transfer_groups: &HashSet<String>,
-        target: &str,
-    ) -> Decimal {
-        let Some(account_type) = account_types.get(&activity.account_id) else {
-            return Decimal::ZERO;
-        };
-        let classification =
-            classify_activity_for_aggregation(activity, account_type, transfer_groups);
-        classification.net_amount(self.converted_abs_amount(activity, target))
     }
 
     /// Fetch explicit activity ids without applying the normal status/date/limit
@@ -557,7 +570,7 @@ impl CashActivityService {
                     splits,
                     event_id,
                     transfer_link_status,
-                    converted_amount: None,
+                    cash_movement: None,
                 }
             })
             .collect())
@@ -2014,11 +2027,12 @@ mod tests {
         assert!(split_repo.replaced.lock().unwrap().is_empty());
     }
 
+    /// The balance measures cash movement, not the spending net: transfers
+    /// count by direction instead of washing out to zero.
     #[tokio::test]
-    async fn filtered_balance_signs_each_bucket_the_way_its_row_displays() {
-        // Deposit +100 income, withdrawal -40 outflow, refund credit +15,
-        // cross-boundary transfer out -25 saving, and a within-spending
-        // transfer pair contributing nothing.
+    async fn filtered_balance_sums_signed_cash_movement() {
+        // +100 deposit, -40 withdrawal, +15 refund credit, -25 transfer out,
+        // and a transfer pair whose two legs cancel (-500 +500).
         let mut refund = search_activity("refund", "CREDIT", 15);
         refund.subtype = Some("REFUND".to_string());
         let mut saving = search_activity("saving", "TRANSFER_OUT", 25);
@@ -2047,6 +2061,143 @@ mod tests {
         assert_eq!(response.total_count, 6);
         assert_eq!(balance.amount, 50.0);
         assert_eq!(balance.currency, "USD");
+    }
+
+    /// Regression for the reported bug: filtering to Transfer In showed 0.00
+    /// because every linked transfer classified as a neutral internal move.
+    #[tokio::test]
+    async fn filtering_to_transfer_in_totals_the_inflow() {
+        let mut linked_a = search_activity("in-a", "TRANSFER_IN", 300);
+        linked_a.source_group_id = Some("pair-a".to_string());
+        let mut linked_b = search_activity("in-b", "TRANSFER_IN", 200);
+        linked_b.source_group_id = Some("pair-b".to_string());
+        let mut paired_out = search_activity("out-a", "TRANSFER_OUT", 300);
+        paired_out.source_group_id = Some("pair-a".to_string());
+
+        let service = make_search_service(
+            vec![linked_a, linked_b, paired_out],
+            passthrough_fx(),
+            account_types::CASH,
+        );
+
+        let response = service
+            .search(
+                CashActivitySearchRequest {
+                    activity_types: Some(vec!["TRANSFER_IN".to_string()]),
+                    ..search_request()
+                },
+                "USD",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.total_count, 2);
+        assert_eq!(response.filtered_balance.unwrap().amount, 500.0);
+    }
+
+    #[tokio::test]
+    async fn filtering_to_transfer_out_totals_the_outflow() {
+        let mut out_a = search_activity("out-a", "TRANSFER_OUT", 300);
+        out_a.source_group_id = Some("pair-a".to_string());
+        let mut out_b = search_activity("out-b", "TRANSFER_OUT", 200);
+        out_b.source_group_id = Some("pair-b".to_string());
+
+        let service =
+            make_search_service(vec![out_a, out_b], passthrough_fx(), account_types::CASH);
+
+        let response = service
+            .search(
+                CashActivitySearchRequest {
+                    activity_types: Some(vec!["TRANSFER_OUT".to_string()]),
+                    ..search_request()
+                },
+                "USD",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.filtered_balance.unwrap().amount, -500.0);
+    }
+
+    /// Both legs of an internal move still cancel when both are in the filtered
+    /// set — the money never left the user's accounts.
+    #[tokio::test]
+    async fn a_transfer_pair_in_the_same_filter_still_nets_to_zero() {
+        let mut out = search_activity("out", "TRANSFER_OUT", 750);
+        out.source_group_id = Some("pair".to_string());
+        let mut into = search_activity("in", "TRANSFER_IN", 750);
+        into.source_group_id = Some("pair".to_string());
+
+        let service = make_search_service(vec![out, into], passthrough_fx(), account_types::CASH);
+
+        let response = service.search(search_request(), "USD").await.unwrap();
+
+        assert_eq!(response.filtered_balance.unwrap().amount, 0.0);
+    }
+
+    /// A plain CREDIT with no subtype is `Ignored`, so it never appears in this
+    /// list at all — and therefore cannot count toward the balance. It does move
+    /// cash on the account page, so this is a known reconciliation gap, pinned
+    /// here so the exclusion stays deliberate rather than accidental.
+    #[tokio::test]
+    async fn a_credit_without_a_subtype_is_not_listed_and_so_is_excluded() {
+        let service = make_search_service(
+            vec![search_activity("credit", "CREDIT", 60)],
+            passthrough_fx(),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "USD").await.unwrap();
+
+        assert_eq!(response.total_count, 0);
+        assert_eq!(response.filtered_balance.unwrap().amount, 0.0);
+    }
+
+    /// A refund credit is visible, and moves cash in.
+    #[tokio::test]
+    async fn a_refund_credit_counts_as_an_inflow() {
+        let mut refund = search_activity("refund", "CREDIT", 60);
+        refund.subtype = Some("REFUND".to_string());
+
+        let service = make_search_service(vec![refund], passthrough_fx(), account_types::CASH);
+
+        let response = service.search(search_request(), "USD").await.unwrap();
+
+        assert_eq!(response.filtered_balance.unwrap().amount, 60.0);
+        assert_eq!(response.items[0].cash_movement, Some(60.0));
+    }
+
+    /// Interest is income on a cash account but a charge on a credit card.
+    #[tokio::test]
+    async fn credit_card_interest_is_an_outflow() {
+        let service = make_search_service(
+            vec![search_activity("interest", "INTEREST", 12)],
+            passthrough_fx(),
+            account_types::CREDIT_CARD,
+        );
+
+        let response = service.search(search_request(), "USD").await.unwrap();
+
+        assert_eq!(response.filtered_balance.unwrap().amount, -12.0);
+    }
+
+    /// Non-POSTED rows are visible in this list but excluded from account
+    /// balances, so counting them here would disagree with the account page.
+    #[tokio::test]
+    async fn rows_that_are_not_posted_contribute_nothing() {
+        let mut draft = search_activity("draft", "DEPOSIT", 400);
+        draft.status = ActivityStatus::Draft;
+
+        let service = make_search_service(
+            vec![draft, search_activity("posted", "DEPOSIT", 100)],
+            passthrough_fx(),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "USD").await.unwrap();
+
+        assert_eq!(response.total_count, 2);
+        assert_eq!(response.filtered_balance.unwrap().amount, 100.0);
     }
 
     #[tokio::test]
@@ -2084,7 +2235,7 @@ mod tests {
 
         assert_eq!(response.filtered_balance.unwrap().amount, -80.0);
         // Rows carry the converted magnitude; the sign stays with the bucket.
-        assert_eq!(response.items[0].converted_amount, Some(80.0));
+        assert_eq!(response.items[0].cash_movement, Some(-80.0));
     }
 
     #[tokio::test]
@@ -2120,6 +2271,6 @@ mod tests {
         let response = service.search(search_request(), "").await.unwrap();
 
         assert!(response.filtered_balance.is_none());
-        assert!(response.items[0].converted_amount.is_none());
+        assert!(response.items[0].cash_movement.is_none());
     }
 }

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -162,6 +162,7 @@ impl CashActivityService {
                     event_id,
                     transfer_link_status,
                     cash_movement: None,
+                    cash_movement_native: None,
                 }
             })
             .collect();
@@ -409,14 +410,32 @@ impl CashActivityService {
         // it covers every matching row, not just the returned page. Only the
         // first page carries it: page 1 is refetched on every filter change, so
         // later pages can skip the recomputation.
+        // When every matching row shares a currency, total in that currency and
+        // skip FX entirely — a single-currency account then reads exactly, with
+        // none of the per-activity-rate drift that converting would introduce.
+        // Only a genuinely mixed set falls back to the base currency.
         let filtered_balance = (req.offset == 0 && !base_currency.is_empty()).then(|| {
-            let amount = activities
-                .iter()
-                .map(|a| self.cash_movement(a, &account_types, base_currency))
-                .sum();
-            FilteredBalance {
-                amount: decimal_to_f64(amount),
-                currency: base_currency.to_string(),
+            match self.sole_currency(&activities, &account_types) {
+                Some(currency) => FilteredBalance {
+                    amount: decimal_to_f64(
+                        activities
+                            .iter()
+                            .map(|a| self.native_cash_movement(a, &account_types))
+                            .sum(),
+                    ),
+                    currency: currency.to_string(),
+                    converted: false,
+                },
+                None => FilteredBalance {
+                    amount: decimal_to_f64(
+                        activities
+                            .iter()
+                            .map(|a| self.converted_cash_movement(a, &account_types, base_currency))
+                            .sum(),
+                    ),
+                    currency: base_currency.to_string(),
+                    converted: true,
+                },
             }
         });
 
@@ -445,8 +464,11 @@ impl CashActivityService {
                 let event_id = tag_map.remove(&a.id);
                 let cash_flow_bucket = cash_flow_bucket_for(&a, &account_types, &transfer_groups);
                 let transfer_link_status = transfer_link_status_for(&a, &transfer_link_resolution);
-                let cash_movement = (!base_currency.is_empty())
-                    .then(|| decimal_to_f64(self.cash_movement(&a, &account_types, base_currency)));
+                let cash_movement = (!base_currency.is_empty()).then(|| {
+                    decimal_to_f64(self.converted_cash_movement(&a, &account_types, base_currency))
+                });
+                let cash_movement_native = (!base_currency.is_empty())
+                    .then(|| decimal_to_f64(self.native_cash_movement(&a, &account_types)));
                 CashActivity {
                     activity: a,
                     cash_flow_bucket,
@@ -455,6 +477,7 @@ impl CashActivityService {
                     event_id,
                     transfer_link_status,
                     cash_movement,
+                    cash_movement_native,
                 }
             })
             .collect();
@@ -466,7 +489,7 @@ impl CashActivityService {
         })
     }
 
-    /// Signed cash movement of one activity in `target` currency: positive when
+    /// Signed cash movement of one activity in its OWN currency: positive when
     /// money entered the account, negative when it left.
     ///
     /// The sign and magnitude come from `ActivityEconomicsResolver`, the same
@@ -481,15 +504,11 @@ impl CashActivityService {
     /// account page.
     ///
     /// Unlike the spending buckets, transfers count by direction instead of
-    /// washing out: a Transfer-In filter totals inflow. The FX conversion is
-    /// applied to the *signed* effect, not to `|amount|`, because those two
-    /// differ for security transfers. Falls back to the native amount when no
-    /// rate is available, so a missing rate understates rather than drops a row.
-    fn cash_movement(
+    /// washing out: a Transfer-In filter totals inflow.
+    fn native_cash_movement(
         &self,
         activity: &Activity,
         account_types: &HashMap<String, String>,
-        target: &str,
     ) -> Decimal {
         if !activity.is_posted() {
             return Decimal::ZERO;
@@ -497,13 +516,26 @@ impl CashActivityService {
         let is_credit_card = account_types
             .get(&activity.account_id)
             .is_some_and(|account_type| account_type == account_types::CREDIT_CARD);
-        let native = ActivityEconomicsResolver::resolve_cash_with_account_context(
+        ActivityEconomicsResolver::resolve_cash_with_account_context(
             activity,
             Decimal::ONE,
             is_credit_card,
         )
         .signed_cash_effect
-        .unwrap_or(Decimal::ZERO);
+        .unwrap_or(Decimal::ZERO)
+    }
+
+    /// `native_cash_movement` converted into `target`. The conversion is applied
+    /// to the *signed* effect, not to `|amount|`, because those two differ for
+    /// security transfers. Falls back to the native amount when no rate is
+    /// available, so a missing rate understates rather than drops a row.
+    fn converted_cash_movement(
+        &self,
+        activity: &Activity,
+        account_types: &HashMap<String, String>,
+        target: &str,
+    ) -> Decimal {
+        let native = self.native_cash_movement(activity, account_types);
         fx_to_target(
             self.fx.as_ref(),
             native,
@@ -512,6 +544,32 @@ impl CashActivityService {
             activity.activity_date.date_naive(),
         )
         .unwrap_or(native)
+    }
+
+    /// The one currency shared by every row that actually moves cash, if there
+    /// is one.
+    ///
+    /// Rows contributing nothing (not posted, or no cash effect) are ignored:
+    /// they cannot change the total, so letting them force an FX conversion
+    /// would lose precision for no reason. `None` means the set spans several
+    /// currencies and has to be converted to the base currency.
+    fn sole_currency<'a>(
+        &self,
+        activities: &'a [Activity],
+        account_types: &HashMap<String, String>,
+    ) -> Option<&'a str> {
+        let mut sole: Option<&str> = None;
+        for activity in activities {
+            if self.native_cash_movement(activity, account_types) == Decimal::ZERO {
+                continue;
+            }
+            match sole {
+                None => sole = Some(&activity.currency),
+                Some(seen) if seen == activity.currency => {}
+                Some(_) => return None,
+            }
+        }
+        sole
     }
 
     /// Fetch explicit activity ids without applying the normal status/date/limit
@@ -571,6 +629,7 @@ impl CashActivityService {
                     event_id,
                     transfer_link_status,
                     cash_movement: None,
+                    cash_movement_native: None,
                 }
             })
             .collect())
@@ -2223,19 +2282,166 @@ mod tests {
         assert_eq!(response.filtered_balance.unwrap().amount, -50.0);
     }
 
+    /// A currency helper for the multi-currency cases below.
+    fn search_activity_in(id: &str, activity_type: &str, amount: i64, currency: &str) -> Activity {
+        let mut a = search_activity(id, activity_type, amount);
+        a.currency = currency.to_string();
+        a
+    }
+
+    /// The reported case: one account in a currency that is not the base one.
+    /// Converting would drift by the FX rate, so a single-currency set is
+    /// totalled in its own currency and left alone.
     #[tokio::test]
-    async fn filtered_balance_and_row_amounts_convert_to_the_base_currency() {
+    async fn a_single_currency_set_totals_in_that_currency_without_converting() {
         let service = make_search_service(
-            vec![search_activity("spend", "WITHDRAWAL", 40)],
+            vec![search_activity_in("spend", "WITHDRAWAL", 40, "USD")],
+            fixed_rate_fx(Decimal::new(2, 0)),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "EUR").await.unwrap();
+        let balance = response.filtered_balance.unwrap();
+
+        assert_eq!(balance.amount, -40.0);
+        assert_eq!(balance.currency, "USD");
+        assert!(!balance.converted);
+    }
+
+    /// Same shape, but the shared currency IS the base currency.
+    #[tokio::test]
+    async fn a_set_already_in_the_base_currency_is_not_marked_converted() {
+        let service = make_search_service(
+            vec![search_activity_in("spend", "WITHDRAWAL", 40, "EUR")],
+            fixed_rate_fx(Decimal::new(2, 0)),
+            account_types::CASH,
+        );
+
+        let balance = service
+            .search(search_request(), "EUR")
+            .await
+            .unwrap()
+            .filtered_balance
+            .unwrap();
+
+        assert_eq!(balance.amount, -40.0);
+        assert_eq!(balance.currency, "EUR");
+        assert!(!balance.converted);
+    }
+
+    /// Several currencies leave no honest choice but the base currency.
+    #[tokio::test]
+    async fn a_mixed_currency_set_converts_to_the_base_currency() {
+        let service = make_search_service(
+            vec![
+                search_activity_in("usd", "WITHDRAWAL", 40, "USD"),
+                search_activity_in("gbp", "WITHDRAWAL", 10, "GBP"),
+            ],
+            fixed_rate_fx(Decimal::new(2, 0)),
+            account_types::CASH,
+        );
+
+        let response = service.search(search_request(), "EUR").await.unwrap();
+        let balance = response.filtered_balance.unwrap();
+
+        // Both rows convert at the stubbed 2x rate: -(40*2) + -(10*2).
+        assert_eq!(balance.amount, -100.0);
+        assert_eq!(balance.currency, "EUR");
+        assert!(balance.converted);
+    }
+
+    /// Rows are always given both amounts, so a client can total either way.
+    #[tokio::test]
+    async fn rows_carry_both_the_native_and_the_converted_movement() {
+        let service = make_search_service(
+            vec![search_activity_in("spend", "WITHDRAWAL", 40, "USD")],
             fixed_rate_fx(Decimal::new(2, 0)),
             account_types::CASH,
         );
 
         let response = service.search(search_request(), "EUR").await.unwrap();
 
-        assert_eq!(response.filtered_balance.unwrap().amount, -80.0);
-        // Rows carry the converted magnitude; the sign stays with the bucket.
+        assert_eq!(response.items[0].cash_movement_native, Some(-40.0));
         assert_eq!(response.items[0].cash_movement, Some(-80.0));
+    }
+
+    /// A row that moves no cash must not drag a single-currency set into a
+    /// conversion it does not need — it cannot change the total either way.
+    #[tokio::test]
+    async fn a_zero_movement_row_in_another_currency_does_not_force_conversion() {
+        let mut draft = search_activity_in("draft", "DEPOSIT", 500, "GBP");
+        draft.status = ActivityStatus::Draft;
+
+        let service = make_search_service(
+            vec![search_activity_in("spend", "WITHDRAWAL", 40, "USD"), draft],
+            fixed_rate_fx(Decimal::new(2, 0)),
+            account_types::CASH,
+        );
+
+        let balance = service
+            .search(search_request(), "EUR")
+            .await
+            .unwrap()
+            .filtered_balance
+            .unwrap();
+
+        assert_eq!(balance.amount, -40.0);
+        assert_eq!(balance.currency, "USD");
+        assert!(!balance.converted);
+    }
+
+    /// The currency is decided over the WHOLE filtered set, not the page, so a
+    /// second currency beyond the page limit still forces the conversion.
+    #[tokio::test]
+    async fn a_currency_beyond_the_page_limit_still_forces_conversion() {
+        let mut activities: Vec<Activity> = (0..3)
+            .map(|i| search_activity_in(&format!("usd-{i}"), "WITHDRAWAL", 10, "USD"))
+            .collect();
+        activities.push(search_activity_in("gbp", "WITHDRAWAL", 10, "GBP"));
+
+        let service =
+            make_search_service(activities, fixed_rate_fx(Decimal::ONE), account_types::CASH);
+
+        let response = service
+            .search(
+                CashActivitySearchRequest {
+                    limit: 2,
+                    ..search_request()
+                },
+                "EUR",
+            )
+            .await
+            .unwrap();
+        let balance = response.filtered_balance.unwrap();
+
+        assert_eq!(response.items.len(), 2);
+        assert_eq!(balance.currency, "EUR");
+        assert!(balance.converted);
+        assert_eq!(balance.amount, -40.0);
+    }
+
+    /// Mixed currencies that happen to cancel still report as converted — the
+    /// disclosure is about how the total was reached, not whether it is zero.
+    #[tokio::test]
+    async fn a_mixed_set_that_nets_to_zero_is_still_marked_converted() {
+        let service = make_search_service(
+            vec![
+                search_activity_in("in", "DEPOSIT", 50, "USD"),
+                search_activity_in("out", "WITHDRAWAL", 50, "GBP"),
+            ],
+            fixed_rate_fx(Decimal::ONE),
+            account_types::CASH,
+        );
+
+        let balance = service
+            .search(search_request(), "EUR")
+            .await
+            .unwrap()
+            .filtered_balance
+            .unwrap();
+
+        assert_eq!(balance.amount, 0.0);
+        assert!(balance.converted);
     }
 
     #[tokio::test]

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -51,9 +51,11 @@ pub struct CashActivityService {
     splits: Arc<dyn ActivitySplitRepositoryTrait>,
     activity_events: Arc<dyn crate::activity_events::ActivityEventsRepositoryTrait>,
     events: Arc<EventsService>,
+    fx: Arc<dyn wealthfolio_core::fx::FxServiceTrait>,
 }
 
 impl CashActivityService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         activity_repo: Arc<dyn ActivityRepositoryTrait>,
         account_repo: Arc<dyn AccountRepositoryTrait>,
@@ -62,6 +64,7 @@ impl CashActivityService {
         splits: Arc<dyn ActivitySplitRepositoryTrait>,
         activity_events: Arc<dyn crate::activity_events::ActivityEventsRepositoryTrait>,
         events: Arc<EventsService>,
+        fx: Arc<dyn wealthfolio_core::fx::FxServiceTrait>,
     ) -> Self {
         Self {
             activity_repo,
@@ -71,6 +74,7 @@ impl CashActivityService {
             splits,
             activity_events,
             events,
+            fx,
         }
     }
 
@@ -1038,6 +1042,95 @@ mod tests {
         }
     }
 
+    /// FX stub that multiplies cross-currency conversions by a fixed rate.
+    /// `passthrough_fx()` (rate 1) returns amounts unchanged. Local to this
+    /// module (the analytics tests' PassthroughFx is `pub(super)` there).
+    struct MockFx {
+        rate: Decimal,
+    }
+
+    fn passthrough_fx() -> Arc<MockFx> {
+        Arc::new(MockFx { rate: Decimal::ONE })
+    }
+
+    #[async_trait]
+    impl wealthfolio_core::fx::FxServiceTrait for MockFx {
+        fn initialize(&self) -> wealthfolio_core::Result<()> {
+            Ok(())
+        }
+        fn get_historical_rates(
+            &self,
+            _: &str,
+            _: &str,
+            _: i64,
+        ) -> wealthfolio_core::Result<Vec<wealthfolio_core::fx::ExchangeRate>> {
+            Ok(vec![])
+        }
+        fn get_latest_exchange_rate(&self, _: &str, _: &str) -> wealthfolio_core::Result<Decimal> {
+            Ok(Decimal::ONE)
+        }
+        fn get_exchange_rate_for_date(
+            &self,
+            _: &str,
+            _: &str,
+            _: chrono::NaiveDate,
+        ) -> wealthfolio_core::Result<Decimal> {
+            Ok(Decimal::ONE)
+        }
+        fn convert_currency(
+            &self,
+            amount: Decimal,
+            _: &str,
+            _: &str,
+        ) -> wealthfolio_core::Result<Decimal> {
+            Ok(amount)
+        }
+        fn convert_currency_for_date(
+            &self,
+            amount: Decimal,
+            _: &str,
+            _: &str,
+            _: chrono::NaiveDate,
+        ) -> wealthfolio_core::Result<Decimal> {
+            Ok(amount)
+        }
+        fn get_latest_exchange_rates(
+            &self,
+        ) -> wealthfolio_core::Result<Vec<wealthfolio_core::fx::ExchangeRate>> {
+            Ok(vec![])
+        }
+        async fn add_exchange_rate(
+            &self,
+            _: wealthfolio_core::fx::NewExchangeRate,
+        ) -> wealthfolio_core::Result<wealthfolio_core::fx::ExchangeRate> {
+            unimplemented!("PassthroughFx is read-only")
+        }
+        async fn update_exchange_rate(
+            &self,
+            _: &str,
+            _: &str,
+            _: Decimal,
+        ) -> wealthfolio_core::Result<wealthfolio_core::fx::ExchangeRate> {
+            unimplemented!("PassthroughFx is read-only")
+        }
+        async fn delete_exchange_rate(&self, _: &str) -> wealthfolio_core::Result<()> {
+            Ok(())
+        }
+        async fn register_currency_pair(&self, _: &str, _: &str) -> wealthfolio_core::Result<()> {
+            Ok(())
+        }
+        async fn register_currency_pair_manual(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> wealthfolio_core::Result<()> {
+            Ok(())
+        }
+        async fn ensure_fx_pairs(&self, _: Vec<(String, String)>) -> wealthfolio_core::Result<()> {
+            Ok(())
+        }
+    }
+
     #[derive(Default)]
     struct MockSettingsRepo;
 
@@ -1655,6 +1748,7 @@ mod tests {
             split_repo.clone(),
             activity_events,
             events,
+            Arc::new(PassthroughFx),
         );
         (service, assignment_repo, split_repo)
     }

--- a/crates/spending/src/cash_activities/traits.rs
+++ b/crates/spending/src/cash_activities/traits.rs
@@ -16,7 +16,9 @@ pub trait CashActivityServiceTrait: Send + Sync {
 #[async_trait]
 impl CashActivityServiceTrait for CashActivityService {
     async fn search(&self, req: CashActivitySearchRequest) -> Result<CashActivitySearchResponse> {
-        CashActivityService::search(self, req).await
+        // Agent tools read native per-row amounts; no base currency, so the
+        // service skips FX conversion and the filtered balance.
+        CashActivityService::search(self, req, "").await
     }
 
     async fn get_by_activity_ids(&self, activity_ids: &[String]) -> Result<Vec<CashActivity>> {


### PR DESCRIPTION

Fixes https://github.com/wealthfolio/wealthfolio/issues/1576 and pairs very well with #1599 and #1583.

## What this does

Adds two balance readouts to the Spending → Transactions tab, next to the existing transaction count:

- **Selected balance** — appears whenever rows are checked, showing the net of exactly those rows.
- **Filtered balance** — appears while a filter or search term is active, showing the net over the **entire** filtered set, including rows that scrolling hasn't loaded yet.

Both can be on screen at the same time, and both respect the balance-privacy toggle.

## What the number means

The design follows popular budgeting apps patterns, which show `Selected balance:` and `Filtered balance:` pills under the same conditions — including treating an active search as "filtered".

The balance measures **cash movement**: what actually moved in and out of the accounts. Money in adds, money out subtracts, and transfers count by direction rather than cancelling out.

| Row                                | Contributes |
| ---------------------------------- | ----------- |
| Income                             | adds        |
| Spending — outflow                 | subtracts   |
| Spending — refund                  | adds        |
| Transfer in                        | adds        |
| Transfer out                       | subtracts   |
| Draft / pending (not yet posted)   | nothing     |

So filtering to Transfer In totals your inflow, Transfer Out totals your outflow, and a single account on its own agrees with that account's own page. Both legs of an internal move still cancel when both are in the filtered set, because the money never left your accounts.

An earlier revision summed a _spending net_ instead, which treated moves between your own accounts as neither income nor expense and contributed zero. @steprp [tested it](https://github.com/wealthfolio/wealthfolio/pull/1594#issuecomment-5480307131) and found a Transfer-In filter showing `0.00` — correct under that rule, and useless in practice, since every row in that filter was excluded by construction. Cash movement is the right question for a readout attached to a transaction list; the earn-and-spend question is already answered by Insights, Budget and Reports, none of which this PR touches.

**Tradeoff:** transfer rows still render unsigned in the table. A transfer row shows `$900.00` with no `+`/`−` while contributing `+900` to the balance, so the rows no longer visibly add up to the pill. Signing them would restore that, at the cost of changing how every transfer looks. Both pills use the one rule, so selecting every filtered row still equals the filtered balance — it just isn't verifiable by eye on transfer rows. A test pins the unsigned rendering so a later change can't repaint it silently.

Amounts are FX-converted to the base currency at each activity's own date, falling back to the native amount when no rate is available so a missing rate understates rather than silently drops a row.

## Implementation

**Why the filtered balance can't be a client-side sum:** the transactions list is paginated at 50 rows, so the client only ever holds part of the result set. Summing what's loaded gives a number that silently disagrees with the filter — see the verification below, where the loaded page sums to `+60` while the true balance is `−100`.

**Backend** (`crates/spending`)

- `search()` sums the full filtered set _before_ pagination into a new `FilteredBalance { amount, currency }` on the response. This is one O(n) pass over a `Vec` that is already materialized in memory — no extra queries.
- The balance rides only on the first page (`offset == 0`), which clients refetch on every filter change; later pages carry `None`.
- Each returned row gains `cashMovement` — the _signed_ movement in the base currency — so the client sums rows across currencies without re-deriving a sign.
- The base currency is injected by the Tauri and Axum callers and never sent by the client. The agent-tools trait passes an empty string, which skips conversion entirely and leaves that surface unchanged.
- Signs come from `ActivityEconomicsResolver`, the same resolver the holdings engine uses to build account cash balances, so agreement with the account page holds by construction rather than by a second sign table that could drift. Reusing it also covers three cases a hand-rolled mapping gets wrong: credit-card interest is a charge rather than income, a security-transfer leg moves only its fee, and non-posted rows are visible in this list but excluded from balances. FX is applied to the signed effect rather than to `|amount|`, since those differ for security transfers.

**Frontend** (`apps/frontend/src/features/spending`)

- The selected balance is a plain sum of the server-provided `cashMovement` over the checked rows, so the two pills cannot disagree. Selection is limited to loaded rows, so no extra round-trip is needed.
- The filtered balance is read off page 0 of the existing infinite query.
- Visibility reuses the tab's existing `filtersActive` flag (which already accounts for the debounced search) rather than introducing a second notion of "filtered".
- New i18n keys `filters.selectedBalance` / `filters.filteredBalance` across all 7 locales.

Bucket classification is untouched: categorization, the Categorized/Uncategorized filter, split and assign guards, bulk-categorize scope and row colour all read `cashFlowBucket` exactly as before.

## Verification

Exercised against a real DB with 6K+ activities and a test dataset of 66 activities on a CASH account — one per bucket plus 60 filler rows to force a second page.

**The reported cases.** Filtering one account:

| Filter                | Before    | After       |
| --------------------- | --------- | ----------- |
| Transfer In only      | `0.00`    | `+900.00`   |
| Transfer Out only     | —         | `−1,150.00` |
| Account only          | `−100.00` | `−100.00`   |

The account-only figure matches that account's own `cashBalance` from the valuation endpoint exactly (`−100.00 USD`).

**The filtered balance covers unloaded rows.** With 66 matching rows and 50 loaded:

|                               |           |
| ----------------------------- | --------- |
| Sum of the 50 **loaded** rows | `+60.00`  |
| `filteredBalance` over all 66 | `−100.00` |

`1000 − 400 + 150 − 250 − 900 + 900 − 600 = −100` ✓. Page 2 (`offset: 50`) correctly omits the balance.

**Per-row signs.** Filtering to the six sampler rows returns `500.00` — `+1000 (deposit) − 400 (withdrawal) + 150 (refund) − 250 (transfer out) − 900 + 900 (transfer pair)`.

**UI behaviour**, confirmed in the running app:

| Scenario                     | Result                                    |
| ---------------------------- | ----------------------------------------- |
| Unfiltered, nothing selected | no pills                                  |
| Two −$10 rows checked        | Selected balance −$20.00                  |
| Search filter active         | Filtered balance $500.00                  |
| Both at once                 | Selected $600.00 **and** Filtered $500.00 |
| All filtered rows selected   | Selected $500.00 **=** Filtered $500.00   |
| Selection cleared            | Selected pill hides, Filtered remains     |
| Balance privacy on           | both pills mask to `••••`                 |

**Tests**

- 12 service tests: transfer-in totals inflow (the reported regression), transfer-out totals outflow, a transfer pair nets to zero, credit-card interest is an outflow, non-posted rows contribute nothing, refund credits add, a subtype-less credit stays excluded, per-row signs, coverage beyond the page limit, FX conversion of both the balance and per-row amounts, `None` on later pages, and the empty-base-currency skip.
- 8 filter-bar component tests covering all eight combinations of (selected balance present) × (filtered balance present) × (filter active), plus 8 helper tests for the selected-balance sum and a guard that transfer rows still render unsigned.
- Full `cargo test --workspace` and the frontend suite pass, along with `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo check -p wealthfolio-server --release`, `pnpm type-check`, `pnpm lint`, `pnpm format:check`, and `pnpm build`.

## Notes for reviewers

- The first two commits are pure infrastructure and behaviour-preserving: a move of `fx_to_target` into the shared classification module, and threading the existing FX service into `CashActivityService`.
- The last commit is the semantics fix from review feedback; reviewing it on its own shows exactly what changed and why.
- `CashActivitySearchResponse` gains an optional field; existing consumers deserialize unchanged.
- The pills render on both desktop and mobile.

## Commits

- `6064696c8` refactor(spending): move fx_to_target into activity_classification
- `c62d45e93` feat(spending): thread FX service into CashActivityService
- `247b2ed6e` feat(spending): return a filtered balance and converted row amounts
- `b32a434c7` feat(spending): show selected and filtered balance in the transactions bar
- `4a5416a17` test(spending): cover every selected/filtered balance combination
- `b95fe1816` fix(spending): measure cash movement, not the spending net

26 files changed, 931 insertions(+), 50 deletions(-)

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
