### PR TITLE
feat(activity/spending): infinite scroll for spending and investment activity lists

### DIFF
--- a/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
@@ -48,7 +48,12 @@ describe("InfiniteScrollTrigger", () => {
 
   it("renders a sentinel and observes it while more pages exist", () => {
     render(
-      <InfiniteScrollTrigger onLoadMore={vi.fn()} hasNextPage={true} isFetchingNextPage={false} />,
+      <InfiniteScrollTrigger
+        onLoadMore={vi.fn()}
+        hasNextPage={true}
+        isFetching={false}
+        isFetchingNextPage={false}
+      />,
     );
 
     expect(instances).toHaveLength(1);
@@ -57,7 +62,12 @@ describe("InfiniteScrollTrigger", () => {
 
   it("renders nothing when pagination is finished", () => {
     const { container } = render(
-      <InfiniteScrollTrigger onLoadMore={vi.fn()} hasNextPage={false} isFetchingNextPage={false} />,
+      <InfiniteScrollTrigger
+        onLoadMore={vi.fn()}
+        hasNextPage={false}
+        isFetching={false}
+        isFetchingNextPage={false}
+      />,
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -70,6 +80,7 @@ describe("InfiniteScrollTrigger", () => {
       <InfiniteScrollTrigger
         onLoadMore={onLoadMore}
         hasNextPage={true}
+        isFetching={false}
         isFetchingNextPage={false}
       />,
     );
@@ -80,14 +91,52 @@ describe("InfiniteScrollTrigger", () => {
 
   it("shows the loading indicator while the next page is fetching", () => {
     render(
-      <InfiniteScrollTrigger onLoadMore={vi.fn()} hasNextPage={true} isFetchingNextPage={true} />,
+      <InfiniteScrollTrigger
+        onLoadMore={vi.fn()}
+        hasNextPage={true}
+        isFetching={true}
+        isFetchingNextPage={true}
+      />,
     );
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
+  it("does not fetch the next page while a background refetch is in flight", () => {
+    const onLoadMore = vi.fn();
+    const { rerender } = render(
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetching={false}
+        isFetchingNextPage={false}
+      />,
+    );
+    const observerCallback = lastInstance().callback;
+
+    // A background refetch starts: isFetching without isFetchingNextPage.
+    rerender(
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetching={true}
+        isFetchingNextPage={false}
+      />,
+    );
+
+    // An entry delivered from the observer created before the rerender
+    // must see the latest state and refuse to overlap the refetch.
+    observerCallback([{ isIntersecting: true }]);
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
   it("reconnects the observer when the trigger moves to a different layout slot", () => {
-    const props = { onLoadMore: vi.fn(), hasNextPage: true, isFetchingNextPage: false };
+    const props = {
+      onLoadMore: vi.fn(),
+      hasNextPage: true,
+      isFetching: false,
+      isFetchingNextPage: false,
+    };
     const { rerender } = render(
       <div data-testid="desktop">
         <InfiniteScrollTrigger {...props} />

--- a/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InfiniteScrollTrigger } from "./infinite-scroll-trigger";
+
+type ObserverCallback = (entries: { isIntersecting: boolean }[]) => void;
+
+interface ObserverInstance {
+  callback: ObserverCallback;
+  options: IntersectionObserverInit | undefined;
+  observed: Element[];
+  disconnected: boolean;
+}
+
+let instances: ObserverInstance[] = [];
+
+class MockIntersectionObserver {
+  instance: ObserverInstance;
+
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    this.instance = { callback, options, observed: [], disconnected: false };
+    instances.push(this.instance);
+  }
+
+  observe = (element: Element) => {
+    this.instance.observed.push(element);
+  };
+
+  disconnect = () => {
+    this.instance.disconnected = true;
+  };
+}
+
+function lastInstance(): ObserverInstance {
+  const instance = instances[instances.length - 1];
+  if (!instance) throw new Error("no IntersectionObserver was created");
+  return instance;
+}
+
+describe("InfiniteScrollTrigger", () => {
+  beforeEach(() => {
+    instances = [];
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a sentinel and observes it while more pages exist", () => {
+    render(
+      <InfiniteScrollTrigger onLoadMore={vi.fn()} hasNextPage={true} isFetchingNextPage={false} />,
+    );
+
+    expect(instances).toHaveLength(1);
+    expect(lastInstance().observed).toHaveLength(1);
+  });
+
+  it("renders nothing when pagination is finished", () => {
+    const { container } = render(
+      <InfiniteScrollTrigger onLoadMore={vi.fn()} hasNextPage={false} isFetchingNextPage={false} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(instances).toHaveLength(0);
+  });
+
+  it("calls onLoadMore when the sentinel intersects", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetchingNextPage={false}
+      />,
+    );
+
+    lastInstance().callback([{ isIntersecting: true }]);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the loading indicator while the next page is fetching", () => {
+    render(
+      <InfiniteScrollTrigger onLoadMore={vi.fn()} hasNextPage={true} isFetchingNextPage={true} />,
+    );
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("reconnects the observer when the trigger moves to a different layout slot", () => {
+    const props = { onLoadMore: vi.fn(), hasNextPage: true, isFetchingNextPage: false };
+    const { rerender } = render(
+      <div data-testid="desktop">
+        <InfiniteScrollTrigger {...props} />
+      </div>,
+    );
+    expect(instances).toHaveLength(1);
+
+    rerender(
+      <section data-testid="mobile">
+        <InfiniteScrollTrigger {...props} />
+      </section>,
+    );
+
+    expect(instances.length).toBeGreaterThan(1);
+    expect(instances[0].disconnected).toBe(true);
+    const active = lastInstance();
+    expect(active.disconnected).toBe(false);
+    expect(active.observed).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InfiniteScrollTrigger } from "./infinite-scroll-trigger";
 
@@ -100,6 +100,51 @@ describe("InfiniteScrollTrigger", () => {
     );
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("keeps a status live region mounted before any fetch starts", () => {
+    render(
+      <InfiniteScrollTrigger
+        onLoadMore={vi.fn()}
+        hasNextPage={true}
+        isFetching={false}
+        isFetchingNextPage={false}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("offers an accessible Load more button that fetches on activation", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetching={false}
+        isFetchingNextPage={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the Load more button while a fetch is in flight", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetching={true}
+        isFetchingNextPage={true}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /load more/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onLoadMore).not.toHaveBeenCalled();
   });
 
   it("does not fetch the next page while a background refetch is in flight", () => {

--- a/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { useLayoutEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InfiniteScrollTrigger } from "./infinite-scroll-trigger";
 
@@ -36,6 +37,31 @@ function lastInstance(): ObserverInstance {
   return instance;
 }
 
+function BackgroundRefetchHarness({ onLoadMore }: { onLoadMore: () => void }) {
+  const [isFetching, setIsFetching] = useState(false);
+
+  useLayoutEffect(() => {
+    if (isFetching) {
+      lastInstance().callback([{ isIntersecting: true }]);
+    }
+  }, [isFetching]);
+
+  return (
+    <>
+      <button type="button" onClick={() => setIsFetching(true)}>
+        Start background refetch
+      </button>
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetching={isFetching}
+        isFetchingNextPage={false}
+        hasLoadMoreError={false}
+      />
+    </>
+  );
+}
+
 describe("InfiniteScrollTrigger", () => {
   beforeEach(() => {
     instances = [];
@@ -53,6 +79,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={false}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -67,6 +94,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={false}
         isFetching={false}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -82,6 +110,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={false}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -96,6 +125,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={true}
         isFetchingNextPage={true}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -109,6 +139,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={false}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -123,6 +154,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={false}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -138,6 +170,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={true}
         isFetchingNextPage={true}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -155,6 +188,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={false}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
     const observerCallback = lastInstance().callback;
@@ -166,6 +200,7 @@ describe("InfiniteScrollTrigger", () => {
         hasNextPage={true}
         isFetching={true}
         isFetchingNextPage={false}
+        hasLoadMoreError={false}
       />,
     );
 
@@ -175,12 +210,43 @@ describe("InfiniteScrollTrigger", () => {
     expect(onLoadMore).not.toHaveBeenCalled();
   });
 
+  it("uses the current fetch guard before passive effects run", () => {
+    const onLoadMore = vi.fn();
+    render(<BackgroundRefetchHarness onLoadMore={onLoadMore} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start background refetch" }));
+
+    expect(onLoadMore).not.toHaveBeenCalled();
+  });
+
+  it("stops automatic loading after a next-page error and offers a manual retry", () => {
+    const onLoadMore = vi.fn();
+    render(
+      <InfiniteScrollTrigger
+        onLoadMore={onLoadMore}
+        hasNextPage={true}
+        isFetching={false}
+        isFetchingNextPage={false}
+        hasLoadMoreError={true}
+      />,
+    );
+
+    expect(instances).toHaveLength(0);
+    expect(screen.getByRole("status")).toHaveTextContent("Error");
+
+    const retryButton = screen.getByRole("button", { name: "Retry" });
+    expect(retryButton).not.toHaveClass("sr-only");
+    fireEvent.click(retryButton);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
   it("reconnects the observer when the trigger moves to a different layout slot", () => {
     const props = {
       onLoadMore: vi.fn(),
       hasNextPage: true,
       isFetching: false,
       isFetchingNextPage: false,
+      hasLoadMoreError: false,
     };
     const { rerender } = render(
       <div data-testid="desktop">

--- a/apps/frontend/src/components/infinite-scroll-trigger.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.tsx
@@ -12,6 +12,8 @@ export interface InfiniteScrollTriggerProps {
   isFetching: boolean;
   /** The next page specifically loading; drives the spinner. */
   isFetchingNextPage: boolean;
+  /** The most recent next-page request failed; disables automatic retries. */
+  hasLoadMoreError: boolean;
   className?: string;
 }
 
@@ -26,6 +28,7 @@ export function InfiniteScrollTrigger({
   hasNextPage,
   isFetching,
   isFetchingNextPage,
+  hasLoadMoreError,
   className,
 }: InfiniteScrollTriggerProps) {
   const { t } = useTranslation();
@@ -37,7 +40,7 @@ export function InfiniteScrollTrigger({
   }, [hasNextPage, isFetching, onLoadMore]);
 
   const sentinelRef = useIntersectionObserver(loadMore, {
-    enabled: hasNextPage && !isFetching,
+    enabled: hasNextPage && !isFetching && !hasLoadMoreError,
     rootMargin: "800px",
   });
 
@@ -53,12 +56,14 @@ export function InfiniteScrollTrigger({
         aria-live="polite"
         className="text-muted-foreground flex items-center justify-center gap-2 text-sm"
       >
-        {isFetchingNextPage && (
+        {isFetchingNextPage ? (
           <>
             <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
             {t("common:loading")}
           </>
-        )}
+        ) : hasLoadMoreError ? (
+          t("common:error")
+        ) : null}
       </div>
       {hasNextPage && (
         <Button
@@ -67,9 +72,9 @@ export function InfiniteScrollTrigger({
           size="sm"
           disabled={isFetching}
           onClick={loadMore}
-          className="sr-only focus:not-sr-only"
+          className={cn(!hasLoadMoreError && "sr-only focus:not-sr-only")}
         >
-          {t("common:load_more")}
+          {t(hasLoadMoreError ? "common:retry" : "common:load_more")}
         </Button>
       )}
     </div>

--- a/apps/frontend/src/components/infinite-scroll-trigger.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.tsx
@@ -7,6 +7,8 @@ import { cn } from "@/lib/utils";
 export interface InfiniteScrollTriggerProps {
   onLoadMore: () => void;
   hasNextPage: boolean;
+  /** Any fetch in flight for this list, including a background refetch. */
+  isFetching: boolean;
   /** The next page specifically loading; drives the spinner. */
   isFetchingNextPage: boolean;
   className?: string;
@@ -21,17 +23,20 @@ export interface InfiniteScrollTriggerProps {
 export function InfiniteScrollTrigger({
   onLoadMore,
   hasNextPage,
+  isFetching,
   isFetchingNextPage,
   className,
 }: InfiniteScrollTriggerProps) {
   const { t } = useTranslation();
 
+  // Guard on isFetching (not just isFetchingNextPage) so a next-page
+  // request can't start while a background refetch is in flight.
   const loadMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) onLoadMore();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+    if (hasNextPage && !isFetching) onLoadMore();
+  }, [hasNextPage, isFetching, onLoadMore]);
 
   const sentinelRef = useIntersectionObserver(loadMore, {
-    enabled: hasNextPage && !isFetchingNextPage,
+    enabled: hasNextPage && !isFetching,
     rootMargin: "800px",
   });
 

--- a/apps/frontend/src/components/infinite-scroll-trigger.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -45,11 +46,31 @@ export function InfiniteScrollTrigger({
   return (
     <div className={cn("flex w-full flex-col items-center", className)}>
       {hasNextPage && <div ref={sentinelRef} className="h-px w-full" aria-hidden="true" />}
-      {isFetchingNextPage && (
-        <span className="text-muted-foreground flex items-center gap-2 text-sm">
-          <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
-          {t("common:loading")}
-        </span>
+      {/* Persistent live region: mounted before a fetch starts so screen
+          readers announce the loading state when it appears. */}
+      <div
+        role="status"
+        aria-live="polite"
+        className="text-muted-foreground flex items-center justify-center gap-2 text-sm"
+      >
+        {isFetchingNextPage && (
+          <>
+            <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
+            {t("common:loading")}
+          </>
+        )}
+      </div>
+      {hasNextPage && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isFetching}
+          onClick={loadMore}
+          className="sr-only focus:not-sr-only"
+        >
+          {t("common:load_more")}
+        </Button>
       )}
     </div>
   );

--- a/apps/frontend/src/components/infinite-scroll-trigger.tsx
+++ b/apps/frontend/src/components/infinite-scroll-trigger.tsx
@@ -1,0 +1,51 @@
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
+import { cn } from "@/lib/utils";
+
+export interface InfiniteScrollTriggerProps {
+  onLoadMore: () => void;
+  hasNextPage: boolean;
+  /** The next page specifically loading; drives the spinner. */
+  isFetchingNextPage: boolean;
+  className?: string;
+}
+
+/**
+ * Shared infinite-scroll trigger for paginated lists. Owns the sentinel,
+ * the observer lifecycle, the fetch guard, and the loading indicator; the
+ * list keeps control of placement, scroll container, and query state.
+ * Render it inside the list's row flow, directly after the rows.
+ */
+export function InfiniteScrollTrigger({
+  onLoadMore,
+  hasNextPage,
+  isFetchingNextPage,
+  className,
+}: InfiniteScrollTriggerProps) {
+  const { t } = useTranslation();
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) onLoadMore();
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+
+  const sentinelRef = useIntersectionObserver(loadMore, {
+    enabled: hasNextPage && !isFetchingNextPage,
+    rootMargin: "800px",
+  });
+
+  if (!hasNextPage && !isFetchingNextPage) return null;
+
+  return (
+    <div className={cn("flex w-full flex-col items-center", className)}>
+      {hasNextPage && <div ref={sentinelRef} className="h-px w-full" aria-hidden="true" />}
+      {isFetchingNextPage && (
+        <span className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
+          {t("common:loading")}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/features/ai-assistant/components/thread-list.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/thread-list.tsx
@@ -1,5 +1,5 @@
 import { ThreadListPrimitive } from "@assistant-ui/react";
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -9,6 +9,7 @@ import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Input } from "@wealthfolio/ui/components/ui/input";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useRuntimeContext } from "../hooks/use-runtime-context";
 import {
   flattenThreadPages,
@@ -38,44 +39,6 @@ function useDebouncedValue<T>(value: T, delay: number): T {
   }, [value, delay]);
 
   return debouncedValue;
-}
-
-/**
- * Custom hook for intersection observer (infinite scroll trigger).
- */
-function useIntersectionObserver(
-  callback: () => void,
-  options?: {
-    enabled?: boolean;
-    rootMargin?: string;
-  },
-) {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const { enabled = true, rootMargin = "100px" } = options ?? {};
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    const element = ref.current;
-    if (!element) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          callback();
-        }
-      },
-      { rootMargin },
-    );
-
-    observer.observe(element);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [callback, enabled, rootMargin]);
-
-  return ref;
 }
 
 export const ThreadList: FC = () => {

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -18,7 +18,7 @@ import { generateId } from "@/lib/id";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
+import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { QueryKeys } from "@/lib/query-keys";
 import { formatDateISO } from "@/lib/utils";
@@ -839,26 +839,14 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const isRefreshing = isFetching && !isFetchingNextPage;
     const isMobile = useIsMobileViewport();
 
-    const loadMore = useCallback(() => {
-      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
-    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-    const sentinelRef = useIntersectionObserver(loadMore, {
-      enabled: hasNextPage && !isFetchingNextPage,
-      rootMargin: "200px",
-    });
-
-    const loadMoreSentinel = hasNextPage ? (
-      <>
-        <div ref={sentinelRef} className="h-px" aria-hidden="true" />
-        {isFetchingNextPage && (
-          <span className="text-muted-foreground flex items-center text-sm">
-            <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-            {t("spending:txTab.loading")}
-          </span>
-        )}
-      </>
-    ) : null;
+    const loadMoreTrigger =
+      hasNextPage || isFetchingNextPage ? (
+        <InfiniteScrollTrigger
+          onLoadMore={fetchNextPage}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      ) : null;
 
     const renderRows = () =>
       rows.map((r) => {
@@ -1004,7 +992,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
               </div>
             )}
             {renderRows()}
-            {loadMoreSentinel && <div className="flex justify-center pt-1">{loadMoreSentinel}</div>}
+            {loadMoreTrigger && <div className="flex justify-center pt-1">{loadMoreTrigger}</div>}
           </div>
         ) : (
           <div className="rounded-md border">
@@ -1041,9 +1029,9 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
               <TableBody>{renderRows()}</TableBody>
             </Table>
 
-            {loadMoreSentinel && (
+            {loadMoreTrigger && (
               <div className="border-border flex items-center justify-center border-t p-3">
-                {loadMoreSentinel}
+                {loadMoreTrigger}
               </div>
             )}
           </div>

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -18,6 +18,7 @@ import { generateId } from "@/lib/id";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { QueryKeys } from "@/lib/query-keys";
 import { formatDateISO } from "@/lib/utils";
@@ -838,22 +839,25 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const isRefreshing = isFetching && !isFetchingNextPage;
     const isMobile = useIsMobileViewport();
 
-    const loadMoreButton = hasNextPage ? (
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => fetchNextPage()}
-        disabled={isFetchingNextPage}
-      >
-        {isFetchingNextPage ? (
-          <>
+    const loadMore = useCallback(() => {
+      if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+    const sentinelRef = useIntersectionObserver(loadMore, {
+      enabled: hasNextPage && !isFetchingNextPage,
+      rootMargin: "200px",
+    });
+
+    const loadMoreSentinel = hasNextPage ? (
+      <>
+        <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+        {isFetchingNextPage && (
+          <span className="text-muted-foreground flex items-center text-sm">
             <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
             {t("spending:txTab.loading")}
-          </>
-        ) : (
-          t("spending:txTab.loadMore", { count: totalCount - rows.length })
+          </span>
         )}
-      </Button>
+      </>
     ) : null;
 
     const renderRows = () =>
@@ -1000,7 +1004,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
               </div>
             )}
             {renderRows()}
-            {loadMoreButton && <div className="flex justify-center pt-1">{loadMoreButton}</div>}
+            {loadMoreSentinel && <div className="flex justify-center pt-1">{loadMoreSentinel}</div>}
           </div>
         ) : (
           <div className="rounded-md border">
@@ -1037,9 +1041,9 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
               <TableBody>{renderRows()}</TableBody>
             </Table>
 
-            {loadMoreButton && (
+            {loadMoreSentinel && (
               <div className="border-border flex items-center justify-center border-t p-3">
-                {loadMoreButton}
+                {loadMoreSentinel}
               </div>
             )}
           </div>

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -479,6 +479,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
       isLoading,
       isFetching,
       isFetchingNextPage,
+      isFetchNextPageError,
       isError,
       error,
       hasNextPage,
@@ -846,6 +847,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           hasNextPage={hasNextPage}
           isFetching={isFetching}
           isFetchingNextPage={isFetchingNextPage}
+          hasLoadMoreError={isFetchNextPageError}
         />
       ) : null;
 
@@ -945,7 +947,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
             <Skeleton className="h-12" />
             <Skeleton className="h-12" />
           </div>
-        ) : isError ? (
+        ) : isError && !isFetchNextPageError ? (
           <EmptyPlaceholder>
             <EmptyPlaceholder.Icon name="AlertTriangle" />
             <EmptyPlaceholder.Title>{t("spending:txTab.loadErrorTitle")}</EmptyPlaceholder.Title>

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -844,6 +844,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
         <InfiniteScrollTrigger
           onLoadMore={fetchNextPage}
           hasNextPage={hasNextPage}
+          isFetching={isFetching}
           isFetchingNextPage={isFetchingNextPage}
         />
       ) : null;

--- a/apps/frontend/src/features/spending/hooks/use-cash-activity-search.test.tsx
+++ b/apps/frontend/src/features/spending/hooks/use-cash-activity-search.test.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCashActivitySearch } from "./use-cash-activity-search";
+
+const adapterMocks = vi.hoisted(() => ({
+  searchCashActivities: vi.fn(),
+}));
+
+vi.mock("../adapters/cash-activities", () => adapterMocks);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useCashActivitySearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes a next-page error without discarding the first page", async () => {
+    adapterMocks.searchCashActivities
+      .mockResolvedValueOnce({ items: [], totalCount: 100 })
+      .mockRejectedValueOnce(new Error("page 2 failed"));
+
+    const { result } = renderHook(() => useCashActivitySearch({}), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.isFetchNextPageError).toBe(true));
+    expect(result.current.totalCount).toBe(100);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+});

--- a/apps/frontend/src/features/spending/hooks/use-cash-activity-search.ts
+++ b/apps/frontend/src/features/spending/hooks/use-cash-activity-search.ts
@@ -54,6 +54,7 @@ export function useCashActivitySearch(
     isLoading: query.isLoading,
     isFetching: query.isFetching,
     isFetchingNextPage: query.isFetchingNextPage,
+    isFetchNextPageError: query.isFetchNextPageError,
     isError: query.isError,
     hasNextPage: query.hasNextPage ?? false,
     fetchNextPage: query.fetchNextPage,

--- a/apps/frontend/src/hooks/use-intersection-observer.test.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.test.ts
@@ -54,7 +54,7 @@ describe("useIntersectionObserver", () => {
 
     expect(instances).toHaveLength(1);
     expect(lastInstance().observed).toEqual([element]);
-    expect(lastInstance().options).toEqual({ rootMargin: "100px" });
+    expect(lastInstance().options).toEqual({ root: null, rootMargin: "100px" });
   });
 
   it("invokes the callback when the sentinel intersects", () => {
@@ -137,6 +137,90 @@ describe("useIntersectionObserver", () => {
     const { result } = renderHook(() => useIntersectionObserver(vi.fn(), { rootMargin: "200px" }));
     act(() => result.current(document.createElement("div")));
 
-    expect(lastInstance().options).toEqual({ rootMargin: "200px" });
+    expect(lastInstance().options).toEqual({ root: null, rootMargin: "200px" });
+  });
+
+  describe("scroll root resolution", () => {
+    function setScrollMetrics(element: HTMLElement, scrollHeight: number, clientHeight: number) {
+      Object.defineProperty(element, "scrollHeight", { value: scrollHeight, configurable: true });
+      Object.defineProperty(element, "clientHeight", { value: clientHeight, configurable: true });
+    }
+
+    function scrollableAncestor(scrollHeight = 800, clientHeight = 400): HTMLElement {
+      const el = document.createElement("div");
+      el.style.overflowY = "auto";
+      setScrollMetrics(el, scrollHeight, clientHeight);
+      return el;
+    }
+
+    it("uses the nearest scrollable ancestor as the observer root", () => {
+      const scroller = scrollableAncestor();
+      const sentinel = document.createElement("div");
+      scroller.appendChild(sentinel);
+
+      const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
+      act(() => result.current(sentinel));
+
+      expect(lastInstance().options?.root).toBe(scroller);
+    });
+
+    it("skips an overflow container that grows instead of scrolling", () => {
+      // scrollHeight == clientHeight: the container fits its content, so
+      // rooting on it would leave the sentinel permanently intersecting.
+      const grown = scrollableAncestor(400, 400);
+      const sentinel = document.createElement("div");
+      grown.appendChild(sentinel);
+
+      const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
+      act(() => result.current(sentinel));
+
+      expect(lastInstance().options?.root).toBeNull();
+    });
+
+    it("skips ancestors that overflow visibly even when their content is taller", () => {
+      const visible = document.createElement("div");
+      setScrollMetrics(visible, 800, 400);
+      const sentinel = document.createElement("div");
+      visible.appendChild(sentinel);
+
+      const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
+      act(() => result.current(sentinel));
+
+      expect(lastInstance().options?.root).toBeNull();
+    });
+
+    it("prefers the nearest of two nested scrollable ancestors", () => {
+      const outer = scrollableAncestor();
+      const inner = scrollableAncestor();
+      outer.appendChild(inner);
+      const sentinel = document.createElement("div");
+      inner.appendChild(sentinel);
+
+      const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
+      act(() => result.current(sentinel));
+
+      expect(lastInstance().options?.root).toBe(inner);
+    });
+
+    it("re-resolves the root when re-enabled after content grows", () => {
+      const container = scrollableAncestor(400, 400); // fits: not scrollable yet
+      const sentinel = document.createElement("div");
+      container.appendChild(sentinel);
+
+      const { result, rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) => useIntersectionObserver(vi.fn(), { enabled }),
+        { initialProps: { enabled: true } },
+      );
+      act(() => result.current(sentinel));
+      expect(lastInstance().options?.root).toBeNull();
+
+      // A fetch cycle: enabled flips false while loading, content grows,
+      // enabled flips back — the new observer must pick up the real root.
+      rerender({ enabled: false });
+      setScrollMetrics(container, 1200, 400);
+      rerender({ enabled: true });
+
+      expect(lastInstance().options?.root).toBe(container);
+    });
   });
 });

--- a/apps/frontend/src/hooks/use-intersection-observer.test.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.test.ts
@@ -1,0 +1,85 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useIntersectionObserver } from "./use-intersection-observer";
+
+type ObserverCallback = (entries: { isIntersecting: boolean }[]) => void;
+
+const observeMock = vi.fn();
+const disconnectMock = vi.fn();
+let observerCallback: ObserverCallback | undefined;
+let observerOptions: IntersectionObserverInit | undefined;
+
+class MockIntersectionObserver {
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    observerCallback = callback;
+    observerOptions = options;
+  }
+
+  observe = observeMock;
+  disconnect = disconnectMock;
+}
+
+function renderWithElement(
+  callback: () => void,
+  options?: Parameters<typeof useIntersectionObserver>[1],
+) {
+  const element = document.createElement("div");
+  return renderHook(() => {
+    const ref = useIntersectionObserver(callback, options);
+    // Attach the sentinel during render so the effect sees it.
+    ref.current = element;
+    return ref;
+  });
+}
+
+describe("useIntersectionObserver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    observerCallback = undefined;
+    observerOptions = undefined;
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("observes the sentinel element when enabled", () => {
+    renderWithElement(vi.fn());
+
+    expect(observeMock).toHaveBeenCalledTimes(1);
+    expect(observerOptions).toEqual({ rootMargin: "100px" });
+  });
+
+  it("invokes the callback when the sentinel intersects", () => {
+    const callback = vi.fn();
+    renderWithElement(callback);
+
+    observerCallback?.([{ isIntersecting: true }]);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    observerCallback?.([{ isIntersecting: false }]);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create an observer when disabled", () => {
+    renderWithElement(vi.fn(), { enabled: false });
+
+    expect(observeMock).not.toHaveBeenCalled();
+    expect(observerCallback).toBeUndefined();
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = renderWithElement(vi.fn());
+    expect(observeMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes a custom rootMargin to the observer", () => {
+    renderWithElement(vi.fn(), { rootMargin: "200px" });
+
+    expect(observerOptions).toEqual({ rootMargin: "200px" });
+  });
+});

--- a/apps/frontend/src/hooks/use-intersection-observer.test.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.test.ts
@@ -1,42 +1,44 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useIntersectionObserver } from "./use-intersection-observer";
 
 type ObserverCallback = (entries: { isIntersecting: boolean }[]) => void;
 
-const observeMock = vi.fn();
-const disconnectMock = vi.fn();
-let observerCallback: ObserverCallback | undefined;
-let observerOptions: IntersectionObserverInit | undefined;
-
-class MockIntersectionObserver {
-  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
-    observerCallback = callback;
-    observerOptions = options;
-  }
-
-  observe = observeMock;
-  disconnect = disconnectMock;
+interface ObserverInstance {
+  callback: ObserverCallback;
+  options: IntersectionObserverInit | undefined;
+  observed: Element[];
+  disconnected: boolean;
 }
 
-function renderWithElement(
-  callback: () => void,
-  options?: Parameters<typeof useIntersectionObserver>[1],
-) {
-  const element = document.createElement("div");
-  return renderHook(() => {
-    const ref = useIntersectionObserver(callback, options);
-    // Attach the sentinel during render so the effect sees it.
-    ref.current = element;
-    return ref;
-  });
+let instances: ObserverInstance[] = [];
+
+class MockIntersectionObserver {
+  instance: ObserverInstance;
+
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    this.instance = { callback, options, observed: [], disconnected: false };
+    instances.push(this.instance);
+  }
+
+  observe = (element: Element) => {
+    this.instance.observed.push(element);
+  };
+
+  disconnect = () => {
+    this.instance.disconnected = true;
+  };
+}
+
+function lastInstance(): ObserverInstance {
+  const instance = instances[instances.length - 1];
+  if (!instance) throw new Error("no IntersectionObserver was created");
+  return instance;
 }
 
 describe("useIntersectionObserver", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    observerCallback = undefined;
-    observerOptions = undefined;
+    instances = [];
     vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
   });
 
@@ -44,42 +46,97 @@ describe("useIntersectionObserver", () => {
     vi.unstubAllGlobals();
   });
 
-  it("observes the sentinel element when enabled", () => {
-    renderWithElement(vi.fn());
+  it("observes the sentinel attached through the returned callback ref", () => {
+    const element = document.createElement("div");
+    const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
 
-    expect(observeMock).toHaveBeenCalledTimes(1);
-    expect(observerOptions).toEqual({ rootMargin: "100px" });
+    act(() => result.current(element));
+
+    expect(instances).toHaveLength(1);
+    expect(lastInstance().observed).toEqual([element]);
+    expect(lastInstance().options).toEqual({ rootMargin: "100px" });
   });
 
   it("invokes the callback when the sentinel intersects", () => {
     const callback = vi.fn();
-    renderWithElement(callback);
+    const { result } = renderHook(() => useIntersectionObserver(callback));
+    act(() => result.current(document.createElement("div")));
 
-    observerCallback?.([{ isIntersecting: true }]);
+    lastInstance().callback([{ isIntersecting: true }]);
     expect(callback).toHaveBeenCalledTimes(1);
 
-    observerCallback?.([{ isIntersecting: false }]);
+    lastInstance().callback([{ isIntersecting: false }]);
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it("does not create an observer when disabled", () => {
-    renderWithElement(vi.fn(), { enabled: false });
+  it("reconnects to the new sentinel when the node is replaced", () => {
+    const elementA = document.createElement("div");
+    const elementB = document.createElement("div");
+    const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
 
-    expect(observeMock).not.toHaveBeenCalled();
-    expect(observerCallback).toBeUndefined();
+    act(() => result.current(elementA));
+    // A layout switch detaches the old sentinel and attaches a new one.
+    act(() => result.current(elementB));
+
+    expect(instances).toHaveLength(2);
+    expect(instances[0].disconnected).toBe(true);
+    expect(instances[1].observed).toEqual([elementB]);
+    expect(instances[1].disconnected).toBe(false);
+  });
+
+  it("disconnects and stops observing when the sentinel unmounts", () => {
+    const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
+    act(() => result.current(document.createElement("div")));
+    expect(instances).toHaveLength(1);
+
+    act(() => result.current(null));
+
+    expect(instances).toHaveLength(1);
+    expect(lastInstance().disconnected).toBe(true);
+  });
+
+  it("invokes the latest callback after a rerender", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ callback }: { callback: () => void }) => useIntersectionObserver(callback),
+      { initialProps: { callback: first } },
+    );
+    act(() => result.current(document.createElement("div")));
+
+    rerender({ callback: second });
+    lastInstance().callback([{ isIntersecting: true }]);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not create an observer when disabled, and connects once enabled", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useIntersectionObserver(vi.fn(), { enabled }),
+      { initialProps: { enabled: false } },
+    );
+    act(() => result.current(document.createElement("div")));
+    expect(instances).toHaveLength(0);
+
+    rerender({ enabled: true });
+    expect(instances).toHaveLength(1);
+    expect(lastInstance().observed).toHaveLength(1);
   });
 
   it("disconnects the observer on unmount", () => {
-    const { unmount } = renderWithElement(vi.fn());
-    expect(observeMock).toHaveBeenCalledTimes(1);
+    const { result, unmount } = renderHook(() => useIntersectionObserver(vi.fn()));
+    act(() => result.current(document.createElement("div")));
+    expect(instances).toHaveLength(1);
 
     unmount();
-    expect(disconnectMock).toHaveBeenCalledTimes(1);
+    expect(lastInstance().disconnected).toBe(true);
   });
 
   it("passes a custom rootMargin to the observer", () => {
-    renderWithElement(vi.fn(), { rootMargin: "200px" });
+    const { result } = renderHook(() => useIntersectionObserver(vi.fn(), { rootMargin: "200px" }));
+    act(() => result.current(document.createElement("div")));
 
-    expect(observerOptions).toEqual({ rootMargin: "200px" });
+    expect(lastInstance().options).toEqual({ rootMargin: "200px" });
   });
 });

--- a/apps/frontend/src/hooks/use-intersection-observer.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Custom hook for intersection observer (infinite scroll trigger).
+ */
+export function useIntersectionObserver(
+  callback: () => void,
+  options?: {
+    enabled?: boolean;
+    rootMargin?: string;
+  },
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { enabled = true, rootMargin = "100px" } = options ?? {};
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          callback();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [callback, enabled, rootMargin]);
+
+  return ref;
+}

--- a/apps/frontend/src/hooks/use-intersection-observer.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.ts
@@ -1,6 +1,28 @@
 import { useEffect, useRef, useState } from "react";
 
 /**
+ * Find the element that actually scrolls the sentinel, to use as the
+ * observer root. The scrollability check matters twice over: an
+ * `overflow: auto` container that grows with its content (scrollHeight ==
+ * clientHeight) must not become the root — the sentinel would always
+ * intersect it and fetch every page in a loop — and with the viewport as
+ * root, an intermediate scroller clips the intersection so rootMargin
+ * gives no lead time. The +1 tolerates sub-pixel rounding.
+ */
+function findScrollContainer(node: HTMLElement): Element | null {
+  for (let el = node.parentElement; el; el = el.parentElement) {
+    const { overflowY } = getComputedStyle(el);
+    if (
+      (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      el.scrollHeight > el.clientHeight + 1
+    ) {
+      return el;
+    }
+  }
+  return null;
+}
+
+/**
  * Custom hook for intersection observer (infinite scroll trigger).
  *
  * Returns a callback ref to attach to the sentinel element. Using a callback
@@ -28,13 +50,19 @@ export function useIntersectionObserver(
   useEffect(() => {
     if (!enabled || !node) return;
 
+    // Resolved on every effect run on purpose: `enabled` flips false→true
+    // across each fetch cycle, so once loaded content makes an ancestor
+    // scrollable the root upgrades from the viewport to the real scroller
+    // (restoring the full rootMargin lead time).
+    const root = findScrollContainer(node);
+
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) {
           callbackRef.current();
         }
       },
-      { rootMargin },
+      { root, rootMargin },
     );
 
     observer.observe(node);

--- a/apps/frontend/src/hooks/use-intersection-observer.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.ts
@@ -1,7 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * Custom hook for intersection observer (infinite scroll trigger).
+ *
+ * Returns a callback ref to attach to the sentinel element. Using a callback
+ * ref (rather than a ref object) lets the observer reconnect when the sentinel
+ * node is replaced — e.g. when a layout switch unmounts one sentinel and
+ * mounts another.
  */
 export function useIntersectionObserver(
   callback: () => void,
@@ -10,30 +15,34 @@ export function useIntersectionObserver(
     rootMargin?: string;
   },
 ) {
-  const ref = useRef<HTMLDivElement | null>(null);
+  const [node, setNode] = useState<HTMLElement | null>(null);
   const { enabled = true, rootMargin = "100px" } = options ?? {};
 
+  // Always invoke the latest callback so an observer entry delivered between
+  // a state change and the next effect run cannot call a stale closure.
+  const callbackRef = useRef(callback);
   useEffect(() => {
-    if (!enabled) return;
+    callbackRef.current = callback;
+  });
 
-    const element = ref.current;
-    if (!element) return;
+  useEffect(() => {
+    if (!enabled || !node) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) {
-          callback();
+          callbackRef.current();
         }
       },
       { rootMargin },
     );
 
-    observer.observe(element);
+    observer.observe(node);
 
     return () => {
       observer.disconnect();
     };
-  }, [callback, enabled, rootMargin]);
+  }, [node, enabled, rootMargin]);
 
-  return ref;
+  return setNode;
 }

--- a/apps/frontend/src/hooks/use-intersection-observer.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Find the element that actually scrolls the sentinel, to use as the
@@ -40,10 +40,10 @@ export function useIntersectionObserver(
   const [node, setNode] = useState<HTMLElement | null>(null);
   const { enabled = true, rootMargin = "100px" } = options ?? {};
 
-  // Always invoke the latest callback so an observer entry delivered between
-  // a state change and the next effect run cannot call a stale closure.
+  // Update during the layout phase so a queued observer entry cannot use a
+  // stale closure between commit and passive-effect cleanup.
   const callbackRef = useRef(callback);
-  useEffect(() => {
+  useLayoutEffect(() => {
     callbackRef.current = callback;
   });
 

--- a/apps/frontend/src/i18n/locales/de/activity.json
+++ b/apps/frontend/src/i18n/locales/de/activity.json
@@ -80,7 +80,6 @@
   "duplicate": "Duplizieren",
   "delete": "Löschen",
   "loading": "Wird geladen...",
-  "load_more": "Mehr laden",
   "search_placeholder": "Suchen...",
   "clear_search": "Suche löschen",
   "filter_account": "Konto",

--- a/apps/frontend/src/i18n/locales/de/common.json
+++ b/apps/frontend/src/i18n/locales/de/common.json
@@ -13,6 +13,7 @@
   "map_to": "Zuordnen zu...",
   "search_all_currencies": "Alle Währungen durchsuchen...",
   "loading": "Wird geladen...",
+  "load_more": "Mehr laden",
   "error": "Fehler",
   "cancel": "Abbrechen",
   "save": "Speichern",

--- a/apps/frontend/src/i18n/locales/de/spending.json
+++ b/apps/frontend/src/i18n/locales/de/spending.json
@@ -824,10 +824,7 @@
     "deselectAllVisible": "Alle sichtbaren Transaktionen abwählen",
     "selectAllVisible": "Alle sichtbaren Transaktionen auswählen",
     "nameNotes": "Name / Notizen",
-    "loading": "Wird geladen…",
-    "loadMore": "Mehr laden ({{count}} verbleibend)",
-    "loadMore_one": "Mehr laden ({{count}} verbleibend)",
-    "loadMore_other": "Mehr laden ({{count}} verbleibend)"
+    "loading": "Wird geladen…"
   },
   "tabContent": {
     "stageWhereLabel": "Wo ich stehe",

--- a/apps/frontend/src/i18n/locales/de/spending.json
+++ b/apps/frontend/src/i18n/locales/de/spending.json
@@ -823,8 +823,7 @@
     "addTransaction": "Transaktion hinzufügen",
     "deselectAllVisible": "Alle sichtbaren Transaktionen abwählen",
     "selectAllVisible": "Alle sichtbaren Transaktionen auswählen",
-    "nameNotes": "Name / Notizen",
-    "loading": "Wird geladen…"
+    "nameNotes": "Name / Notizen"
   },
   "tabContent": {
     "stageWhereLabel": "Wo ich stehe",

--- a/apps/frontend/src/i18n/locales/en/activity.json
+++ b/apps/frontend/src/i18n/locales/en/activity.json
@@ -135,7 +135,6 @@
   "duplicate": "Duplicate",
   "delete": "Delete",
   "loading": "Loading…",
-  "load_more": "Load more...",
   "search_placeholder": "Search...",
   "clear_search": "Clear search",
   "filter_account": "Account",

--- a/apps/frontend/src/i18n/locales/en/common.json
+++ b/apps/frontend/src/i18n/locales/en/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "Welcome",
   "loading": "Loading...",
+  "load_more": "Load more...",
   "error": "Error",
   "success": "Success",
   "cancel": "Cancel",

--- a/apps/frontend/src/i18n/locales/en/spending.json
+++ b/apps/frontend/src/i18n/locales/en/spending.json
@@ -823,8 +823,7 @@
     "addTransaction": "Add transaction",
     "deselectAllVisible": "Deselect all visible transactions",
     "selectAllVisible": "Select all visible transactions",
-    "nameNotes": "Name / Notes",
-    "loading": "Loading…"
+    "nameNotes": "Name / Notes"
   },
   "tabContent": {
     "stageWhereLabel": "Where I am",

--- a/apps/frontend/src/i18n/locales/en/spending.json
+++ b/apps/frontend/src/i18n/locales/en/spending.json
@@ -824,10 +824,7 @@
     "deselectAllVisible": "Deselect all visible transactions",
     "selectAllVisible": "Select all visible transactions",
     "nameNotes": "Name / Notes",
-    "loading": "Loading…",
-    "loadMore": "Load more ({{count}} remaining)",
-    "loadMore_one": "Load more ({{count}} remaining)",
-    "loadMore_other": "Load more ({{count}} remaining)"
+    "loading": "Loading…"
   },
   "tabContent": {
     "stageWhereLabel": "Where I am",

--- a/apps/frontend/src/i18n/locales/es/activity.json
+++ b/apps/frontend/src/i18n/locales/es/activity.json
@@ -136,7 +136,6 @@
   "duplicate": "Duplicar",
   "delete": "Eliminar",
   "loading": "Cargando…",
-  "load_more": "Cargar más...",
   "search_placeholder": "Buscar...",
   "clear_search": "Borrar búsqueda",
   "filter_account": "Cuenta",

--- a/apps/frontend/src/i18n/locales/es/common.json
+++ b/apps/frontend/src/i18n/locales/es/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "Bienvenido",
   "loading": "Cargando...",
+  "load_more": "Cargar más...",
   "error": "Error",
   "success": "Éxito",
   "cancel": "Cancelar",

--- a/apps/frontend/src/i18n/locales/es/spending.json
+++ b/apps/frontend/src/i18n/locales/es/spending.json
@@ -871,8 +871,7 @@
     "addTransaction": "Añadir transacción",
     "deselectAllVisible": "Deseleccionar todas las transacciones visibles",
     "selectAllVisible": "Seleccionar todas las transacciones visibles",
-    "nameNotes": "Nombre / Notas",
-    "loading": "Cargando…"
+    "nameNotes": "Nombre / Notas"
   },
   "tabContent": {
     "stageWhereLabel": "Dónde estoy",

--- a/apps/frontend/src/i18n/locales/es/spending.json
+++ b/apps/frontend/src/i18n/locales/es/spending.json
@@ -872,11 +872,7 @@
     "deselectAllVisible": "Deseleccionar todas las transacciones visibles",
     "selectAllVisible": "Seleccionar todas las transacciones visibles",
     "nameNotes": "Nombre / Notas",
-    "loading": "Cargando…",
-    "loadMore": "Cargar más ({{count}} restantes)",
-    "loadMore_one": "Cargar más ({{count}} restante)",
-    "loadMore_other": "Cargar más ({{count}} restantes)",
-    "loadMore_many": "Cargar más ({{count}} restantes)"
+    "loading": "Cargando…"
   },
   "tabContent": {
     "stageWhereLabel": "Dónde estoy",

--- a/apps/frontend/src/i18n/locales/fr/activity.json
+++ b/apps/frontend/src/i18n/locales/fr/activity.json
@@ -136,7 +136,6 @@
   "duplicate": "Dupliquer",
   "delete": "Supprimer",
   "loading": "Chargement…",
-  "load_more": "Charger plus...",
   "search_placeholder": "Rechercher...",
   "clear_search": "Effacer la recherche",
   "filter_account": "Compte",

--- a/apps/frontend/src/i18n/locales/fr/common.json
+++ b/apps/frontend/src/i18n/locales/fr/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "Bienvenue",
   "loading": "Chargement...",
+  "load_more": "Charger plus...",
   "error": "Erreur",
   "success": "Succès",
   "cancel": "Annuler",

--- a/apps/frontend/src/i18n/locales/fr/spending.json
+++ b/apps/frontend/src/i18n/locales/fr/spending.json
@@ -871,8 +871,7 @@
     "addTransaction": "Ajouter une transaction",
     "deselectAllVisible": "Désélectionner toutes les transactions visibles",
     "selectAllVisible": "Sélectionner toutes les transactions visibles",
-    "nameNotes": "Nom / Notes",
-    "loading": "Chargement…"
+    "nameNotes": "Nom / Notes"
   },
   "tabContent": {
     "stageWhereLabel": "Où j'en suis",

--- a/apps/frontend/src/i18n/locales/fr/spending.json
+++ b/apps/frontend/src/i18n/locales/fr/spending.json
@@ -872,11 +872,7 @@
     "deselectAllVisible": "Désélectionner toutes les transactions visibles",
     "selectAllVisible": "Sélectionner toutes les transactions visibles",
     "nameNotes": "Nom / Notes",
-    "loading": "Chargement…",
-    "loadMore": "Charger plus ({{count}} restantes)",
-    "loadMore_one": "Charger plus ({{count}} restante)",
-    "loadMore_other": "Charger plus ({{count}} restantes)",
-    "loadMore_many": "Charger plus ({{count}} restantes)"
+    "loading": "Chargement…"
   },
   "tabContent": {
     "stageWhereLabel": "Où j'en suis",

--- a/apps/frontend/src/i18n/locales/it/activity.json
+++ b/apps/frontend/src/i18n/locales/it/activity.json
@@ -136,7 +136,6 @@
   "duplicate": "Duplica",
   "delete": "Elimina",
   "loading": "Caricamento…",
-  "load_more": "Carica altro...",
   "search_placeholder": "Cerca...",
   "clear_search": "Cancella ricerca",
   "filter_account": "Conto",

--- a/apps/frontend/src/i18n/locales/it/common.json
+++ b/apps/frontend/src/i18n/locales/it/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "Benvenuto",
   "loading": "Caricamento...",
+  "load_more": "Carica altro...",
   "error": "Errore",
   "success": "Operazione riuscita",
   "cancel": "Annulla",

--- a/apps/frontend/src/i18n/locales/it/spending.json
+++ b/apps/frontend/src/i18n/locales/it/spending.json
@@ -872,11 +872,7 @@
     "deselectAllVisible": "Deseleziona tutte le transazioni visibili",
     "selectAllVisible": "Seleziona tutte le transazioni visibili",
     "nameNotes": "Nome / Note",
-    "loading": "Caricamento…",
-    "loadMore": "Carica altre ({{count}} rimanenti)",
-    "loadMore_one": "Carica altre ({{count}} rimanente)",
-    "loadMore_many": "Carica altre ({{count}} rimanenti)",
-    "loadMore_other": "Carica altre ({{count}} rimanenti)"
+    "loading": "Caricamento…"
   },
   "tabContent": {
     "stageWhereLabel": "Dove sono",

--- a/apps/frontend/src/i18n/locales/it/spending.json
+++ b/apps/frontend/src/i18n/locales/it/spending.json
@@ -871,8 +871,7 @@
     "addTransaction": "Aggiungi transazione",
     "deselectAllVisible": "Deseleziona tutte le transazioni visibili",
     "selectAllVisible": "Seleziona tutte le transazioni visibili",
-    "nameNotes": "Nome / Note",
-    "loading": "Caricamento…"
+    "nameNotes": "Nome / Note"
   },
   "tabContent": {
     "stageWhereLabel": "Dove sono",

--- a/apps/frontend/src/i18n/locales/ja/activity.json
+++ b/apps/frontend/src/i18n/locales/ja/activity.json
@@ -134,7 +134,6 @@
   "duplicate": "複製",
   "delete": "削除",
   "loading": "読み込み中…",
-  "load_more": "さらに読み込む...",
   "search_placeholder": "検索...",
   "clear_search": "検索をクリア",
   "filter_account": "口座",

--- a/apps/frontend/src/i18n/locales/ja/common.json
+++ b/apps/frontend/src/i18n/locales/ja/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "ようこそ",
   "loading": "読み込み中...",
+  "load_more": "さらに読み込む...",
   "error": "エラー",
   "success": "成功",
   "cancel": "キャンセル",

--- a/apps/frontend/src/i18n/locales/ja/spending.json
+++ b/apps/frontend/src/i18n/locales/ja/spending.json
@@ -815,9 +815,7 @@
     "deselectAllVisible": "表示中の取引の選択をすべて解除",
     "selectAllVisible": "表示中の取引をすべて選択",
     "nameNotes": "名前 / メモ",
-    "loading": "読み込み中…",
-    "loadMore": "さらに読み込む(残り{{count}}件)",
-    "loadMore_other": "さらに読み込む(残り{{count}}件)"
+    "loading": "読み込み中…"
   },
   "tabContent": {
     "stageWhereLabel": "現状",

--- a/apps/frontend/src/i18n/locales/ja/spending.json
+++ b/apps/frontend/src/i18n/locales/ja/spending.json
@@ -814,8 +814,7 @@
     "addTransaction": "取引を追加",
     "deselectAllVisible": "表示中の取引の選択をすべて解除",
     "selectAllVisible": "表示中の取引をすべて選択",
-    "nameNotes": "名前 / メモ",
-    "loading": "読み込み中…"
+    "nameNotes": "名前 / メモ"
   },
   "tabContent": {
     "stageWhereLabel": "現状",

--- a/apps/frontend/src/i18n/locales/ko/activity.json
+++ b/apps/frontend/src/i18n/locales/ko/activity.json
@@ -134,7 +134,6 @@
   "duplicate": "복제",
   "delete": "삭제",
   "loading": "불러오는 중…",
-  "load_more": "더 보기...",
   "search_placeholder": "검색...",
   "clear_search": "검색어 지우기",
   "filter_account": "계좌",

--- a/apps/frontend/src/i18n/locales/ko/common.json
+++ b/apps/frontend/src/i18n/locales/ko/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "환영합니다",
   "loading": "로딩 중...",
+  "load_more": "더 보기...",
   "error": "오류",
   "success": "성공",
   "cancel": "취소",

--- a/apps/frontend/src/i18n/locales/ko/spending.json
+++ b/apps/frontend/src/i18n/locales/ko/spending.json
@@ -815,9 +815,7 @@
     "deselectAllVisible": "표시된 거래 모두 선택 해제",
     "selectAllVisible": "표시된 거래 모두 선택",
     "nameNotes": "이름 / 메모",
-    "loading": "불러오는 중…",
-    "loadMore": "더 불러오기 (남은 항목 {{count}}건)",
-    "loadMore_other": "더 불러오기 (남은 항목 {{count}}건)"
+    "loading": "불러오는 중…"
   },
   "tabContent": {
     "stageWhereLabel": "현재 위치",

--- a/apps/frontend/src/i18n/locales/ko/spending.json
+++ b/apps/frontend/src/i18n/locales/ko/spending.json
@@ -814,8 +814,7 @@
     "addTransaction": "거래 추가",
     "deselectAllVisible": "표시된 거래 모두 선택 해제",
     "selectAllVisible": "표시된 거래 모두 선택",
-    "nameNotes": "이름 / 메모",
-    "loading": "불러오는 중…"
+    "nameNotes": "이름 / 메모"
   },
   "tabContent": {
     "stageWhereLabel": "현재 위치",

--- a/apps/frontend/src/i18n/locales/pt/activity.json
+++ b/apps/frontend/src/i18n/locales/pt/activity.json
@@ -136,7 +136,6 @@
   "duplicate": "Duplicar",
   "delete": "Excluir",
   "loading": "Carregando…",
-  "load_more": "Carregar mais...",
   "search_placeholder": "Buscar...",
   "clear_search": "Limpar busca",
   "filter_account": "Conta",

--- a/apps/frontend/src/i18n/locales/pt/common.json
+++ b/apps/frontend/src/i18n/locales/pt/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "Bem-vindo",
   "loading": "Carregando...",
+  "load_more": "Carregar mais...",
   "error": "Erro",
   "success": "Sucesso",
   "cancel": "Cancelar",

--- a/apps/frontend/src/i18n/locales/pt/spending.json
+++ b/apps/frontend/src/i18n/locales/pt/spending.json
@@ -871,8 +871,7 @@
     "addTransaction": "Adicionar transação",
     "deselectAllVisible": "Desmarcar todas as transações visíveis",
     "selectAllVisible": "Selecionar todas as transações visíveis",
-    "nameNotes": "Nome / Notas",
-    "loading": "Carregando…"
+    "nameNotes": "Nome / Notas"
   },
   "tabContent": {
     "stageWhereLabel": "Onde estou",

--- a/apps/frontend/src/i18n/locales/pt/spending.json
+++ b/apps/frontend/src/i18n/locales/pt/spending.json
@@ -872,11 +872,7 @@
     "deselectAllVisible": "Desmarcar todas as transações visíveis",
     "selectAllVisible": "Selecionar todas as transações visíveis",
     "nameNotes": "Nome / Notas",
-    "loading": "Carregando…",
-    "loadMore": "Carregar mais ({{count}} restantes)",
-    "loadMore_one": "Carregar mais ({{count}} restante)",
-    "loadMore_other": "Carregar mais ({{count}} restantes)",
-    "loadMore_many": "Carregar mais ({{count}} restantes)"
+    "loading": "Carregando…"
   },
   "tabContent": {
     "stageWhereLabel": "Onde estou",

--- a/apps/frontend/src/i18n/locales/zh/activity.json
+++ b/apps/frontend/src/i18n/locales/zh/activity.json
@@ -134,7 +134,6 @@
   "duplicate": "复制",
   "delete": "删除",
   "loading": "加载中……",
-  "load_more": "加载更多……",
   "search_placeholder": "搜索……",
   "clear_search": "清除搜索",
   "filter_account": "账户",

--- a/apps/frontend/src/i18n/locales/zh/common.json
+++ b/apps/frontend/src/i18n/locales/zh/common.json
@@ -2,6 +2,7 @@
   "app_name": "Wealthfolio",
   "welcome": "欢迎",
   "loading": "加载中...",
+  "load_more": "加载更多……",
   "error": "错误",
   "success": "成功",
   "cancel": "取消",

--- a/apps/frontend/src/i18n/locales/zh/spending.json
+++ b/apps/frontend/src/i18n/locales/zh/spending.json
@@ -815,9 +815,7 @@
     "deselectAllVisible": "取消选择所有可见交易",
     "selectAllVisible": "选择所有可见交易",
     "nameNotes": "名称 / 备注",
-    "loading": "正在加载……",
-    "loadMore": "加载更多（剩余 {{count}} 项）",
-    "loadMore_other": "加载更多（剩余 {{count}} 项）"
+    "loading": "正在加载……"
   },
   "tabContent": {
     "stageWhereLabel": "我的现状",

--- a/apps/frontend/src/i18n/locales/zh/spending.json
+++ b/apps/frontend/src/i18n/locales/zh/spending.json
@@ -814,8 +814,7 @@
     "addTransaction": "添加交易",
     "deselectAllVisible": "取消选择所有可见交易",
     "selectAllVisible": "选择所有可见交易",
-    "nameNotes": "名称 / 备注",
-    "loading": "正在加载……"
+    "nameNotes": "名称 / 备注"
   },
   "tabContent": {
     "stageWhereLabel": "我的现状",

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -674,6 +674,7 @@ const AccountPage = () => {
         hasNextPage={accountActivitiesSearch.hasNextPage}
         isFetching={accountActivitiesSearch.isFetching}
         isFetchingNextPage={accountActivitiesSearch.isFetchingNextPage}
+        hasLoadMoreError={accountActivitiesSearch.isFetchNextPageError}
       />
       <ActivityPagination
         isFetching={accountActivitiesSearch.isFetchingNextPage}
@@ -695,6 +696,7 @@ const AccountPage = () => {
         hasNextPage={accountActivitiesSearch.hasNextPage}
         isFetching={accountActivitiesSearch.isFetching}
         isFetchingNextPage={accountActivitiesSearch.isFetchingNextPage}
+        hasLoadMoreError={accountActivitiesSearch.isFetchNextPageError}
       />
       <ActivityPagination
         isFetching={accountActivitiesSearch.isFetchingNextPage}

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -672,6 +672,7 @@ const AccountPage = () => {
         onAdd={() => navigate(`/activities/manage?account=${id}`)}
         onLoadMore={accountActivitiesSearch.fetchNextPage}
         hasNextPage={accountActivitiesSearch.hasNextPage}
+        isFetching={accountActivitiesSearch.isFetching}
         isFetchingNextPage={accountActivitiesSearch.isFetchingNextPage}
       />
       <ActivityPagination
@@ -692,6 +693,7 @@ const AccountPage = () => {
         onAdd={() => navigate(`/activities/manage?account=${id}`)}
         onLoadMore={accountActivitiesSearch.fetchNextPage}
         hasNextPage={accountActivitiesSearch.hasNextPage}
+        isFetching={accountActivitiesSearch.isFetching}
         isFetchingNextPage={accountActivitiesSearch.isFetchingNextPage}
       />
       <ActivityPagination

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -670,10 +670,11 @@ const AccountPage = () => {
         handleDelete={handleActivityDelete}
         onDuplicate={handleActivityDuplicate}
         onAdd={() => navigate(`/activities/manage?account=${id}`)}
+        onLoadMore={accountActivitiesSearch.fetchNextPage}
+        hasNextPage={accountActivitiesSearch.hasNextPage}
+        isFetchingNextPage={accountActivitiesSearch.isFetchingNextPage}
       />
       <ActivityPagination
-        hasMore={accountActivitiesSearch.hasNextPage ?? false}
-        onLoadMore={accountActivitiesSearch.fetchNextPage}
         isFetching={accountActivitiesSearch.isFetchingNextPage}
         totalFetched={accountActivitiesSearch.data.length}
         totalCount={accountActivitiesSearch.totalRowCount}
@@ -689,10 +690,11 @@ const AccountPage = () => {
         handleEdit={handleActivityEdit}
         handleDelete={handleActivityDelete}
         onAdd={() => navigate(`/activities/manage?account=${id}`)}
+        onLoadMore={accountActivitiesSearch.fetchNextPage}
+        hasNextPage={accountActivitiesSearch.hasNextPage}
+        isFetchingNextPage={accountActivitiesSearch.isFetchingNextPage}
       />
       <ActivityPagination
-        hasMore={accountActivitiesSearch.hasNextPage ?? false}
-        onLoadMore={accountActivitiesSearch.fetchNextPage}
         isFetching={accountActivitiesSearch.isFetchingNextPage}
         totalFetched={accountActivitiesSearch.data.length}
         totalCount={accountActivitiesSearch.totalRowCount}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -765,6 +765,7 @@ const ActivityPage = () => {
           hasNextPage={infiniteSearch.hasNextPage}
           isFetching={infiniteSearch.isFetching}
           isFetchingNextPage={infiniteSearch.isFetchingNextPage}
+          hasLoadMoreError={infiniteSearch.isFetchNextPageError}
         />
       ) : shouldUseDatagridView ? (
         <ActivityDataGrid
@@ -800,6 +801,7 @@ const ActivityPage = () => {
           hasNextPage={infiniteSearch.hasNextPage}
           isFetching={infiniteSearch.isFetching}
           isFetchingNextPage={infiniteSearch.isFetchingNextPage}
+          hasLoadMoreError={infiniteSearch.isFetchNextPageError}
         />
       )}
 

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -763,6 +763,7 @@ const ActivityPage = () => {
           onClearFilters={clearInvestmentsFilters}
           onLoadMore={infiniteSearch.fetchNextPage}
           hasNextPage={infiniteSearch.hasNextPage}
+          isFetching={infiniteSearch.isFetching}
           isFetchingNextPage={infiniteSearch.isFetchingNextPage}
         />
       ) : shouldUseDatagridView ? (
@@ -797,6 +798,7 @@ const ActivityPage = () => {
           onClearFilters={clearInvestmentsFilters}
           onLoadMore={infiniteSearch.fetchNextPage}
           hasNextPage={infiniteSearch.hasNextPage}
+          isFetching={infiniteSearch.isFetching}
           isFetchingNextPage={infiniteSearch.isFetchingNextPage}
         />
       )}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -761,6 +761,9 @@ const ActivityPage = () => {
           filtersActive={investmentsFiltersActive}
           onAdd={() => handleEdit(undefined)}
           onClearFilters={clearInvestmentsFilters}
+          onLoadMore={infiniteSearch.fetchNextPage}
+          hasNextPage={infiniteSearch.hasNextPage}
+          isFetchingNextPage={infiniteSearch.isFetchingNextPage}
         />
       ) : shouldUseDatagridView ? (
         <ActivityDataGrid
@@ -792,13 +795,14 @@ const ActivityPage = () => {
           filtersActive={investmentsFiltersActive}
           onAdd={() => handleEdit(undefined)}
           onClearFilters={clearInvestmentsFilters}
+          onLoadMore={infiniteSearch.fetchNextPage}
+          hasNextPage={infiniteSearch.hasNextPage}
+          isFetchingNextPage={infiniteSearch.isFetchingNextPage}
         />
       )}
 
       {!shouldUseDatagridView && (
         <ActivityPagination
-          hasMore={infiniteSearch.hasNextPage ?? false}
-          onLoadMore={infiniteSearch.fetchNextPage}
           isFetching={infiniteSearch.isFetchingNextPage}
           totalFetched={totalFetched}
           totalCount={infiniteSearch.totalRowCount}

--- a/apps/frontend/src/pages/activity/components/activity-pagination.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-pagination.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ActivityPagination } from "./activity-pagination";
+
+describe("ActivityPagination", () => {
+  it("announces the loaded count through a status live region", () => {
+    render(<ActivityPagination isFetching={false} totalFetched={100} totalCount={130} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("100 / 130 activities");
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-pagination.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-pagination.tsx
@@ -15,8 +15,12 @@ export function ActivityPagination({
   const { t } = useTranslation();
   return (
     <div className="my-3 flex shrink-0 items-center justify-center">
-      <div className="text-muted-foreground flex items-center gap-2 text-xs">
-        {isFetching ? <Icons.Spinner className="h-4 w-4 animate-spin" /> : null}
+      <div
+        role="status"
+        aria-live="polite"
+        className="text-muted-foreground flex items-center gap-2 text-xs"
+      >
+        {isFetching ? <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
         <span>{t("activity:pagination_count", { fetched: totalFetched, total: totalCount })}</span>
       </div>
     </div>

--- a/apps/frontend/src/pages/activity/components/activity-pagination.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-pagination.tsx
@@ -1,46 +1,23 @@
-import { Button, Icons } from "@wealthfolio/ui";
+import { Icons } from "@wealthfolio/ui";
 import { useTranslation } from "react-i18next";
 
 interface ActivityPaginationProps {
-  hasMore: boolean;
-  onLoadMore: () => void;
   isFetching: boolean;
   totalFetched: number;
   totalCount: number;
 }
 
 export function ActivityPagination({
-  hasMore,
-  onLoadMore,
   isFetching,
   totalFetched,
   totalCount,
 }: ActivityPaginationProps) {
   const { t } = useTranslation();
   return (
-    <div className="my-3 flex shrink-0 flex-col gap-3 sm:gap-4">
-      <div className="relative flex flex-col items-center justify-center gap-2 sm:flex-row">
-        <div className="text-muted-foreground order-2 flex items-center gap-2 text-xs sm:absolute sm:left-0 sm:order-1">
-          {isFetching && !hasMore ? <Icons.Spinner className="h-4 w-4 animate-spin" /> : null}
-          <span>
-            {t("activity:pagination_count", { fetched: totalFetched, total: totalCount })}
-          </span>
-        </div>
-        {hasMore && (
-          <Button
-            onClick={onLoadMore}
-            variant="outline"
-            disabled={isFetching}
-            className="order-1 gap-2 sm:order-2"
-          >
-            {isFetching ? (
-              <Icons.Spinner className="h-4 w-4 animate-spin" />
-            ) : (
-              <Icons.ChevronDown className="h-4 w-4" />
-            )}
-            {isFetching ? t("activity:loading") : t("activity:load_more")}
-          </Button>
-        )}
+    <div className="my-3 flex shrink-0 items-center justify-center">
+      <div className="text-muted-foreground flex items-center gap-2 text-xs">
+        {isFetching ? <Icons.Spinner className="h-4 w-4 animate-spin" /> : null}
+        <span>{t("activity:pagination_count", { fetched: totalFetched, total: totalCount })}</span>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -26,10 +26,9 @@ import {
   useDateFormatting,
 } from "@wealthfolio/ui";
 import { Card } from "@wealthfolio/ui/components/ui/card";
-import { useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
+import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
 import { ActivityOperations } from "../activity-operations";
 import { ActivityTypeBadge } from "../activity-type-badge";
 
@@ -72,14 +71,6 @@ export const ActivityTableMobile = ({
   const { t } = useTranslation();
   const { settings } = useSettingsContext();
   const appTimezone = settings?.timezone?.trim() || undefined;
-
-  const loadMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
-  const sentinelRef = useIntersectionObserver(loadMore, {
-    enabled: Boolean(onLoadMore) && hasNextPage && !isFetchingNextPage,
-    rootMargin: "800px",
-  });
 
   if (isLoading) {
     return (
@@ -372,12 +363,12 @@ export const ActivityTableMobile = ({
           </Card>
         );
       })}
-      {hasNextPage && <div ref={sentinelRef} className="h-px" aria-hidden="true" />}
-      {isFetchingNextPage && (
-        <div className="text-muted-foreground flex items-center justify-center gap-2 p-3 text-sm">
-          <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
-          {t("activity:loading")}
-        </div>
+      {onLoadMore && (
+        <InfiniteScrollTrigger
+          onLoadMore={onLoadMore}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+        />
       )}
     </div>
   );

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -46,6 +46,7 @@ interface ActivityTableMobileProps {
   onClearFilters?: () => void;
   onLoadMore?: () => void;
   hasNextPage?: boolean;
+  isFetching?: boolean;
   isFetchingNextPage?: boolean;
 }
 
@@ -63,6 +64,7 @@ export const ActivityTableMobile = ({
   onClearFilters,
   onLoadMore,
   hasNextPage = false,
+  isFetching,
   isFetchingNextPage = false,
 }: ActivityTableMobileProps) => {
   const formatting = useAmountFormatting();
@@ -367,6 +369,7 @@ export const ActivityTableMobile = ({
         <InfiniteScrollTrigger
           onLoadMore={onLoadMore}
           hasNextPage={hasNextPage}
+          isFetching={isFetching ?? isFetchingNextPage}
           isFetchingNextPage={isFetchingNextPage}
         />
       )}

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -26,8 +26,10 @@ import {
   useDateFormatting,
 } from "@wealthfolio/ui";
 import { Card } from "@wealthfolio/ui/components/ui/card";
+import { useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { ActivityOperations } from "../activity-operations";
 import { ActivityTypeBadge } from "../activity-type-badge";
 
@@ -43,6 +45,9 @@ interface ActivityTableMobileProps {
   filtersActive?: boolean;
   onAdd?: () => void;
   onClearFilters?: () => void;
+  onLoadMore?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
 }
 
 export const ActivityTableMobile = ({
@@ -57,6 +62,9 @@ export const ActivityTableMobile = ({
   filtersActive = false,
   onAdd,
   onClearFilters,
+  onLoadMore,
+  hasNextPage = false,
+  isFetchingNextPage = false,
 }: ActivityTableMobileProps) => {
   const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
@@ -64,6 +72,14 @@ export const ActivityTableMobile = ({
   const { t } = useTranslation();
   const { settings } = useSettingsContext();
   const appTimezone = settings?.timezone?.trim() || undefined;
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+  const sentinelRef = useIntersectionObserver(loadMore, {
+    enabled: Boolean(onLoadMore) && hasNextPage && !isFetchingNextPage,
+    rootMargin: "800px",
+  });
 
   if (isLoading) {
     return (
@@ -356,6 +372,13 @@ export const ActivityTableMobile = ({
           </Card>
         );
       })}
+      {hasNextPage && <div ref={sentinelRef} className="h-px" aria-hidden="true" />}
+      {isFetchingNextPage && (
+        <div className="text-muted-foreground flex items-center justify-center gap-2 p-3 text-sm">
+          <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
+          {t("activity:loading")}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -48,6 +48,7 @@ interface ActivityTableMobileProps {
   hasNextPage?: boolean;
   isFetching?: boolean;
   isFetchingNextPage?: boolean;
+  hasLoadMoreError?: boolean;
 }
 
 export const ActivityTableMobile = ({
@@ -66,6 +67,7 @@ export const ActivityTableMobile = ({
   hasNextPage = false,
   isFetching,
   isFetchingNextPage = false,
+  hasLoadMoreError = false,
 }: ActivityTableMobileProps) => {
   const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
@@ -371,6 +373,7 @@ export const ActivityTableMobile = ({
           hasNextPage={hasNextPage}
           isFetching={isFetching ?? isFetchingNextPage}
           isFetchingNextPage={isFetchingNextPage}
+          hasLoadMoreError={hasLoadMoreError}
         />
       )}
     </div>

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -53,6 +53,7 @@ import {
 } from "@wealthfolio/ui/components/ui/table";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { ActivityOperations } from "../activity-operations";
 import { ActivityTypeBadge } from "../activity-type-badge";
@@ -69,6 +70,9 @@ interface ActivityTableProps {
   filtersActive?: boolean;
   onAdd?: () => void;
   onClearFilters?: () => void;
+  onLoadMore?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
 }
 
 export const ActivityTable = ({
@@ -83,6 +87,9 @@ export const ActivityTable = ({
   filtersActive = false,
   onAdd,
   onClearFilters,
+  onLoadMore,
+  hasNextPage = false,
+  isFetchingNextPage = false,
 }: ActivityTableProps) => {
   const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
@@ -96,6 +103,14 @@ export const ActivityTable = ({
     async (activity: ActivityDetails) => duplicateActivityMutation.mutateAsync(activity),
     [duplicateActivityMutation],
   );
+
+  const loadMore = React.useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
+  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
+  const sentinelRef = useIntersectionObserver(loadMore, {
+    enabled: Boolean(onLoadMore) && hasNextPage && !isFetchingNextPage,
+    rootMargin: "800px",
+  });
 
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
     accountId: false,
@@ -687,6 +702,13 @@ export const ActivityTable = ({
             })}
           </TableBody>
         </Table>
+        {hasNextPage && <div ref={sentinelRef} className="h-px" aria-hidden="true" />}
+        {isFetchingNextPage && (
+          <div className="text-muted-foreground flex items-center justify-center gap-2 p-3 text-sm">
+            <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
+            {t("activity:loading")}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -53,7 +53,7 @@ import {
 } from "@wealthfolio/ui/components/ui/table";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import { useIntersectionObserver } from "@/hooks/use-intersection-observer";
+import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { ActivityOperations } from "../activity-operations";
 import { ActivityTypeBadge } from "../activity-type-badge";
@@ -103,14 +103,6 @@ export const ActivityTable = ({
     async (activity: ActivityDetails) => duplicateActivityMutation.mutateAsync(activity),
     [duplicateActivityMutation],
   );
-
-  const loadMore = React.useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) onLoadMore?.();
-  }, [hasNextPage, isFetchingNextPage, onLoadMore]);
-  const sentinelRef = useIntersectionObserver(loadMore, {
-    enabled: Boolean(onLoadMore) && hasNextPage && !isFetchingNextPage,
-    rootMargin: "800px",
-  });
 
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
     accountId: false,
@@ -702,12 +694,12 @@ export const ActivityTable = ({
             })}
           </TableBody>
         </Table>
-        {hasNextPage && <div ref={sentinelRef} className="h-px" aria-hidden="true" />}
-        {isFetchingNextPage && (
-          <div className="text-muted-foreground flex items-center justify-center gap-2 p-3 text-sm">
-            <Icons.Spinner className="h-4 w-4 animate-spin" aria-hidden="true" />
-            {t("activity:loading")}
-          </div>
+        {onLoadMore && (
+          <InfiniteScrollTrigger
+            onLoadMore={onLoadMore}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+          />
         )}
       </div>
     </div>

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -74,6 +74,7 @@ interface ActivityTableProps {
   hasNextPage?: boolean;
   isFetching?: boolean;
   isFetchingNextPage?: boolean;
+  hasLoadMoreError?: boolean;
 }
 
 export const ActivityTable = ({
@@ -92,6 +93,7 @@ export const ActivityTable = ({
   hasNextPage = false,
   isFetching,
   isFetchingNextPage = false,
+  hasLoadMoreError = false,
 }: ActivityTableProps) => {
   const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
@@ -702,6 +704,7 @@ export const ActivityTable = ({
             hasNextPage={hasNextPage}
             isFetching={isFetching ?? isFetchingNextPage}
             isFetchingNextPage={isFetchingNextPage}
+            hasLoadMoreError={hasLoadMoreError}
           />
         )}
       </div>

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -72,6 +72,7 @@ interface ActivityTableProps {
   onClearFilters?: () => void;
   onLoadMore?: () => void;
   hasNextPage?: boolean;
+  isFetching?: boolean;
   isFetchingNextPage?: boolean;
 }
 
@@ -89,6 +90,7 @@ export const ActivityTable = ({
   onClearFilters,
   onLoadMore,
   hasNextPage = false,
+  isFetching,
   isFetchingNextPage = false,
 }: ActivityTableProps) => {
   const formatting = useAmountFormatting();
@@ -698,6 +700,7 @@ export const ActivityTable = ({
           <InfiniteScrollTrigger
             onLoadMore={onLoadMore}
             hasNextPage={hasNextPage}
+            isFetching={isFetching ?? isFetchingNextPage}
             isFetchingNextPage={isFetchingNextPage}
           />
         )}

--- a/apps/frontend/src/pages/activity/hooks/use-activity-search.test.tsx
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-search.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useActivitySearch } from "./use-activity-search";
@@ -95,5 +95,30 @@ describe("useActivitySearch", () => {
       "",
       { id: "date", desc: true },
     );
+  });
+
+  it("exposes a next-page error without discarding the first page", async () => {
+    adapterMocks.searchActivities
+      .mockResolvedValueOnce({ data: [], meta: { totalRowCount: 100 } })
+      .mockRejectedValueOnce(new Error("page 2 failed"));
+
+    const { result } = renderHook(
+      () =>
+        useActivitySearch({
+          filters: { accountIds: undefined, activityTypes: [] },
+          searchQuery: "",
+          sorting: [],
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.isFetchNextPageError).toBe(true));
+    expect(result.current.totalRowCount).toBe(100);
+    expect(result.current.hasNextPage).toBe(true);
   });
 });

--- a/apps/frontend/src/pages/activity/hooks/use-activity-search.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-search.ts
@@ -49,6 +49,7 @@ export interface UseActivitySearchInfiniteResult {
   hasNextPage: boolean | undefined;
   isFetching: boolean;
   isFetchingNextPage: boolean;
+  isFetchNextPageError: boolean;
   isLoading: boolean;
   refetch: () => Promise<unknown>;
 }
@@ -203,6 +204,7 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
     hasNextPage: infiniteQuery.hasNextPage,
     isFetching: infiniteQuery.isFetching,
     isFetchingNextPage: infiniteQuery.isFetchingNextPage,
+    isFetchNextPageError: infiniteQuery.isFetchNextPageError,
     isLoading: infiniteQuery.isLoading,
     refetch: infiniteQuery.refetch,
   };


### PR DESCRIPTION
## Summary

Replaces the manual "Load More" buttons with infinite scroll across the app's activity lists: **Spending → Transactions**, the **Activity page's Investments tab** (table and mobile card views), and the **Account page's activity list**. Addresses the infinite-scroll half of #1510 and extends the same treatment to the investment side.

## Motivation

Both transaction views paginate 50 rows at a time behind a "Load More" button. For accounts with a few thousand transactions — exactly the case when you're categorising spend, cleaning up notes, or auditing trade history — reaching older data means clicking through dozens of pages.

## What changed

Nine commits. The first three land the feature, the next five address the review feedback, and the final commit hardens failed-page and observer timing behavior.

### 1. `refactor(frontend): extract useIntersectionObserver into shared hooks`

The AI-assistant thread list already had a private `useIntersectionObserver` hook. Lifted it verbatim into `apps/frontend/src/hooks/use-intersection-observer.ts` and pointed `thread-list.tsx` at the shared copy. No behavior change; adds unit tests for the hook.

### 2. `feat(spending): replace Load More button with infinite scroll`

`spending-transactions-tab.tsx` renders a sentinel element instead of a button, at both render sites (mobile card list and desktop table footer — only one mounts at a time). The now-unused `txTab.loadMore*` keys are removed from all 9 locales (including the Italian and Brazilian Portuguese locales added since #1510 was filed).

### 3. `feat(activity): replace Load More button with infinite scroll`

The investments half: the two activity tables render the sentinel in the row flow, directly after the rows (the old button's slot below the list is always on screen, so observing it would fetch every page in a loop). `ActivityPagination` is reduced to its "N of M" counter, the **datagrid view keeps its classic page-number pagination**, and the asset profile page's read-only tables are unaffected (the pagination props are optional). The now-unused `activity:load_more` key is removed from all 9 locales.

### 4. `fix(hooks): reconnect useIntersectionObserver when the sentinel node changes` _(review point 2)_

The hook now returns a callback ref, so when a layout switch replaces the sentinel element the observer disconnects and re-observes the new node instead of watching a removed element. Observer entries are routed through a latest-callback ref, closing the window where an entry delivered between a state change and the next effect run could invoke a stale closure. Covered by reconnection tests.

### 5. `fix(hooks): observe the nearest scrollable ancestor as the intersection root` _(review point 3)_

The lists scroll inside nested containers, so with the viewport as root the intermediate scroller clipped the intersection before `rootMargin` could take effect. The hook now walks up from the sentinel to the nearest ancestor that _actually scrolls_ (`overflow-y: auto/scroll` **and** `scrollHeight > clientHeight`) and observes within it. The scrollability check is load-bearing: an overflow container that merely grows with its content must not become the root, or the sentinel would intersect it permanently and fetch every page in a loop. The root is re-resolved on every observer reconnect — the enabled flag flips across each fetch cycle, so the root upgrades from the viewport to the real scroller as soon as loaded content makes one scrollable.

### 6. `refactor(frontend): extract a shared InfiniteScrollTrigger for infinite lists` _(review point 1)_

One shared component now owns the sentinel, observer lifecycle, fetch guard, spinner, and accessible loading status for all three lists; each list keeps control of trigger placement, its scroll container, translation, and query state. The trigger standardizes the 800px lead margin and the `common:loading` label (the orphaned `spending:txTab.loading` key is removed; `activity:loading` stays — the view controls still use it).

### 7. `fix(frontend): don't fetch the next page while a background refetch is in flight` _(review point 4)_

The fetch guard and the observer's enabled flag now check `!isFetching` rather than only `!isFetchingNextPage`, so a sentinel firing during a broad cache invalidation's background refetch can't start an overlapping next-page request. The three lists pass their query's `isFetching` through. A test covers the exact race: an entry delivered from an observer created before the refetch does not trigger a fetch.

### 8. `feat(a11y): announce infinite-scroll loading and add a keyboard Load more fallback` _(review point 5)_

The trigger keeps a persistent `role="status"` live region mounted (so page-loading is announced) and renders a visually hidden but focusable **Load more** button — revealed on focus, disabled during a fetch so keyboard focus isn't dropped — giving keyboard and screen-reader users an explicit control. `ActivityPagination`'s "N of M" counter is a status live region too, so count updates are announced as pages land. The button label reintroduces the previously removed `load_more` translations verbatim, relocated under `common` since the key is now shared.

### 9. `fix(frontend): harden infinite scroll state handling`

Stops automatic loading after a next-page failure, keeps the loaded rows visible, and shows a manual **Retry** button. Query hooks expose TanStack Query's `isFetchNextPageError`, while the shared UI uses the generic `hasLoadMoreError` prop.

The observer callback ref now updates during the layout phase, so an entry delivered before passive effects run uses the current fetch guard. Regression tests cover failed next-page requests for both activity query hooks, the visible retry path, and the layout-effect timing window.

**On review point 6 (eager page-2 request):** agreed and removed — the prefetch commits are gone entirely rather than reverted. With the observer rooted on the real scroll container (point 3), the 800px `rootMargin` provides the early loading the prefetch was papering over.

## Notes for reviewers

- No changes to the fetch layer — pagination is still the existing `useInfiniteQuery` at 50/page on both sides (offset-based for spending, page-index for activities).
- The sentinel is `aria-hidden` and zero-height; loading and count updates are announced via the `role="status"` regions.
- On mobile, the swipable view keeps the neighbouring tab mounted; its trigger will background-fill until its content exceeds the slide height plus the 800px margin (1–2 pages), then stop — the same bounded fill-the-scrollport behavior any rootMargin-based infinite list shows before first scroll, and it warms the neighbour tab.
- All loaded rows stay in the DOM (see the performance note in the review thread — `@tanstack/react-virtual` is already a dependency, so a follow-up issue can adopt it for very long lists without adding a package).

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
