### PR TITLE
fix(import): resolve ambiguous day/month order from the whole date column

### DIFF
--- a/apps/frontend/src/i18n/locales/en/activity.json
+++ b/apps/frontend/src/i18n/locales/en/activity.json
@@ -1213,7 +1213,9 @@
       "positionsCount_one": "{{count}} holding",
       "positionsCount_other": "{{count}} holdings",
       "readyRows_one": "{{count}} row",
-      "readyRows_other": "{{count}} rows"
+      "readyRows_other": "{{count}} rows",
+      "ambiguousDateTitle": "Date order is ambiguous",
+      "ambiguousDateHint": "Dates like {{example}} can be read as day/month or month/day, and nothing in this file settles it. Go back and choose a date format instead of Auto-detect."
     },
     "symbolPanel": {
       "unrecognized_one": "{{count}} unrecognized symbol",

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -17,12 +17,66 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** Field order of a purely numeric date such as "03/08/2026". */
+export type DateOrder = "DMY" | "MDY";
+
+const NUMERIC_DATE_RE = /^(\d{1,2})([/.-])(\d{1,2})\2(\d{2,4})(?:\D|$)/;
+
+const MONTH_FIRST_NUMERIC_FORMATS = [
+  "MM/dd/yyyy", // "05/01/2024" - US Standard
+  "M/d/yyyy", // "5/1/2024" - US Relaxed
+];
+
+const DAY_FIRST_NUMERIC_FORMATS = [
+  "dd/MM/yyyy", // "01/05/2024" - UK/EU Standard
+  "d/M/yyyy", // "1/5/2024" - UK/EU Relaxed
+  "dd.MM.yyyy", // "01.05.2024" - German/Swiss/Russian
+  "d.M.yyyy", // "1.5.2024" - German/Swiss Relaxed
+  "dd-MM-yyyy", // "01-05-2024" - Dutch/Danish
+];
+
+/**
+ * True when a numeric date could be read either way — both leading fields are
+ * <= 12, so "03/08/2026" is 3 August or 8 March with equal justification.
+ */
+export function isAmbiguousNumericDate(dateStr: string): boolean {
+  const match = NUMERIC_DATE_RE.exec((dateStr ?? "").trim());
+  if (!match) return false;
+  return Number(match[1]) <= 12 && Number(match[3]) <= 12;
+}
+
+/**
+ * Decide whether a whole column of numeric dates is day-first or month-first.
+ *
+ * A single value carries no answer, but one "13/08/2026" anywhere in the column
+ * settles every other row in it. Returns null when the column offers no
+ * evidence, or contradicts itself — callers must not guess in that case.
+ */
+export function detectDateOrder(values: Iterable<string>): DateOrder | null {
+  let dayFirst = false;
+  let monthFirst = false;
+
+  for (const value of values) {
+    const match = NUMERIC_DATE_RE.exec((value ?? "").trim());
+    if (!match) continue;
+    const first = Number(match[1]);
+    const second = Number(match[3]);
+    if (first > 12 && second <= 12) dayFirst = true;
+    else if (second > 12 && first <= 12) monthFirst = true;
+  }
+
+  if (dayFirst === monthFirst) return null;
+  return dayFirst ? "DMY" : "MDY";
+}
+
 /**
  * Attempts to parse a date string in multiple formats using date-fns
  * @param dateStr The date string to parse
+ * @param order Field order for ambiguous numeric dates, from detectDateOrder.
+ *   Omit it to keep the historical month-first preference.
  * @returns A valid Date object if parsing succeeds, null if all parsing attempts fail
  */
-export function tryParseDate(dateStr: string): Date | null {
+export function tryParseDate(dateStr: string, order?: DateOrder): Date | null {
   if (!dateStr) return null;
 
   // Standardize the input - replace multiple spaces with single space and trim
@@ -44,8 +98,8 @@ export function tryParseDate(dateStr: string): Date | null {
     "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX", // Added Standard ISO timestamp with microsecond precision and timezone offset
 
     // 12-hour / AM-PM Formats (e.g. Questrade exports). Only the unambiguous
-    // ISO date order is auto-detected; slash orders (MM/dd vs dd/MM) are
-    // ambiguous and must be chosen explicitly via an import format preset.
+    // ISO date order is listed here; slash orders (MM/dd vs dd/MM) are settled
+    // by the `order` argument or an explicit import format preset.
     "yyyy-MM-dd hh:mm:ss a", // "2024-05-01 12:00:00 AM"
     "yyyy-MM-dd hh:mm a", // "2024-05-01 12:00 AM"
 
@@ -60,15 +114,14 @@ export function tryParseDate(dateStr: string): Date | null {
     "MMMM dd yyyy", // "MAY 01 2024" (full month)
     "MMM-dd-yyyy", // "MAY-01-2024" - Month name with separators
     "MMMM-dd-yyyy", // "MAY-01-2024" (full month)
-    "MM/dd/yyyy", // "05/01/2024" - US Standard
-    "M/d/yyyy", // "5/1/2024" - US Relaxed
 
-    // European Banking Formats
-    "dd/MM/yyyy", // "01/05/2024" - UK/EU Standard
-    "d/M/yyyy", // "1/5/2024" - UK/EU Relaxed
-    "dd.MM.yyyy", // "01.05.2024" - German/Swiss/Russian
-    "d.M.yyyy", // "1.5.2024" - German/Swiss Relaxed
-    "dd-MM-yyyy", // "01-05-2024" - Dutch/Danish
+    // Numeric day/month orders. "05/01/2024" is 5 January or May 1st with equal
+    // justification, so whichever group is tried first silently decides. When
+    // the caller resolved the order from the whole column, honour it; otherwise
+    // keep the historical month-first preference.
+    ...(order === "DMY"
+      ? [...DAY_FIRST_NUMERIC_FORMATS, ...MONTH_FIRST_NUMERIC_FORMATS]
+      : [...MONTH_FIRST_NUMERIC_FORMATS, ...DAY_FIRST_NUMERIC_FORMATS]),
 
     // Asian Banking Formats
     "yyyy年MM月dd日", // "2024年05月01日" - Japanese

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -20,20 +20,55 @@ export function cn(...inputs: ClassValue[]) {
 /** Field order of a purely numeric date such as "03/08/2026". */
 export type DateOrder = "DMY" | "MDY";
 
-const NUMERIC_DATE_RE = /^(\d{1,2})([/.-])(\d{1,2})\2(\d{2,4})(?:\D|$)/;
+/**
+ * Numeric dates the formats below can actually parse: two small fields, a
+ * repeated separator, four-digit year. Detection deliberately matches no more
+ * than parsing supports — claiming an order for "03/08/26" would be useless,
+ * since no pattern here reads a two-digit year.
+ */
+const NUMERIC_DATE_RE = /^(\d{1,2})([/.-])(\d{1,2})\2(\d{4})(?:\D|$)/;
 
-const MONTH_FIRST_NUMERIC_FORMATS = [
+/**
+ * The two field orders NUMERIC_DATE_RE can report, each covering every
+ * separator that regex accepts, so anything detection resolves is also
+ * parseable. Keep the two lists mirror images of each other.
+ */
+export const MONTH_FIRST_NUMERIC_FORMATS = [
   "MM/dd/yyyy", // "05/01/2024" - US Standard
   "M/d/yyyy", // "5/1/2024" - US Relaxed
+  "MM.dd.yyyy", // "05.01.2024"
+  "M.d.yyyy", // "5.1.2024"
+  "MM-dd-yyyy", // "05-01-2024"
+  "M-d-yyyy", // "5-1-2024"
 ];
 
-const DAY_FIRST_NUMERIC_FORMATS = [
+export const DAY_FIRST_NUMERIC_FORMATS = [
   "dd/MM/yyyy", // "01/05/2024" - UK/EU Standard
   "d/M/yyyy", // "1/5/2024" - UK/EU Relaxed
   "dd.MM.yyyy", // "01.05.2024" - German/Swiss/Russian
   "d.M.yyyy", // "1.5.2024" - German/Swiss Relaxed
   "dd-MM-yyyy", // "01-05-2024" - Dutch/Danish
+  "d-M-yyyy", // "1-5-2024"
 ];
+
+/**
+ * Numeric patterns by resolved field order. `auto` is the historical sequence
+ * and stays exactly as it was — dot dates read day-first there, so a file that
+ * imports correctly today keeps doing so when a column yields no evidence.
+ */
+const NUMERIC_FORMATS_BY_ORDER = {
+  auto: [
+    "MM/dd/yyyy",
+    "M/d/yyyy",
+    "dd/MM/yyyy",
+    "d/M/yyyy",
+    "dd.MM.yyyy",
+    "d.M.yyyy",
+    "dd-MM-yyyy",
+  ],
+  DMY: [...DAY_FIRST_NUMERIC_FORMATS, ...MONTH_FIRST_NUMERIC_FORMATS],
+  MDY: [...MONTH_FIRST_NUMERIC_FORMATS, ...DAY_FIRST_NUMERIC_FORMATS],
+} as const;
 
 /**
  * True when a numeric date could be read either way — both leading fields are
@@ -118,10 +153,8 @@ export function tryParseDate(dateStr: string, order?: DateOrder): Date | null {
     // Numeric day/month orders. "05/01/2024" is 5 January or May 1st with equal
     // justification, so whichever group is tried first silently decides. When
     // the caller resolved the order from the whole column, honour it; otherwise
-    // keep the historical month-first preference.
-    ...(order === "DMY"
-      ? [...DAY_FIRST_NUMERIC_FORMATS, ...MONTH_FIRST_NUMERIC_FORMATS]
-      : [...MONTH_FIRST_NUMERIC_FORMATS, ...DAY_FIRST_NUMERIC_FORMATS]),
+    // leave the historical sequence untouched.
+    ...NUMERIC_FORMATS_BY_ORDER[order ?? "auto"],
 
     // Asian Banking Formats
     "yyyy年MM月dd日", // "2024年05月01日" - Japanese

--- a/apps/frontend/src/pages/activity/import/steps/holdings-confirm-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/holdings-confirm-step.tsx
@@ -19,6 +19,7 @@ import { useImportContext } from "../context";
 import { setImportResult, nextStep } from "../context/import-actions";
 import { buildNewAssetFromDraft } from "../utils/asset-review-utils";
 import {
+  analyzeDateColumn,
   buildHoldingsRowResolutionMap,
   parseDateToYMD,
   parseHoldingsSnapshots,
@@ -328,10 +329,18 @@ export function HoldingsConfirmStep() {
         const fieldMappings = (enrichedMapping?.fieldMappings || {}) as Record<string, string>;
         const dateHeader = fieldMappings[HoldingsFormat.DATE];
         const dateIndex = dateHeader ? headers.indexOf(dateHeader) : -1;
+        // Same day/month order the snapshots were parsed with, or these dates
+        // will not match the snapshot keys they are being checked against.
+        const { order: dateOrder } = analyzeDateColumn(
+          headers,
+          parsedRows,
+          fieldMappings,
+          parseOptions.dateFormat,
+        );
         const belongsToValidSnapshot = (rowIndex: number) => {
           if (dateIndex < 0 || rowIndex < 0) return false;
           const rawDate = parsedRows[rowIndex]?.[dateIndex] ?? "";
-          const snapshotDate = parseDateToYMD(rawDate, parseOptions.dateFormat);
+          const snapshotDate = parseDateToYMD(rawDate, parseOptions.dateFormat, dateOrder);
           return snapshotDate !== null && validSnapshotDates.has(snapshotDate);
         };
         const validAssetKeys = new Set(

--- a/apps/frontend/src/pages/activity/import/steps/holdings-review-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/holdings-review-step.tsx
@@ -10,6 +10,7 @@ import { ImportAlert } from "../components/import-alert";
 import { HoldingsFormat } from "./holdings-mapping-step";
 import {
   CASH_SYMBOL,
+  analyzeDateColumn,
   buildHoldingsRowResolutionMap,
   type HoldingsRowResolution,
   parseDateToYMD,
@@ -34,6 +35,8 @@ function buildHoldingsRows(
   rowResolutions?: Record<number, HoldingsRowResolution>,
 ): HoldingsRow[] {
   const { dateFormat, decimalSeparator, thousandsSeparator, defaultCurrency } = parseOptions;
+
+  const { order: dateOrder } = analyzeDateColumn(headers, parsedRows, fieldMappings, dateFormat);
 
   const dateIndex = fieldMappings[HoldingsFormat.DATE]
     ? headers.indexOf(fieldMappings[HoldingsFormat.DATE])
@@ -65,7 +68,7 @@ function buildHoldingsRows(
     // Skip rows with missing required fields
     if (!rawDate || !rawSymbol || !rawQuantity) continue;
 
-    const normalizedDate = parseDateToYMD(rawDate, dateFormat) ?? rawDate;
+    const normalizedDate = parseDateToYMD(rawDate, dateFormat, dateOrder) ?? rawDate;
     const quantity =
       parseNumericValue(rawQuantity, decimalSeparator, thousandsSeparator) ?? rawQuantity;
     const avgCost =
@@ -114,6 +117,10 @@ export function HoldingsReviewStep() {
       defaultCurrency: parseConfig.defaultCurrency,
     }),
     [parseConfig],
+  );
+  const dateColumn = useMemo(
+    () => analyzeDateColumn(headers, parsedRows, fieldMappings, parseConfig.dateFormat),
+    [headers, parsedRows, fieldMappings, parseConfig.dateFormat],
   );
   const rowResolutions = useMemo(
     () => buildHoldingsRowResolutionMap(draftActivities),
@@ -255,6 +262,17 @@ export function HoldingsReviewStep() {
 
   return (
     <div className="flex flex-col gap-6">
+      {dateColumn.needsExplicitFormat && (
+        <ImportAlert
+          variant="warning"
+          size="sm"
+          title={t("activity:import.holdings.ambiguousDateTitle")}
+          description={t("activity:import.holdings.ambiguousDateHint", {
+            example: dateColumn.ambiguousSample,
+          })}
+          className="mb-0"
+        />
+      )}
       {/* Summary Cards */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <ImportAlert

--- a/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
@@ -1,0 +1,148 @@
+import { format as formatDate } from "date-fns";
+import { describe, expect, it } from "vitest";
+
+import { detectDateOrder, isAmbiguousNumericDate, tryParseDate } from "@/lib/utils";
+import { HoldingsFormat } from "../steps/holdings-mapping-step";
+import { analyzeDateColumn, parseDateToYMD } from "./holdings-import-utils";
+
+describe("detectDateOrder", () => {
+  it("reads a column as day-first when a day exceeds 12", () => {
+    expect(detectDateOrder(["03/08/2026", "26/06/2026"])).toBe("DMY");
+  });
+
+  it("reads a column as month-first when the second field exceeds 12", () => {
+    expect(detectDateOrder(["03/08/2026", "06/26/2026"])).toBe("MDY");
+  });
+
+  it("returns null when every value could be read either way", () => {
+    expect(detectDateOrder(["03/08/2026", "10/06/2026"])).toBeNull();
+  });
+
+  it("returns null when the column contradicts itself", () => {
+    expect(detectDateOrder(["26/06/2026", "06/26/2026"])).toBeNull();
+  });
+
+  it("ignores values that are not numeric dates", () => {
+    expect(detectDateOrder(["2026-08-03", "", "not a date"])).toBeNull();
+  });
+
+  it("handles dot and dash separators", () => {
+    expect(detectDateOrder(["13.08.2026"])).toBe("DMY");
+    expect(detectDateOrder(["08-13-2026"])).toBe("MDY");
+  });
+
+  it("does not mix separators within one value", () => {
+    expect(detectDateOrder(["13/08-2026"])).toBeNull();
+  });
+});
+
+describe("isAmbiguousNumericDate", () => {
+  it("flags values whose leading fields are both <= 12", () => {
+    expect(isAmbiguousNumericDate("03/08/2026")).toBe(true);
+  });
+
+  it("does not flag values a day field already resolves", () => {
+    expect(isAmbiguousNumericDate("26/06/2026")).toBe(false);
+  });
+
+  it("does not flag ISO dates", () => {
+    expect(isAmbiguousNumericDate("2026-08-03")).toBe(false);
+  });
+});
+
+describe("parseDateToYMD", () => {
+  it("honours a resolved day-first order", () => {
+    expect(parseDateToYMD("03/08/2026", "auto", "DMY")).toBe("2026-08-03");
+  });
+
+  it("keeps month-first when no order was resolved", () => {
+    expect(parseDateToYMD("03/08/2026", "auto")).toBe("2026-03-08");
+  });
+
+  it("lets an explicit preset win over a resolved order", () => {
+    expect(parseDateToYMD("03/08/2026", "MM/DD/YYYY", "DMY")).toBe("2026-03-08");
+  });
+
+  it("leaves ISO dates alone", () => {
+    expect(parseDateToYMD("2026-08-03", "auto", "DMY")).toBe("2026-08-03");
+  });
+
+  it("leaves the existing dot-date reading alone when no order was resolved", () => {
+    // Regression guard: "auto" must stay byte-for-byte the historical order,
+    // where dd.MM precedes MM.dd.
+    expect(parseDateToYMD("01.05.2024", "auto")).toBe("2024-05-01");
+  });
+
+  it("refuses a numeric date no pattern matched rather than guessing", () => {
+    // 33 is not a day and not a month; the Date constructor would still invent
+    // something engine-specific here.
+    expect(parseDateToYMD("33/33/2026", "auto")).toBeNull();
+  });
+});
+
+describe("tryParseDate", () => {
+  // tryParseDate returns a local-midnight Date, so compare in local time —
+  // toISOString would shift the day for any positive UTC offset.
+  const ymd = (date: Date | null) => (date ? formatDate(date, "yyyy-MM-dd") : null);
+
+  it("honours a resolved day-first order", () => {
+    expect(ymd(tryParseDate("03/08/2026", "DMY"))).toBe("2026-08-03");
+  });
+
+  it("is unchanged without an order", () => {
+    expect(ymd(tryParseDate("03/08/2026"))).toBe("2026-03-08");
+  });
+
+  it("still parses European dot dates when the order is month-first", () => {
+    expect(ymd(tryParseDate("01.05.2024", "MDY"))).toBe("2024-05-01");
+  });
+});
+
+describe("analyzeDateColumn", () => {
+  const headers = ["data", "isin", "qty"];
+  const mapping = { [HoldingsFormat.DATE]: "data" };
+
+  it("resolves the order from the column and asks for nothing", () => {
+    const rows = [
+      ["03/08/2026", "IT0005425761", "8000"],
+      ["26/06/2026", "IT0005425761", "8000"],
+    ];
+    expect(analyzeDateColumn(headers, rows, mapping, "auto")).toEqual({
+      order: "DMY",
+      needsExplicitFormat: false,
+    });
+  });
+
+  it("asks for an explicit format when the whole column is ambiguous", () => {
+    // The real case: a statement whose every row carries one date, 3 August.
+    const rows = [
+      ["03/08/2026", "IT0005425761", "8000"],
+      ["03/08/2026", "DE000WA7T3D8", "3"],
+    ];
+    expect(analyzeDateColumn(headers, rows, mapping, "auto")).toEqual({
+      needsExplicitFormat: true,
+      ambiguousSample: "03/08/2026",
+    });
+  });
+
+  it("stays quiet once the user picked a format", () => {
+    const rows = [["03/08/2026", "IT0005425761", "8000"]];
+    expect(analyzeDateColumn(headers, rows, mapping, "DD/MM/YYYY")).toEqual({
+      needsExplicitFormat: false,
+    });
+  });
+
+  it("stays quiet when the date column is not mapped", () => {
+    const rows = [["03/08/2026", "IT0005425761", "8000"]];
+    expect(analyzeDateColumn(headers, rows, {}, "auto")).toEqual({
+      needsExplicitFormat: false,
+    });
+  });
+
+  it("stays quiet for ISO columns", () => {
+    const rows = [["2026-08-03", "IT0005425761", "8000"]];
+    expect(analyzeDateColumn(headers, rows, mapping, "auto")).toEqual({
+      needsExplicitFormat: false,
+    });
+  });
+});

--- a/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
@@ -5,6 +5,10 @@ import { detectDateOrder, isAmbiguousNumericDate, tryParseDate } from "@/lib/uti
 import { HoldingsFormat } from "../steps/holdings-mapping-step";
 import { analyzeDateColumn, parseDateToYMD } from "./holdings-import-utils";
 
+// tryParseDate returns a local-midnight Date, so compare in local time —
+// toISOString would shift the day for any positive UTC offset.
+const ymd = (date: Date | null) => (date ? formatDate(date, "yyyy-MM-dd") : null);
+
 describe("detectDateOrder", () => {
   it("reads a column as day-first when a day exceeds 12", () => {
     expect(detectDateOrder(["03/08/2026", "26/06/2026"])).toBe("DMY");
@@ -33,6 +37,50 @@ describe("detectDateOrder", () => {
 
   it("does not mix separators within one value", () => {
     expect(detectDateOrder(["13/08-2026"])).toBeNull();
+  });
+
+  it("ignores two-digit years, which no pattern can parse", () => {
+    expect(detectDateOrder(["13/08/26"])).toBeNull();
+    expect(detectDateOrder(["08/13/26"])).toBeNull();
+  });
+
+  it("still reads a four-digit year followed by a time", () => {
+    expect(detectDateOrder(["13/08/2026 14:30"])).toBe("DMY");
+  });
+});
+
+describe("numeric format coverage", () => {
+  // Detection reports an order for any separator NUMERIC_DATE_RE accepts, so
+  // both parsers must be able to read that order back for each of them.
+  const separatorCases = [
+    ["/", "08/13/2026", "13/08/2026"],
+    [".", "08.13.2026", "13.08.2026"],
+    ["-", "08-13-2026", "13-08-2026"],
+  ] as const;
+
+  it.each(separatorCases)(
+    "resolves and parses month-first %s dates",
+    (_sep, monthFirst, _dayFirst) => {
+      const order = detectDateOrder([monthFirst]);
+      expect(order).toBe("MDY");
+      expect(parseDateToYMD(monthFirst, "auto", order ?? undefined)).toBe("2026-08-13");
+      expect(ymd(tryParseDate(monthFirst, order ?? undefined))).toBe("2026-08-13");
+    },
+  );
+
+  it.each(separatorCases)(
+    "resolves and parses day-first %s dates",
+    (_sep, _monthFirst, dayFirst) => {
+      const order = detectDateOrder([dayFirst]);
+      expect(order).toBe("DMY");
+      expect(parseDateToYMD(dayFirst, "auto", order ?? undefined)).toBe("2026-08-13");
+      expect(ymd(tryParseDate(dayFirst, order ?? undefined))).toBe("2026-08-13");
+    },
+  );
+
+  it("applies a resolved order to single-digit dates too", () => {
+    expect(parseDateToYMD("3/8/2026", "auto", "DMY")).toBe("2026-08-03");
+    expect(ymd(tryParseDate("3/8/2026", "DMY"))).toBe("2026-08-03");
   });
 });
 
@@ -81,10 +129,6 @@ describe("parseDateToYMD", () => {
 });
 
 describe("tryParseDate", () => {
-  // tryParseDate returns a local-midnight Date, so compare in local time —
-  // toISOString would shift the day for any positive UTC offset.
-  const ymd = (date: Date | null) => (date ? formatDate(date, "yyyy-MM-dd") : null);
-
   it("honours a resolved day-first order", () => {
     expect(ymd(tryParseDate("03/08/2026", "DMY"))).toBe("2026-08-03");
   });
@@ -93,8 +137,14 @@ describe("tryParseDate", () => {
     expect(ymd(tryParseDate("03/08/2026"))).toBe("2026-03-08");
   });
 
-  it("still parses European dot dates when the order is month-first", () => {
-    expect(ymd(tryParseDate("01.05.2024", "MDY"))).toBe("2024-05-01");
+  it("reads dot dates month-first once the column resolved that order", () => {
+    expect(ymd(tryParseDate("01.05.2024", "MDY"))).toBe("2024-01-05");
+  });
+
+  it("leaves dot dates day-first when no order was resolved", () => {
+    // Regression guard: the `auto` sequence is unchanged, so German/Swiss files
+    // that read correctly today keep doing so.
+    expect(ymd(tryParseDate("01.05.2024"))).toBe("2024-05-01");
   });
 });
 

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/constants";
 import { canonicalizeActivitySubtype } from "@/lib/activity-utils";
 import type { ActivityImport } from "@/lib/types";
-import { tryParseDate } from "@/lib/utils";
+import { type DateOrder, detectDateOrder, tryParseDate } from "@/lib/utils";
 import { isValid, parse, parseISO } from "date-fns";
 import { findMappedActivityType } from "./activity-type-mapping";
 import { getDateFnsPattern } from "./date-format-options";
@@ -193,7 +193,11 @@ export function reconcileExpenseReversalBoundary(
  * Parse a date value using the configured format (priority) then auto-detection fallback.
  * Returns a full ISO datetime string preserving any time component from the source.
  */
-export function parseDateValue(value: string | undefined, dateFormat: string): string {
+export function parseDateValue(
+  value: string | undefined,
+  dateFormat: string,
+  order?: DateOrder,
+): string {
   if (!value || value.trim() === "") return "";
 
   const trimmed = value.trim();
@@ -220,7 +224,7 @@ export function parseDateValue(value: string | undefined, dateFormat: string): s
   }
 
   // 3. Auto-detection fallback (handles 80+ formats)
-  const autoDetected = tryParseDate(trimmed);
+  const autoDetected = tryParseDate(trimmed, order);
   if (autoDetected) return autoDetected.toISOString();
 
   // 4. Return as-is if nothing works (will surface as validation error)
@@ -685,6 +689,14 @@ export function createDraftActivities(
     return row[idx];
   };
 
+  // Numeric dates are ambiguous per row but usually not per column: one
+  // "26/06/2026" among them fixes the day/month order for every other row.
+  const dateOrder =
+    dateFormat === "auto"
+      ? (detectDateOrder(parsedRows.map((row) => getColumnValue(row, ImportFormat.DATE) ?? "")) ??
+        undefined)
+      : undefined;
+
   return parsedRows.flatMap((row, rowIndex): DraftActivity[] => {
     // Extract raw values from CSV
     const rawDate = getColumnValue(row, ImportFormat.DATE);
@@ -714,7 +726,7 @@ export function createDraftActivities(
       : getColumnValue(row, ImportFormat.INSTRUMENT_TYPE);
 
     // Parse and normalize values
-    const activityDate = parseDateValue(rawDate, dateFormat);
+    const activityDate = parseDateValue(rawDate, dateFormat, dateOrder);
     const signedAmount = parseSignedNumericValue(rawAmount, decimalSeparator, thousandsSeparator);
     const signedQuantity = parseSignedNumericValue(
       rawQuantity,

--- a/apps/frontend/src/pages/activity/import/utils/holdings-import-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/holdings-import-utils.ts
@@ -1,20 +1,34 @@
 import { parse, parseISO, isValid, format as formatDate } from "date-fns";
 
 import type { HoldingsSnapshotInput, HoldingsPositionInput } from "@/lib/types";
-import { type DateOrder, detectDateOrder, isAmbiguousNumericDate } from "@/lib/utils";
+import {
+  DAY_FIRST_NUMERIC_FORMATS,
+  type DateOrder,
+  MONTH_FIRST_NUMERIC_FORMATS,
+  detectDateOrder,
+  isAmbiguousNumericDate,
+} from "@/lib/utils";
 import type { DraftActivity } from "../context";
 import { HoldingsFormat } from "../steps/holdings-mapping-step";
 import { getDateFnsPattern } from "./date-format-options";
 
 export const CASH_SYMBOL = "$CASH";
 
-/** Numeric dates like 03/08/2026, 3-8-26 — day/month order is not self-evident. */
+/**
+ * Numeric dates like 03/08/2026 or 3-8-26 — the field order is not self-evident.
+ * Deliberately broader than the detection regex in lib/utils: this only guards
+ * the `new Date` fallback, and two-digit-year dates are exactly the input that
+ * fallback would guess at, so they must not reach it either.
+ */
 const NUMERIC_DATE_SHAPE = /^\d{1,2}([/.-])\d{1,2}\1\d{2,4}$/;
 
 /**
- * Numeric date patterns, ordered by which field leads. `auto` is the historical
- * order and stays byte-for-byte as it was, so files that parse correctly today
- * keep doing so when the column yields no evidence either way.
+ * Numeric date patterns, ordered by which field leads. The resolved orders
+ * reuse the shared lists so detection and parsing support the same formats.
+ * `auto` keeps its historical sequence — dash dates read month-first here, so
+ * files that parse correctly today keep doing so when a column yields no
+ * evidence — with the single-digit forms appended: those used to be reachable
+ * only through `new Date`, which guessed their field order.
  */
 const NUMERIC_PATTERNS = {
   auto: [
@@ -24,26 +38,16 @@ const NUMERIC_PATTERNS = {
     "dd-MM-yyyy",
     "dd.MM.yyyy",
     "MM.dd.yyyy",
+    "M/d/yyyy",
+    "d/M/yyyy",
+    "M-d-yyyy",
+    "d-M-yyyy",
+    "d.M.yyyy",
+    "M.d.yyyy",
     "yyyy/MM/dd",
   ],
-  DMY: [
-    "dd/MM/yyyy",
-    "dd-MM-yyyy",
-    "dd.MM.yyyy",
-    "MM/dd/yyyy",
-    "MM-dd-yyyy",
-    "MM.dd.yyyy",
-    "yyyy/MM/dd",
-  ],
-  MDY: [
-    "MM/dd/yyyy",
-    "MM-dd-yyyy",
-    "MM.dd.yyyy",
-    "dd/MM/yyyy",
-    "dd-MM-yyyy",
-    "dd.MM.yyyy",
-    "yyyy/MM/dd",
-  ],
+  DMY: [...DAY_FIRST_NUMERIC_FORMATS, ...MONTH_FIRST_NUMERIC_FORMATS, "yyyy/MM/dd"],
+  MDY: [...MONTH_FIRST_NUMERIC_FORMATS, ...DAY_FIRST_NUMERIC_FORMATS, "yyyy/MM/dd"],
 } as const;
 
 export interface ParseOptions {

--- a/apps/frontend/src/pages/activity/import/utils/holdings-import-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/holdings-import-utils.ts
@@ -1,11 +1,50 @@
 import { parse, parseISO, isValid, format as formatDate } from "date-fns";
 
 import type { HoldingsSnapshotInput, HoldingsPositionInput } from "@/lib/types";
+import { type DateOrder, detectDateOrder, isAmbiguousNumericDate } from "@/lib/utils";
 import type { DraftActivity } from "../context";
 import { HoldingsFormat } from "../steps/holdings-mapping-step";
 import { getDateFnsPattern } from "./date-format-options";
 
 export const CASH_SYMBOL = "$CASH";
+
+/** Numeric dates like 03/08/2026, 3-8-26 — day/month order is not self-evident. */
+const NUMERIC_DATE_SHAPE = /^\d{1,2}([/.-])\d{1,2}\1\d{2,4}$/;
+
+/**
+ * Numeric date patterns, ordered by which field leads. `auto` is the historical
+ * order and stays byte-for-byte as it was, so files that parse correctly today
+ * keep doing so when the column yields no evidence either way.
+ */
+const NUMERIC_PATTERNS = {
+  auto: [
+    "MM/dd/yyyy",
+    "dd/MM/yyyy",
+    "MM-dd-yyyy",
+    "dd-MM-yyyy",
+    "dd.MM.yyyy",
+    "MM.dd.yyyy",
+    "yyyy/MM/dd",
+  ],
+  DMY: [
+    "dd/MM/yyyy",
+    "dd-MM-yyyy",
+    "dd.MM.yyyy",
+    "MM/dd/yyyy",
+    "MM-dd-yyyy",
+    "MM.dd.yyyy",
+    "yyyy/MM/dd",
+  ],
+  MDY: [
+    "MM/dd/yyyy",
+    "MM-dd-yyyy",
+    "MM.dd.yyyy",
+    "dd/MM/yyyy",
+    "dd-MM-yyyy",
+    "dd.MM.yyyy",
+    "yyyy/MM/dd",
+  ],
+} as const;
 
 export interface ParseOptions {
   dateFormat: string;
@@ -131,7 +170,50 @@ export function parseNumericValue(
   return Number.isFinite(numericCheck) ? candidate : undefined;
 }
 
-export function parseDateToYMD(dateStr: string, dateFormat: string): string | null {
+export interface DateColumnAnalysis {
+  /** Day/month order resolved from the column, if it carries the evidence. */
+  order?: DateOrder;
+  /** The column is numeric-ambiguous and nothing settles it — ask the user. */
+  needsExplicitFormat: boolean;
+  /** First unresolvable value, to show the user what is being guessed at. */
+  ambiguousSample?: string;
+}
+
+/**
+ * Inspect a holdings CSV's date column as a whole rather than row by row.
+ *
+ * A lone "03/08/2026" cannot be read, but a "26/06/2026" elsewhere in the same
+ * column resolves every row in it. When the column is all-ambiguous and the
+ * user left the format on auto-detect, say so instead of silently guessing.
+ */
+export function analyzeDateColumn(
+  headers: string[],
+  rows: string[][],
+  mapping: Record<string, string>,
+  dateFormat: string,
+): DateColumnAnalysis {
+  if (dateFormat !== "auto") return { needsExplicitFormat: false };
+
+  const dateHeader = mapping[HoldingsFormat.DATE];
+  const dateIndex = dateHeader ? headers.indexOf(dateHeader) : -1;
+  if (dateIndex < 0) return { needsExplicitFormat: false };
+
+  const values = rows.map((row) => row[dateIndex] ?? "");
+  const order = detectDateOrder(values) ?? undefined;
+  if (order) return { order, needsExplicitFormat: false };
+
+  const ambiguousSample = values.find(isAmbiguousNumericDate);
+  return {
+    needsExplicitFormat: ambiguousSample !== undefined,
+    ...(ambiguousSample ? { ambiguousSample: ambiguousSample.trim() } : {}),
+  };
+}
+
+export function parseDateToYMD(
+  dateStr: string,
+  dateFormat: string,
+  order?: DateOrder,
+): string | null {
   const trimmed = dateStr.trim();
   if (!trimmed) return null;
 
@@ -164,15 +246,10 @@ export function parseDateToYMD(dateStr: string, dateFormat: string): string | nu
     }
   }
 
-  const commonPatterns = [
-    "MM/dd/yyyy",
-    "dd/MM/yyyy",
-    "MM-dd-yyyy",
-    "dd-MM-yyyy",
-    "dd.MM.yyyy",
-    "MM.dd.yyyy",
-    "yyyy/MM/dd",
-  ];
+  // "03/08/2026" is 3 August or 8 March depending only on which pattern runs
+  // first, so a day/month order resolved from the whole column decides it.
+  // Without that evidence the existing per-separator order is left untouched.
+  const commonPatterns = order ? NUMERIC_PATTERNS[order] : NUMERIC_PATTERNS.auto;
   for (const p of commonPatterns) {
     try {
       const parsed = parse(trimmed, p, new Date());
@@ -182,9 +259,14 @@ export function parseDateToYMD(dateStr: string, dateFormat: string): string | nu
     }
   }
 
-  const date = new Date(trimmed);
-  if (!isNaN(date.getTime())) {
-    return formatDate(date, "yyyy-MM-dd");
+  // Never hand a numeric date to the Date constructor: its day/month order is
+  // engine-defined, so it reintroduces exactly the guess the patterns above
+  // just resolved. Anything still unparsed here is not a numeric date.
+  if (!NUMERIC_DATE_SHAPE.test(trimmed)) {
+    const date = new Date(trimmed);
+    if (!isNaN(date.getTime())) {
+      return formatDate(date, "yyyy-MM-dd");
+    }
   }
 
   return null;
@@ -288,6 +370,7 @@ function parseHoldingsSnapshotsInternal(
   const currencyHeader = mapping[HoldingsFormat.CURRENCY];
 
   const dateIndex = dateHeader ? headers.indexOf(dateHeader) : -1;
+  const { order: dateOrder } = analyzeDateColumn(headers, rows, mapping, dateFormat);
   const symbolIndex = symbolHeader ? headers.indexOf(symbolHeader) : -1;
   const quantityIndex = quantityHeader ? headers.indexOf(quantityHeader) : -1;
   const avgCostIndex = avgCostHeader ? headers.indexOf(avgCostHeader) : -1;
@@ -307,7 +390,7 @@ function parseHoldingsSnapshotsInternal(
     const rawAvgCost = avgCostIndex >= 0 ? row[avgCostIndex]?.trim() : undefined;
     const currency = currencyIndex >= 0 ? row[currencyIndex]?.trim() : defaultCurrency;
 
-    const normalizedDate = parseDateToYMD(rawDate, dateFormat);
+    const normalizedDate = parseDateToYMD(rawDate, dateFormat, dateOrder);
     const parsedQuantity = parseNumericValue(rawQuantity, decimalSeparator, thousandsSeparator);
     const parsedAvgCost = parseNumericValue(rawAvgCost, decimalSeparator, thousandsSeparator);
 


### PR DESCRIPTION
## The problem

`parseDateToYMD` (holdings import) and `tryParseDate` (activity import) both list `MM/dd/yyyy` ahead of `dd/MM/yyyy` in their auto-detect pattern arrays. Whichever runs first silently wins, so a CSV whose dates read `03/08/2026` imports as **8 March** rather than 3 August.

It is silent by construction: the review table shows the misread date, which looks perfectly plausible. I hit this with a European brokerage statement — the snapshot landed four months in the past, behind a newer one, so it never affected current holdings and went unnoticed. The next month's file, dated `10/06/2026`, landed four months in the *future* and became the winning "latest" quote for eleven positions, valuing them at cost.

`lib/utils.ts` already documented the intended contract, two lines above the code that breaks it:

```
// 12-hour / AM-PM Formats (e.g. Questrade exports). Only the unambiguous
// ISO date order is auto-detected; slash orders (MM/dd vs dd/MM) are
// ambiguous and must be chosen explicitly via an import format preset.
```

The AM/PM block below that comment honours it. The numeric block twelve lines further down does not.

## The fix

**Look at the column, not the row.** A lone `03/08/2026` is unreadable, but one `26/06/2026` anywhere in the same column settles every row in it. `detectDateOrder(values)` returns `DMY`, `MDY`, or `null` when the column offers no evidence or contradicts itself. Both import paths resolve it once and thread it into the row parsers.

**Say so when the column cannot settle it.** If the format is still on auto-detect and every date is ambiguous, the holdings review step shows a warning naming the value it cannot read, rather than guessing. This is the case column detection alone cannot escape, and it is the one that bit me — all 43 rows of my statement carried the same date.

**Stop guessing in the `new Date()` fallback.** `parseDateToYMD` ended with a bare `new Date(trimmed)`. Its field order for numeric dates is engine-defined, so it reintroduced exactly the ambiguity the pattern list had just resolved. It is now skipped for numeric-shaped input; non-numeric strings still reach it.

## Compatibility

Without a resolved order the pattern sequence is byte-for-byte what it is today, including the existing per-separator quirk where `dd.MM` precedes `MM.dd` while `MM/dd` precedes `dd/MM`. Files that import correctly today keep doing so. There is a test pinning that.

## Verification

- `apps/frontend/src/pages/activity/import/utils/date-order.test.ts` — 24 cases: detection, per-separator handling, contradictory columns, preset precedence, and the no-order regression guard
- `pnpm --filter frontend test` over `src/pages/activity/import` and `src/lib` — 377 passed, 30 files
- `pnpm type-check` clean
- `eslint` clean on the touched files

## Note

The warning string is added to `en/activity.json` only; the other locales fall back to English. Happy to add translations, or to drop the UI warning entirely and land just the detection if you would rather keep the change to the utils.
