### PR TITLE
fix(layout): clear the macOS traffic lights in Floating Bar mode

### DIFF
--- a/apps/frontend/src/components/page/swipable-page.tsx
+++ b/apps/frontend/src/components/page/swipable-page.tsx
@@ -293,7 +293,7 @@ export function SwipablePage({
           <div className="hidden h-full flex-col md:flex">
             {/* Header with Navigation and Actions */}
             <div className="flex shrink-0 items-center justify-between gap-4 px-2 pb-3 pt-4 lg:px-4">
-              <div className="flex items-center gap-3">
+              <div className="titlebar-nudge flex items-center gap-3">
                 {title && <h1 className="text-muted-foreground text-sm font-medium">{title}</h1>}
                 <NavigationPills
                   views={views}

--- a/apps/frontend/src/globals.css
+++ b/apps/frontend/src/globals.css
@@ -713,6 +713,19 @@ body.qr-scan-active .scan-hide-target {
     padding-right: env(safe-area-inset-right, 0);
   }
 
+  /*
+   * Nudges a header's leading group clear of the macOS traffic lights when no
+   * sidebar covers the top-left corner. Uses a transform, not padding or
+   * margin, so only this group moves -- the row's other content (page actions
+   * on the trailing edge) keeps its original position.
+   */
+  .titlebar-nudge {
+    /* Holds the whole transform so the default is `none`, not translateY(0px):
+       any transform other than `none` would create a stacking context and a
+       containing block for fixed/absolute descendants on every platform. */
+    transform: var(--titlebar-nudge, none);
+  }
+
   /* Dynamic viewport height to avoid mobile address bar issues */
   .min-h-dvh {
     min-height: 100dvh;

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -29,7 +29,7 @@ const AppLayoutContent = () => {
   } = useSettings();
   const location = useLocation();
   const navigation = useNavigation();
-  const { isMobile, isTauri } = usePlatform();
+  const { isMobile, isMacOS, isTauri } = usePlatform();
   const isMobileViewport = useIsMobileViewport();
   const isIPad =
     typeof window !== "undefined" &&
@@ -39,6 +39,15 @@ const AppLayoutContent = () => {
   const shouldUseMobileNavigation = isIPad ? false : isMobile || isMobileViewport;
   const shouldUseBottomNavigation = shouldUseMobileNavigation || (isLaunchBar && !isFocusMode);
   const isDesktopFocusMode = !shouldUseMobileNavigation && isFocusMode;
+  const hasSidebar = !shouldUseBottomNavigation && !isDesktopFocusMode;
+  // macOS only: `titleBarStyle: "Overlay"` floats the traffic lights over the
+  // WebView, and without the sidebar nothing covers the top-left corner they
+  // occupy. Observed at y 8-20 against pills starting at y 16, so 8px clears
+  // them with a small margin. Consumed by .titlebar-nudge.
+  const titleBarNudge =
+    isTauri && isMacOS && !shouldUseMobileNavigation && !hasSidebar
+      ? "translateY(0.5rem)"
+      : undefined;
   const launchBarHeight =
     !shouldUseMobileNavigation && isLaunchBar && !isFocusMode ? "56px" : undefined;
   const isAppShellReady = isSettingsReady && !!settings?.onboardingCompleted;
@@ -80,17 +89,16 @@ const AppLayoutContent = () => {
     <ErrorBoundary>
       <ApplicationShell
         className="app-shell h-screen overflow-x-hidden"
-        style={
-          launchBarHeight ? { ["--mobile-nav-ui-height" as string]: launchBarHeight } : undefined
-        }
+        style={{
+          ...(launchBarHeight ? { ["--mobile-nav-ui-height" as string]: launchBarHeight } : {}),
+          ...(titleBarNudge ? { ["--titlebar-nudge" as string]: titleBarNudge } : {}),
+        }}
       >
         {/* Mobile sync loading indicator */}
         {shouldUseMobileNavigation && <MobileLoadingIndicator />}
 
         <div className="scan-hide-target">
-          {!shouldUseBottomNavigation && !isDesktopFocusMode && (
-            <AppSidebar navigation={navigation} />
-          )}
+          {hasSidebar && <AppSidebar navigation={navigation} />}
         </div>
 
         <div


### PR DESCRIPTION
Fixes #1590. Supersedes #1591.

## Problem

`titleBarStyle: "Overlay"` floats the macOS window controls over the WebView at the top-left corner. In Sidebar mode the sidebar covers that corner, so nothing collides. **Floating Bar and Focus mode both drop the sidebar**, and the dashboard navigation pills then start at `y 16` against controls observed at `y 8-20` — a 4px overlap.

## Fix

Nudge only the header's leading group, by 8px, on native macOS.

- **A transform, not padding.** The row's layout is untouched, so the trailing page actions keep their current position. Padding the row — or `<main>` — moves both halves and opens a gap above the actions, where there is nothing to clear.
- **Gated on `isTauri && isMacOS`.** The overlay title bar is macOS-only, so Windows, Linux, web, iPad, and iPhone see no change. Off macOS the custom property is unset and the declaration resolves to `none` rather than `translateY(0px)`, which would otherwise create a stacking context and a containing block for fixed/absolute descendants on every platform.
- **Driven by `hasSidebar`,** extracted from the `AppSidebar` render condition so the two cannot drift. That covers Focus mode, which hides the sidebar in *both* navigation modes.

Only `SwipablePage` needs the clearance: `PageHeader` already starts its content at `y 24` (`md:pt-2` plus the inner `p-4`), and desktop Settings clears at `py-8`.

## Why not #1591

That PR diagnosed the cause correctly, and its analysis of `env(safe-area-inset-top)` returning `0` in WKWebView on macOS is right. Three things led me elsewhere:

- It reserves a **full 28px title bar** on top of the header's existing `pt-4`, so the pills land 24px lower than needed, and the top-right actions drop with them.
- Padding `<main>` shifts **every** page in Floating Bar, including those whose headers already clear the controls.
- Gating on `isLaunchBar && !isFocusMode` leaves **Focus mode** broken, which also hides the sidebar.

## Platform impact

| State | Result |
|---|---|
| macOS, Floating Bar / Focus | 8px clearance — intended |
| macOS, Sidebar | unchanged |
| Windows / Linux / web | unchanged |
| iPad / iPhone / Android | unchanged |

## Verification

- `pnpm type-check` — clean
- `pnpm lint` — 0 errors (warning counts unchanged from baseline)
- `pnpm test` — 205 files / 1,627 tests passing
- `git diff --check` — clean
- Manual: native macOS, Floating Bar — pill clearance and window dragging both confirmed
