### PR TITLE
Serve manual-mode assets from the quote store in fetch_quotes_for_symbol

### DIFF
--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -1805,6 +1805,22 @@ where
     ) -> Result<Vec<Quote>> {
         // First try to find an existing asset by ID
         if let Ok(asset) = self.asset_repo.get_by_id(asset_id) {
+            // Manual-mode assets have no provider symbol: asking a provider for them
+            // composes an instrument key that no provider knows and fails. Their prices
+            // only ever live in the quote store.
+            if asset.quote_mode == QuoteMode::Manual {
+                let mut quotes = self.quote_store.range(
+                    &AssetId::new(asset_id),
+                    Day::new(start),
+                    Day::new(end),
+                    None,
+                )?;
+                for quote in &mut quotes {
+                    reconcile_quote_currency(quote, &asset);
+                }
+                return Ok(quotes);
+            }
+
             let start_dt = Utc.from_utc_datetime(&start.and_hms_opt(0, 0, 0).unwrap());
             let end_dt = Utc.from_utc_datetime(&end.and_hms_opt(23, 59, 59).unwrap());
             return self
@@ -3113,6 +3129,132 @@ mod tests {
         }
     }
 
+    /// Quote store that serves stored rows for a date range and counts the range
+    /// queries, so a test can assert whether the stored-quote path was taken.
+    #[derive(Default)]
+    struct RangeQuoteStore {
+        quotes: Vec<Quote>,
+        range_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl QuoteStore for RangeQuoteStore {
+        async fn save_quote(&self, _quote: &Quote) -> Result<Quote> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn delete_quote(&self, _quote_id: &str) -> Result<()> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn upsert_quotes(&self, _quotes: &[Quote]) -> Result<usize> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn delete_quotes_for_asset(&self, _asset_id: &AssetId) -> Result<usize> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn delete_provider_quotes_for_asset(&self, _asset_id: &AssetId) -> Result<usize> {
+            unimplemented!("unused in this test")
+        }
+
+        fn latest(
+            &self,
+            _asset_id: &AssetId,
+            _source: Option<&QuoteSource>,
+        ) -> Result<Option<Quote>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn range(
+            &self,
+            asset_id: &AssetId,
+            start: Day,
+            end: Day,
+            _source: Option<&QuoteSource>,
+        ) -> Result<Vec<Quote>> {
+            self.range_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .quotes
+                .iter()
+                .filter(|quote| {
+                    quote.asset_id == asset_id.as_str()
+                        && quote.timestamp.date_naive() >= start.date()
+                        && quote.timestamp.date_naive() <= end.date()
+                })
+                .cloned()
+                .collect())
+        }
+
+        fn latest_batch(
+            &self,
+            _asset_ids: &[AssetId],
+            _source: Option<&QuoteSource>,
+        ) -> Result<HashMap<AssetId, Quote>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn latest_with_previous(
+            &self,
+            _asset_ids: &[AssetId],
+        ) -> Result<HashMap<AssetId, LatestQuotePair>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_quote_bounds_for_assets(
+            &self,
+            _asset_ids: &[String],
+            _source: &str,
+        ) -> Result<HashMap<String, (NaiveDate, NaiveDate)>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_latest_quote(&self, _symbol: &str) -> Result<Quote> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_latest_quotes(&self, _symbols: &[String]) -> Result<HashMap<String, Quote>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
+        fn get_latest_quotes_pair(
+            &self,
+            _symbols: &[String],
+        ) -> Result<HashMap<String, LatestQuotePair>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_historical_quotes(&self, _symbol: &str) -> Result<Vec<Quote>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_all_historical_quotes(&self) -> Result<Vec<Quote>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_quotes_in_range(
+            &self,
+            _symbol: &str,
+            _start: NaiveDate,
+            _end: NaiveDate,
+        ) -> Result<Vec<Quote>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn find_duplicate_quotes(&self, _symbol: &str, _date: NaiveDate) -> Result<Vec<Quote>> {
+            unimplemented!("unused in this test")
+        }
+    }
+
     struct MockSyncStateStore {
         provider_sync_stats: Vec<ProviderSyncStats>,
         with_errors: Vec<QuoteSyncState>,
@@ -4113,6 +4255,151 @@ mod tests {
             Some("quote_1")
         );
         assert!(snapshot.no_quote_reason.is_none());
+        Ok(())
+    }
+
+    fn stored_quote(asset_id: &str, day: NaiveDate, close: rust_decimal::Decimal) -> Quote {
+        Quote {
+            id: format!("{}_{}", asset_id, day),
+            asset_id: asset_id.to_string(),
+            timestamp: Utc.from_utc_datetime(&day.and_hms_opt(16, 0, 0).unwrap()),
+            open: close,
+            high: close,
+            low: close,
+            close,
+            adjclose: close,
+            volume: dec!(0),
+            currency: "EUR".to_string(),
+            data_source: DATA_SOURCE_MANUAL.to_string(),
+            created_at: Utc::now(),
+            notes: None,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn quote_service_for_asset(
+        asset: Asset,
+        quote_store: Arc<RangeQuoteStore>,
+    ) -> Result<
+        QuoteService<
+            RangeQuoteStore,
+            MockSyncStateStore,
+            MockProviderSettingsStore,
+            PositionStatusAssetRepository,
+            NoopActivityRepository,
+        >,
+    > {
+        let asset_repo = PositionStatusAssetRepository {
+            assets: HashMap::from([(asset.id.clone(), asset)]),
+            reactivated: Arc::new(Mutex::new(Vec::new())),
+            deactivated: Arc::new(Mutex::new(Vec::new())),
+            list_by_asset_ids_calls: Arc::new(AtomicUsize::new(0)),
+        };
+
+        QuoteService::new(
+            quote_store,
+            Arc::new(MockSyncStateStore {
+                provider_sync_stats: vec![],
+                with_errors: vec![],
+                states: Arc::new(Mutex::new(HashMap::new())),
+            }),
+            Arc::new(MockProviderSettingsStore { providers: vec![] }),
+            Arc::new(asset_repo),
+            Arc::new(NoopActivityRepository),
+            Arc::new(MockSecretStore),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn fetch_quotes_for_symbol_serves_manual_asset_from_stored_quotes() -> Result<()> {
+        let asset_id = "SEC:NBIM:XETR";
+        let asset = Asset {
+            id: asset_id.to_string(),
+            kind: AssetKind::Investment,
+            instrument_type: Some(InstrumentType::Equity),
+            quote_mode: QuoteMode::Manual,
+            quote_ccy: "EUR".to_string(),
+            ..Default::default()
+        };
+        let range_calls = Arc::new(AtomicUsize::new(0));
+        let quote_store = Arc::new(RangeQuoteStore {
+            quotes: vec![
+                stored_quote(
+                    asset_id,
+                    NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
+                    dec!(101.5),
+                ),
+                stored_quote(
+                    asset_id,
+                    NaiveDate::from_ymd_opt(2025, 12, 15).unwrap(),
+                    dec!(90),
+                ),
+            ],
+            range_calls: Arc::clone(&range_calls),
+        });
+        let service = quote_service_for_asset(asset, quote_store).await?;
+
+        let quotes = QuoteServiceTrait::fetch_quotes_for_symbol(
+            &service,
+            asset_id,
+            "USD",
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 31).unwrap(),
+        )
+        .await?;
+
+        assert_eq!(
+            range_calls.load(Ordering::Relaxed),
+            1,
+            "manual assets have no provider symbol and must be served from stored quotes"
+        );
+        assert_eq!(quotes.len(), 1);
+        assert_eq!(quotes[0].close, dec!(101.5));
+        assert_eq!(quotes[0].currency, "EUR");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetch_quotes_for_symbol_keeps_provider_path_for_market_asset() -> Result<()> {
+        let asset_id = "SEC:AAPL:XNAS";
+        let asset = Asset {
+            id: asset_id.to_string(),
+            kind: AssetKind::Investment,
+            instrument_type: Some(InstrumentType::Equity),
+            quote_mode: QuoteMode::Market,
+            quote_ccy: "USD".to_string(),
+            ..Default::default()
+        };
+        let range_calls = Arc::new(AtomicUsize::new(0));
+        let quote_store = Arc::new(RangeQuoteStore {
+            quotes: vec![stored_quote(
+                asset_id,
+                NaiveDate::from_ymd_opt(2026, 1, 15).unwrap(),
+                dec!(101.5),
+            )],
+            range_calls: Arc::clone(&range_calls),
+        });
+        let service = quote_service_for_asset(asset, quote_store).await?;
+
+        let result = QuoteServiceTrait::fetch_quotes_for_symbol(
+            &service,
+            asset_id,
+            "USD",
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 31).unwrap(),
+        )
+        .await;
+
+        assert_eq!(
+            range_calls.load(Ordering::Relaxed),
+            0,
+            "market assets must keep using the provider, not stored quotes"
+        );
+        assert!(
+            result.is_err(),
+            "no provider is enabled, so the provider path must surface its own error"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Description

An asset with quote mode `MANUAL` cannot be plotted in benchmark comparison. `fetch_quotes_for_symbol` routes every found asset to the market-data provider. For an asset that has no provider symbol, the provider composes an instrument key it cannot resolve (e.g. `NBIM@XETR` for a manually tracked fund) and errors — even though the asset's quotes sit in the local quote store.

This change makes `fetch_quotes_for_symbol` serve `QuoteMode::Manual` assets from the quote store. It reads the stored quotes for the requested range and applies the same per-row currency reconciliation as the other DB read paths. Market-mode assets keep the provider path unchanged.

I hit this on my production instance while tracking a fund that has no resolvable provider symbol. Its quotes are entered manually, and the benchmark line could never render.

Tests: two hermetic tests cover the change. The manual-path test is the regression test — it fails against the pre-fix code, which routes the asset to the provider. The market-path test guards branch selection: a market-mode asset still takes the provider path, not the store. I ran the full `wealthfolio-core` suite plus `cargo fmt --check` and `cargo clippy -D warnings` for the crate on this branch.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
