### PR TITLE
Improve activity review and editing workflow

### DIFF
--- a/apps/frontend/src/components/page/swipable-page.tsx
+++ b/apps/frontend/src/components/page/swipable-page.tsx
@@ -20,6 +20,7 @@ interface SwipablePageProps {
   onViewChange?: (view: string) => void;
   className?: string;
   contentClassName?: string;
+  desktopContentClassName?: string;
   withPadding?: boolean;
   withMobileNavOffset?: boolean;
   title?: string;
@@ -156,6 +157,7 @@ export function SwipablePage({
   onViewChange,
   className,
   contentClassName,
+  desktopContentClassName,
   withPadding = true,
   withMobileNavOffset = true,
   title,
@@ -310,6 +312,7 @@ export function SwipablePage({
               className={cn(
                 "relative grow overflow-y-auto pt-8 md:pt-2",
                 withPadding && "px-2 pb-2 lg:px-4 lg:pb-4",
+                desktopContentClassName,
               )}
             >
               {views.find((v) => v.value === currentView)?.content}

--- a/apps/frontend/src/hooks/use-intersection-observer.test.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.test.ts
@@ -177,6 +177,19 @@ describe("useIntersectionObserver", () => {
       expect(lastInstance().options?.root).toBeNull();
     });
 
+    it("skips a content-growing overflow ancestor taller than the viewport", () => {
+      const pageScroller = scrollableAncestor(3000, 600);
+      const grown = scrollableAncestor(1205, 1200);
+      const sentinel = document.createElement("div");
+      grown.appendChild(sentinel);
+      pageScroller.appendChild(grown);
+
+      const { result } = renderHook(() => useIntersectionObserver(vi.fn()));
+      act(() => result.current(sentinel));
+
+      expect(lastInstance().options?.root).toBe(pageScroller);
+    });
+
     it("skips ancestors that overflow visibly even when their content is taller", () => {
       const visible = document.createElement("div");
       setScrollMetrics(visible, 800, 400);

--- a/apps/frontend/src/hooks/use-intersection-observer.ts
+++ b/apps/frontend/src/hooks/use-intersection-observer.ts
@@ -3,17 +3,20 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 /**
  * Find the element that actually scrolls the sentinel, to use as the
  * observer root. The scrollability check matters twice over: an
- * `overflow: auto` container that grows with its content (scrollHeight ==
- * clientHeight) must not become the root — the sentinel would always
- * intersect it and fetch every page in a loop — and with the viewport as
- * root, an intermediate scroller clips the intersection so rootMargin
- * gives no lead time. The +1 tolerates sub-pixel rounding.
+ * `overflow: auto` container that grows with its content must not become the
+ * root — the sentinel would always intersect it and fetch every page in a
+ * loop. Such containers may have a few pixels of incidental overflow, so an
+ * element taller than the viewport is also rejected. With the viewport as
+ * root, an intermediate real scroller clips the intersection so rootMargin
+ * still gives the intended lead time. The +1 tolerates sub-pixel rounding.
  */
 function findScrollContainer(node: HTMLElement): Element | null {
   for (let el = node.parentElement; el; el = el.parentElement) {
     const { overflowY } = getComputedStyle(el);
+    const extendsBeyondViewport = el.clientHeight > window.innerHeight + 1;
     if (
       (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      !extendsBeyondViewport &&
       el.scrollHeight > el.clientHeight + 1
     ) {
       return el;

--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -1,12 +1,14 @@
 import { ACTIVITY_SUBTYPES, ActivityStatus, ActivityType } from "./constants";
 import {
   isCashActivity,
+  isGarbageSymbol,
   isCashTransfer,
   isIncomeActivity,
   isAssetBackedIncomeActivity,
   isAssetBackedIncomeSubtype,
   isAssetIdentityRequired,
   needsImportAssetResolution,
+  shouldResolveImportAsset,
   calculateActivityValue,
   calculateActivityCashImpact,
   canonicalizeActivitySubtype,
@@ -138,6 +140,23 @@ describe("Activity Utilities", () => {
     it("resolves provider-supplied symbols for otherwise optional adjustments", () => {
       expect(needsImportAssetResolution(ActivityType.ADJUSTMENT, "CORPORATE_ACTION")).toBe(true);
       expect(isAssetIdentityRequired(ActivityType.ADJUSTMENT, "CORPORATE_ACTION")).toBe(false);
+    });
+
+    it("matches backend placeholder classification for optional-asset imports", () => {
+      expect(isGarbageSymbol("----")).toBe(true);
+      expect(isGarbageSymbol("$FOO")).toBe(true);
+      expect(isGarbageSymbol("$CASH-USD")).toBe(false);
+      expect(shouldResolveImportAsset(ActivityType.ADJUSTMENT, "CASH_SWEEP", "----")).toBe(false);
+      expect(shouldResolveImportAsset(ActivityType.ADJUSTMENT, "CORPORATE_ACTION", "$FOO")).toBe(
+        false,
+      );
+      expect(shouldResolveImportAsset(ActivityType.ADJUSTMENT, "CORPORATE_ACTION", "AAPL")).toBe(
+        true,
+      );
+    });
+
+    it("keeps malformed required-asset symbols in validation", () => {
+      expect(shouldResolveImportAsset(ActivityType.BUY, undefined, "----")).toBe(true);
     });
   });
 

--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -111,6 +111,14 @@ describe("Activity Utilities", () => {
       );
       expect(isAssetIdentityRequired(ActivityType.INTEREST, null)).toBe(false);
     });
+
+    it("requires an asset only for asset-affecting adjustments", () => {
+      expect(isAssetIdentityRequired(ActivityType.ADJUSTMENT, null)).toBe(false);
+      expect(isAssetIdentityRequired(ActivityType.ADJUSTMENT, "CASH_SWEEP")).toBe(false);
+      expect(
+        isAssetIdentityRequired(ActivityType.ADJUSTMENT, ACTIVITY_SUBTYPES.OPTION_EXPIRY),
+      ).toBe(true);
+    });
   });
 
   describe("needsImportAssetResolution", () => {
@@ -125,6 +133,11 @@ describe("Activity Utilities", () => {
 
     it("does not force cash-only interest imports through asset resolution", () => {
       expect(needsImportAssetResolution(ActivityType.INTEREST)).toBe(false);
+    });
+
+    it("resolves provider-supplied symbols for otherwise optional adjustments", () => {
+      expect(needsImportAssetResolution(ActivityType.ADJUSTMENT, "CORPORATE_ACTION")).toBe(true);
+      expect(isAssetIdentityRequired(ActivityType.ADJUSTMENT, "CORPORATE_ACTION")).toBe(false);
     });
   });
 

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -97,18 +97,25 @@ export const isAssetBackedIncomeSubtype = (
  * Activity/subtype pairs that must carry a market asset identity.
  */
 export const isAssetIdentityRequired = (activityType: string, subtype?: string | null): boolean => {
+  if (activityType === ActivityType.ADJUSTMENT) {
+    return subtype?.trim().toUpperCase() === ACTIVITY_SUBTYPES.OPTION_EXPIRY;
+  }
   return isSymbolRequired(activityType) || isAssetBackedIncomeSubtype(activityType, subtype);
 };
 
 /**
- * Import-time asset resolution can also be required by subtype even when the
- * base activity type is normally cash-oriented (e.g. staking rewards).
+ * Import-time asset resolution also applies to optional, provider-supplied
+ * adjustment symbols and asset-backed income subtypes such as staking rewards.
  */
 export const needsImportAssetResolution = (
   activityType: string,
   subtype?: string | null,
 ): boolean => {
-  return isAssetIdentityRequired(activityType, subtype);
+  return (
+    activityType === ActivityType.ADJUSTMENT ||
+    isSymbolRequired(activityType) ||
+    isAssetBackedIncomeSubtype(activityType, subtype)
+  );
 };
 
 export const canonicalizeActivitySubtype = (

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -69,6 +69,17 @@ export const isCashSymbol = (symbol?: string): boolean => {
 };
 
 /**
+ * Matches the backend's import-only placeholder detection. These values are
+ * not real tickers and must never enter asset mapping/resolution.
+ */
+export const isGarbageSymbol = (symbol?: string): boolean => {
+  const normalized = symbol?.trim() ?? "";
+  if (!normalized) return false;
+  if (/^-+$/.test(normalized)) return true;
+  return normalized.startsWith("$") && !isCashSymbol(normalized);
+};
+
+/**
  * Whether a symbol is required for this activity type.
  */
 export const isSymbolRequired = (activityType: string): boolean => {
@@ -116,6 +127,26 @@ export const needsImportAssetResolution = (
     isSymbolRequired(activityType) ||
     isAssetBackedIncomeSubtype(activityType, subtype)
   );
+};
+
+/** Whether an imported symbol represents an asset the user must resolve. */
+export const shouldResolveImportAsset = (
+  activityType: string,
+  subtype: string | null | undefined,
+  symbol: string,
+): boolean => {
+  if (!needsImportAssetResolution(activityType, subtype)) return false;
+  // Required-asset rows still enter validation so malformed symbols surface
+  // as errors. Optional-asset rows mirror backend classification and treat
+  // placeholders as cash movements.
+  if (
+    isSymbolRequired(activityType) &&
+    activityType !== ActivityType.DIVIDEND &&
+    activityType !== ActivityType.ADJUSTMENT
+  ) {
+    return true;
+  }
+  return !isCashSymbol(symbol) && !isGarbageSymbol(symbol);
 };
 
 export const canonicalizeActivitySubtype = (

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -309,6 +309,7 @@ export interface ActivityUpdate {
   activityDate: string | Date;
   /** Optional grouping key (links paired transfer legs). */
   sourceGroupId?: string;
+  /** Omit to preserve the current asset; pass an empty object to clear it. */
   asset?: AssetResolutionInput;
   /** @deprecated Use asset. */
   symbol?: AssetResolutionInput;

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -254,6 +254,11 @@ const ActivityPage = () => {
     [materializeInvestmentFilters],
   );
 
+  const handleReviewActivities = useCallback(() => {
+    setViewMode("datagrid");
+    setStatusFilter("pending");
+  }, [setStatusFilter, setViewMode]);
+
   const setInvestmentDateRange = useCallback(
     (range: DateRange | undefined) => {
       materializeInvestmentFilters({ dateRange: fromDateRange(range) });
@@ -690,7 +695,7 @@ const ActivityPage = () => {
       {statusFilter !== "pending" && (
         <NeedsReviewBanner
           accountIds={effectiveInvestmentAccountIds}
-          onReview={() => setStatusFilter("pending")}
+          onReview={handleReviewActivities}
         />
       )}
       {isHealthActivityDeepLink && (

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -900,7 +900,12 @@ const ActivityPage = () => {
 
   return (
     <>
-      <SwipablePage views={views} defaultView="investments" persistKey="activity-page-tab" />
+      <SwipablePage
+        views={views}
+        defaultView="investments"
+        persistKey="activity-page-tab"
+        desktopContentClassName="overflow-y-visible"
+      />
       {sharedModals}
     </>
   );

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -396,7 +396,7 @@ const ActivityPage = () => {
         : source;
 
     return list
-      .filter((acc: Account) => !acc.isArchived)
+      .filter((acc: Account) => !acc.isArchived || acc.id === selectedActivity?.accountId)
       .map((account: Account) => ({
         value: account.id,
         label: account.name,

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -409,6 +409,7 @@ export function ActivityDataGrid({
     onDelete: handleDelete,
     onLinkTransfer: handleRowLinkTransfer,
     onUnlinkTransfer: handleRowUnlinkTransfer,
+    showSubtypeInType: columnVisibility.subtype === false,
     onSymbolSelect: handleSymbolSelect,
     onCreateCustomAsset: handleCreateCustomAsset,
   });

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
@@ -959,6 +959,56 @@ describe("activity-utils", () => {
       expect(result.updates[0].asset).toBeUndefined();
     });
 
+    it("preserves a symbol-backed adjustment asset on unrelated edits", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "adjustment-1",
+          activityType: ActivityType.ADJUSTMENT,
+          assetId: "asset-aapl",
+          assetSymbol: "AAPL",
+          _originalAssetId: "asset-aapl",
+          _originalAssetSymbol: "AAPL",
+        }),
+      ];
+
+      const result = buildSavePayload(
+        transactions,
+        new Set(["adjustment-1"]),
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.updates[0].asset).toEqual(expect.objectContaining({ id: "asset-aapl" }));
+    });
+
+    it("explicitly clears an adjustment asset when its symbol is removed", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "adjustment-1",
+          activityType: ActivityType.ADJUSTMENT,
+          assetId: "",
+          assetSymbol: "",
+          _originalAssetId: "asset-aapl",
+          _originalAssetSymbol: "AAPL",
+        }),
+      ];
+
+      const result = buildSavePayload(
+        transactions,
+        new Set(["adjustment-1"]),
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.updates[0].asset).toEqual({});
+    });
+
     it("should not force account currency for securities transfers", () => {
       const transactions: LocalTransaction[] = [
         createMockTransaction({

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -543,9 +543,13 @@ export function buildSavePayload(
       transaction.activityType === ActivityType.TRANSFER_OUT;
     const supportsBoundary = isTransfer || transaction.activityType === ActivityType.CREDIT;
     const assetSymbol = (transaction.assetSymbol || "").trim();
+    const isSymbolBackedAdjustment =
+      transaction.activityType === ActivityType.ADJUSTMENT && Boolean(assetSymbol);
     const isCash = isTransfer
       ? isCashTransfer(transaction.activityType, assetSymbol) || !assetSymbol
-      : isAlwaysCashActivity(transaction.activityType, transaction.subtype);
+      : transaction.activityType === ActivityType.ADJUSTMENT
+        ? !isSymbolBackedAdjustment
+        : isAlwaysCashActivity(transaction.activityType, transaction.subtype);
     // For assets not in our lookup (new assets), send undefined currency to let the backend
     // derive it from the asset and properly register the FX pair if needed.
     // Only use account currency fallback for cash activities where the currency is deterministic.
@@ -666,6 +670,10 @@ export function buildSavePayload(
             ? undefined
             : transaction.needsReview,
       };
+
+      if (isCash && transaction._originalAssetId) {
+        updatePayload.asset = {};
+      }
 
       if (!isCash) {
         const currentSymbol = (transaction.assetSymbol || "").trim().toUpperCase();

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/data-grid-cell-memo.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/data-grid-cell-memo.test.tsx
@@ -1,0 +1,151 @@
+import { DataGridCell } from "@wealthfolio/ui/components/data-grid/data-grid-cell";
+import type {
+  CellOpts,
+  DataGridCellProps,
+} from "@wealthfolio/ui/components/data-grid/data-grid-types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+interface TestRow {
+  activityType: string;
+  subtype?: string;
+  needsReview?: boolean;
+  amount?: string;
+}
+
+function cellProps(
+  cellOptions: CellOpts,
+  row: TestRow,
+  renderKey: boolean,
+  getRenderKey?: (rowData: TestRow) => string,
+): DataGridCellProps<TestRow> {
+  return {
+    cell: {
+      getValue: () => row.activityType,
+      row: { id: "activity-1", original: row },
+      column: { columnDef: { meta: { cell: cellOptions, renderKey, getRenderKey } } },
+    },
+    tableMeta: {},
+    rowIndex: 0,
+    columnId: "activityType",
+    rowHeight: "short",
+    isFocused: false,
+    isEditing: false,
+    isSelected: false,
+    isSearchMatch: false,
+    isActiveSearchMatch: false,
+    readOnly: false,
+  } as unknown as DataGridCellProps<TestRow>;
+}
+
+describe("DataGridCell memoization", () => {
+  it("re-renders an unchanged value when its column renderer changes", () => {
+    const row = { activityType: "INTEREST" };
+    const visibleSubtypeOptions: CellOpts = {
+      variant: "select",
+      options: [],
+      valueRenderer: () => "Interest",
+    };
+    const hiddenSubtypeOptions: CellOpts = {
+      variant: "select",
+      options: [],
+      valueRenderer: () => "Interest · Staking reward",
+    };
+
+    const { rerender } = render(<DataGridCell {...cellProps(visibleSubtypeOptions, row, false)} />);
+    expect(screen.getByText("Interest")).toBeInTheDocument();
+
+    rerender(<DataGridCell {...cellProps(hiddenSubtypeOptions, row, true)} />);
+    expect(screen.getByText("Interest · Staking reward")).toBeInTheDocument();
+  });
+
+  it("does not re-render for an equivalent options object when the render key is unchanged", () => {
+    const row = { activityType: "INTEREST" };
+    const valueRenderer = vi.fn(() => "Interest");
+    const firstOptions: CellOpts = { variant: "select", options: [], valueRenderer };
+    const equivalentOptions: CellOpts = { variant: "select", options: [], valueRenderer };
+
+    const { rerender } = render(<DataGridCell {...cellProps(firstOptions, row, false)} />);
+    expect(valueRenderer).toHaveBeenCalledTimes(1);
+
+    rerender(<DataGridCell {...cellProps(equivalentOptions, row, false)} />);
+    expect(valueRenderer).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-renders when an opted-in row dependency changes", () => {
+    const valueRenderer = vi.fn((_value, _option, rowData) => {
+      const row = rowData as TestRow;
+      return `Interest · ${row.subtype}`;
+    });
+    const cellOptions: CellOpts = { variant: "select", options: [], valueRenderer };
+    const getRenderKey = (row: TestRow) =>
+      JSON.stringify([row.subtype ?? null, row.needsReview, false]);
+
+    const { rerender } = render(
+      <DataGridCell
+        {...cellProps(
+          cellOptions,
+          { activityType: "INTEREST", subtype: "STAKING_REWARD", needsReview: true },
+          true,
+          getRenderKey,
+        )}
+      />,
+    );
+    expect(screen.getByText("Interest · STAKING_REWARD")).toBeInTheDocument();
+
+    rerender(
+      <DataGridCell
+        {...cellProps(
+          cellOptions,
+          { activityType: "INTEREST", subtype: "CASH_INTEREST", needsReview: true },
+          true,
+          getRenderKey,
+        )}
+      />,
+    );
+
+    expect(screen.getByText("Interest · CASH_INTEREST")).toBeInTheDocument();
+    expect(valueRenderer).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the cell memoized when an unrelated row field changes", () => {
+    const valueRenderer = vi.fn(() => "Interest · Staking reward");
+    const cellOptions: CellOpts = { variant: "select", options: [], valueRenderer };
+    const getRenderKey = (row: TestRow) =>
+      JSON.stringify([row.subtype ?? null, row.needsReview, false]);
+
+    const { rerender } = render(
+      <DataGridCell
+        {...cellProps(
+          cellOptions,
+          {
+            activityType: "INTEREST",
+            subtype: "STAKING_REWARD",
+            needsReview: true,
+            amount: "10",
+          },
+          true,
+          getRenderKey,
+        )}
+      />,
+    );
+
+    rerender(
+      <DataGridCell
+        {...cellProps(
+          cellOptions,
+          {
+            activityType: "INTEREST",
+            subtype: "STAKING_REWARD",
+            needsReview: true,
+            amount: "20",
+          },
+          true,
+          getRenderKey,
+        )}
+      />,
+    );
+
+    expect(valueRenderer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/status-indicator.component.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/status-indicator.component.test.tsx
@@ -1,0 +1,75 @@
+import { ActivityType } from "@/lib/constants";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { StatusHeaderIndicator, StatusIndicator } from "./status-indicator";
+import type { LocalTransaction } from "./types";
+
+vi.mock("@wealthfolio/ui", () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+function transaction(metadata?: Record<string, unknown>): LocalTransaction {
+  return {
+    id: "activity-1",
+    accountId: "account-1",
+    accountName: "Brokerage",
+    accountCurrency: "USD",
+    activityType: ActivityType.BUY,
+    date: new Date("2026-07-29T12:01:00Z"),
+    quantity: "1",
+    unitPrice: "100",
+    amount: "100",
+    fee: null,
+    currency: "USD",
+    needsReview: true,
+    createdAt: new Date("2026-07-29T12:01:00Z"),
+    updatedAt: new Date("2026-07-29T12:01:00Z"),
+    assetId: "asset-1",
+    assetSymbol: "AAPL",
+    metadata,
+  };
+}
+
+describe("StatusIndicator", () => {
+  it("shows provider-supplied reasons in the row tooltip", () => {
+    render(
+      <StatusIndicator
+        transaction={transaction({ mapping_reasons: ["Ambiguous activity type"] })}
+      />,
+    );
+
+    expect(screen.getByText("Ambiguous activity type")).toBeInTheDocument();
+    expect(screen.queryByText("Newly imported &")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Needs Review: Ambiguous activity type",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the generic message when the provider supplied no reasons", () => {
+    render(<StatusIndicator transaction={transaction()} />);
+
+    expect(screen.getByText("Newly imported &")).toBeInTheDocument();
+    expect(screen.getByText("Pending verification")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Needs Review: Newly imported & Pending verification",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("gives the header indicator an accessible description", () => {
+    render(<StatusHeaderIndicator hasRowsToReview />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "Newly imported & Pending verification",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/status-indicator.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/status-indicator.tsx
@@ -1,7 +1,7 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@wealthfolio/ui";
 import { useTranslation } from "react-i18next";
 import type { LocalTransaction } from "./types";
-import { isPendingReview } from "./types";
+import { getProviderMappingReasons, isPendingReview } from "./types";
 
 interface StatusIndicatorProps {
   transaction: LocalTransaction;
@@ -12,14 +12,49 @@ interface StatusIndicatorProps {
  * (synced from broker but not yet approved by the user)
  */
 export function StatusIndicator({ transaction }: StatusIndicatorProps) {
+  const { t } = useTranslation();
+
   if (!isPendingReview(transaction)) {
     return null;
   }
 
+  const mappingReasons = getProviderMappingReasons(transaction);
+  const genericReason = [
+    t("activity:datagrid.status_tooltip_line1"),
+    t("activity:datagrid.status_tooltip_line2"),
+  ].join(" ");
+  const accessibleLabel = `${t("activity:detail.needs_review")}: ${
+    mappingReasons.length > 0 ? mappingReasons.join("; ") : genericReason
+  }`;
+
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <div className="text-destructive w-full cursor-help text-center">●</div>
-    </div>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={accessibleLabel}
+            className="text-destructive focus-visible:ring-ring flex size-full cursor-help items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-2"
+          >
+            <span aria-hidden="true">●</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="max-w-80">
+          {mappingReasons.length > 0 ? (
+            <ul className="list-disc space-y-1 pl-4">
+              {mappingReasons.map((reason) => (
+                <li key={reason}>{reason}</li>
+              ))}
+            </ul>
+          ) : (
+            <>
+              <p>{t("activity:datagrid.status_tooltip_line1")}</p>
+              <p>{t("activity:datagrid.status_tooltip_line2")}</p>
+            </>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -37,11 +72,22 @@ export function StatusHeaderIndicator({ hasRowsToReview }: StatusHeaderIndicator
     return null;
   }
 
+  const accessibleLabel = [
+    t("activity:datagrid.status_tooltip_line1"),
+    t("activity:datagrid.status_tooltip_line2"),
+  ].join(" ");
+
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="text-destructive w-full cursor-help text-center">●</div>
+          <button
+            type="button"
+            aria-label={accessibleLabel}
+            className="text-destructive focus-visible:ring-ring w-full cursor-help rounded-sm text-center focus-visible:outline-none focus-visible:ring-2"
+          >
+            <span aria-hidden="true">●</span>
+          </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
           <p>{t("activity:datagrid.status_tooltip_line1")}</p>

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { ActivityDetails } from "@/lib/types";
 
-import { toLocalTransaction } from "./types";
+import { getProviderMappingReasons, toLocalTransaction } from "./types";
 
 function activityWithBoundary(isExternal?: boolean): ActivityDetails {
   return {
@@ -34,5 +34,32 @@ describe("toLocalTransaction", () => {
 
   it("keeps a missing boundary distinct from explicit false", () => {
     expect(toLocalTransaction(activityWithBoundary()).isExternal).toBeUndefined();
+  });
+});
+
+describe("getProviderMappingReasons", () => {
+  it("returns provider-supplied mapping reasons", () => {
+    expect(
+      getProviderMappingReasons({
+        metadata: {
+          mapping_reasons: ["Ambiguous activity type", "Manual review requested"],
+        },
+      }),
+    ).toEqual(["Ambiguous activity type", "Manual review requested"]);
+  });
+
+  it("ignores malformed, blank, and duplicate reasons", () => {
+    expect(
+      getProviderMappingReasons({
+        metadata: {
+          mapping_reasons: [" Unknown mapping ", "Unknown mapping", "", null, 42],
+        },
+      }),
+    ).toEqual(["Unknown mapping"]);
+  });
+
+  it("returns no reasons when the provider supplied none", () => {
+    expect(getProviderMappingReasons({})).toEqual([]);
+    expect(getProviderMappingReasons({ metadata: { mapping_reasons: "Unknown" } })).toEqual([]);
   });
 });

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
@@ -197,7 +197,7 @@ export interface ActivityCreatePayload extends ActivityBasePayload {
  * - Or send asset.symbol + asset.exchangeMic to re-resolve the asset
  */
 export interface ActivityUpdatePayload extends ActivityBasePayload {
-  /** Asset resolution input - id plus natural identity and creation hints */
+  /** Omit to preserve, provide identity to replace, or pass {} to clear. */
   asset?: AssetResolutionInput;
   /** Explicit review patch; false approves a flagged activity. */
   needsReview?: boolean;

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
@@ -76,6 +76,23 @@ export function isPendingReview(transaction: LocalTransaction): boolean {
 }
 
 /**
+ * Returns the review reasons supplied by the broker mapping service.
+ */
+export function getProviderMappingReasons(activity: Pick<ActivityDetails, "metadata">): string[] {
+  const reasons = activity.metadata?.mapping_reasons;
+  if (!Array.isArray(reasons)) {
+    return [];
+  }
+
+  const normalizedReasons = reasons
+    .filter((reason): reason is string => typeof reason === "string")
+    .map((reason) => reason.trim())
+    .filter(Boolean);
+
+  return [...new Set(normalizedReasons)];
+}
+
+/**
  * Tracks the state of changes to transactions
  */
 export interface TransactionChangeState {

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shouldDisplaySubtypeInTypeColumn } from "./use-activity-columns";
+
+describe("shouldDisplaySubtypeInTypeColumn", () => {
+  it("hides the subtype from Type when the Subtype column is visible", () => {
+    expect(shouldDisplaySubtypeInTypeColumn(false, undefined, "INTEREST", "STAKING_REWARD")).toBe(
+      false,
+    );
+  });
+
+  it("shows the subtype with Type when the Subtype column is hidden", () => {
+    expect(shouldDisplaySubtypeInTypeColumn(true, undefined, "INTEREST", "STAKING_REWARD")).toBe(
+      true,
+    );
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
@@ -68,6 +68,13 @@ const shouldDisplaySubtype = (
   );
 };
 
+export const shouldDisplaySubtypeInTypeColumn = (
+  showSubtypeInType: boolean,
+  transaction: LocalTransaction | undefined,
+  activityType: string | undefined,
+  subtype: string | null | undefined,
+): boolean => showSubtypeInType && shouldDisplaySubtype(transaction, activityType, subtype);
+
 const getSubtypeDisplayLabel = (t: TFunction, subtype: string, optionLabel?: string): string => {
   return optionLabel ?? localizeActivitySubtypeName(t, subtype);
 };
@@ -79,6 +86,7 @@ interface UseActivityColumnsOptions {
   onDelete: (activity: ActivityDetails) => void;
   onLinkTransfer?: (activity: ActivityDetails) => void;
   onUnlinkTransfer?: (activity: ActivityDetails) => void;
+  showSubtypeInType: boolean;
   /** Called when a symbol is selected from search, with the full result including exchangeMic */
   onSymbolSelect?: (rowIndex: number, result: SymbolSearchResult) => void;
   /** Called when user wants to create a custom asset. Opens a dialog to collect asset metadata. */
@@ -95,6 +103,7 @@ export function useActivityColumns({
   onDelete,
   onLinkTransfer,
   onUnlinkTransfer,
+  showSubtypeInType,
   onSymbolSelect,
   onCreateCustomAsset,
 }: UseActivityColumnsOptions) {
@@ -200,6 +209,16 @@ export function useActivityColumns({
         size: 150,
         enablePinning: false,
         meta: {
+          renderKey: showSubtypeInType,
+          getRenderKey: (rowData) => {
+            if (!showSubtypeInType) return null;
+            const transaction = rowData as LocalTransaction;
+            return JSON.stringify([
+              transaction.subtype ?? null,
+              transaction.needsReview,
+              transaction.isNew === true,
+            ]);
+          },
           cell: {
             variant: "select",
             options: activityTypeOptions,
@@ -210,7 +229,11 @@ export function useActivityColumns({
               return (
                 <ActivityTypeBadge
                   type={value as ActivityType}
-                  subtype={shouldDisplaySubtype(transaction, value, subtype) ? subtype : undefined}
+                  subtype={
+                    shouldDisplaySubtypeInTypeColumn(showSubtypeInType, transaction, value, subtype)
+                      ? subtype
+                      : undefined
+                  }
                   className="text-xs font-normal"
                 />
               );
@@ -473,6 +496,7 @@ export function useActivityColumns({
       onLinkTransfer,
       onUnlinkTransfer,
       onSymbolSelect,
+      showSubtypeInType,
       t,
     ],
   );

--- a/apps/frontend/src/pages/activity/components/activity-detail-sheet.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-detail-sheet.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ActivityReviewReasons } from "./activity-detail-sheet";
+
+describe("ActivityReviewReasons", () => {
+  it("shows provider-supplied reasons for an activity needing review", () => {
+    render(
+      <ActivityReviewReasons
+        activity={{
+          needsReview: true,
+          metadata: {
+            mapping_reasons: ["Provider could not supply a market value"],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Needs Review")).toBeInTheDocument();
+    expect(screen.getByText("Provider could not supply a market value")).toBeInTheDocument();
+  });
+
+  it("does not show stale provider reasons after review is complete", () => {
+    render(
+      <ActivityReviewReasons
+        activity={{
+          needsReview: false,
+          metadata: { mapping_reasons: ["Previously required review"] },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Previously required review")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-detail-sheet.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-detail-sheet.tsx
@@ -17,6 +17,7 @@ import {
 } from "@wealthfolio/ui";
 import { AmountDisplay } from "@wealthfolio/ui/components/financial/amount-display";
 import { useTranslation } from "react-i18next";
+import { getProviderMappingReasons } from "./activity-data-grid/types";
 
 /** An activity with no stored amount booked no cash; rendering `Number(null)`
  * would claim it moved exactly zero. */
@@ -77,6 +78,32 @@ function DetailSection({ title, icon, children }: DetailSectionProps) {
       </div>
       <div className="bg-muted/30 rounded-lg border p-3">{children}</div>
     </div>
+  );
+}
+
+export function ActivityReviewReasons({
+  activity,
+}: {
+  activity: Pick<ActivityDetails, "metadata" | "needsReview">;
+}) {
+  const { t } = useTranslation();
+  const reviewReasons = getProviderMappingReasons(activity);
+
+  if (!activity.needsReview || reviewReasons.length === 0) {
+    return null;
+  }
+
+  return (
+    <DetailSection
+      title={t("activity:detail.needs_review")}
+      icon={<Icons.AlertCircle className="text-warning h-4 w-4" />}
+    >
+      <ul className="list-disc space-y-1 pl-5 text-sm">
+        {reviewReasons.map((reason) => (
+          <li key={reason}>{reason}</li>
+        ))}
+      </ul>
+    </DetailSection>
   );
 }
 
@@ -189,6 +216,8 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
               </div>
             </div>
           </div>
+
+          <ActivityReviewReasons activity={activity} />
 
           {/* Transaction Details */}
           <DetailSection

--- a/apps/frontend/src/pages/activity/components/activity-form.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-form.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ActivityType } from "@/lib/constants";
+import type { AccountSelectOption } from "./forms/fields";
+import { ActivityForm } from "./activity-form";
+
+const { useActivityFormMock } = vi.hoisted(() => ({
+  useActivityFormMock: vi.fn(),
+}));
+
+vi.mock("../hooks/use-activity-form", () => ({
+  useActivityForm: (params: unknown) => useActivityFormMock(params),
+}));
+
+vi.mock("./activity-form-renderer", () => ({
+  ActivityFormRenderer: ({ accounts }: { accounts: AccountSelectOption[] }) => (
+    <div data-testid="rendered-account-ids">
+      {accounts.map((account) => account.value).join(",")}
+    </div>
+  ),
+}));
+
+vi.mock("./activity-type-picker", () => ({
+  ActivityTypePicker: () => null,
+}));
+
+const accounts: AccountSelectOption[] = [
+  {
+    value: "current-account",
+    label: "Current account",
+    currency: "USD",
+    restrictionLevel: "blocked",
+  },
+  {
+    value: "eligible-account",
+    label: "Eligible account",
+    currency: "USD",
+    restrictionLevel: "none",
+  },
+  {
+    value: "other-blocked-account",
+    label: "Other blocked account",
+    currency: "USD",
+    restrictionLevel: "blocked",
+  },
+];
+
+describe("ActivityForm account filtering", () => {
+  beforeEach(() => {
+    useActivityFormMock.mockReturnValue({
+      defaultValues: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      handleSubmit: vi.fn(),
+    });
+  });
+
+  it("keeps the activity's current restricted account available while editing", () => {
+    render(
+      <ActivityForm
+        open
+        accounts={accounts}
+        activity={{
+          id: "credit-activity",
+          accountId: "current-account",
+          activityType: ActivityType.CREDIT,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("rendered-account-ids")).toHaveTextContent(
+      "current-account,eligible-account",
+    );
+  });
+
+  it("continues to exclude restricted accounts when creating an activity", () => {
+    render(
+      <ActivityForm open accounts={accounts} activity={{ activityType: ActivityType.CREDIT }} />,
+    );
+
+    expect(screen.getByTestId("rendered-account-ids")).toHaveTextContent("eligible-account");
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-form.tsx
@@ -72,11 +72,18 @@ export function ActivityForm({
     const base =
       effectiveSelectedType === "TRANSFER" && transferAccounts ? transferAccounts : accounts;
     if (!effectiveSelectedType) return base;
+    const currentAccountId = isEditing ? activity?.accountId : undefined;
     if (effectiveSelectedType === "TRANSFER") {
-      return base.filter(transferAllowsAccount);
+      return base.filter(
+        (account) => account.value === currentAccountId || transferAllowsAccount(account),
+      );
     }
-    return base.filter((acc) => restrictionAllowsType(acc.restrictionLevel, effectiveSelectedType));
-  }, [accounts, transferAccounts, effectiveSelectedType]);
+    return base.filter(
+      (account) =>
+        account.value === currentAccountId ||
+        restrictionAllowsType(account.restrictionLevel, effectiveSelectedType),
+    );
+  }, [accounts, transferAccounts, effectiveSelectedType, isEditing, activity?.accountId]);
 
   // Use the activity form hook with the effective type
   const { defaultValues, isLoading, isError, error, handleSubmit } = useActivityForm({

--- a/apps/frontend/src/pages/activity/components/activity-type-picker.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-type-picker.tsx
@@ -23,8 +23,12 @@ export type SecondaryActivityType =
   | typeof CanonicalActivityType.SPLIT
   | typeof CanonicalActivityType.FEE
   | typeof CanonicalActivityType.INTEREST
-  | typeof CanonicalActivityType.TAX;
-export type ActivityType = PrimaryActivityType | SecondaryActivityType;
+  | typeof CanonicalActivityType.TAX
+  | typeof CanonicalActivityType.CREDIT;
+export type ActivityType =
+  | PrimaryActivityType
+  | SecondaryActivityType
+  | typeof CanonicalActivityType.ADJUSTMENT;
 
 interface ActivityTypeConfig<T extends string> {
   value: T;
@@ -54,6 +58,11 @@ const SECONDARY_ACTIVITY_TYPES: ActivityTypeConfig<SecondaryActivityType>[] = [
   { value: CanonicalActivityType.FEE, labelKey: "activity:type_fee", icon: "Receipt" },
   { value: CanonicalActivityType.INTEREST, labelKey: "activity:type_interest", icon: "Percent" },
   { value: CanonicalActivityType.TAX, labelKey: "activity:type_tax", icon: "ReceiptText" },
+  {
+    value: CanonicalActivityType.CREDIT,
+    labelKey: "activity:type_credit",
+    icon: "BadgeDollarSign",
+  },
 ];
 
 const ALL_ACTIVITY_TYPES = [...PRIMARY_ACTIVITY_TYPES, ...SECONDARY_ACTIVITY_TYPES];

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
@@ -9,11 +9,220 @@ import { splitFormSchema } from "../split-form";
 import { feeFormSchema } from "../fee-form";
 import { interestFormSchema, type InterestFormValues } from "../interest-form";
 import { taxFormSchema } from "../tax-form";
+import { CreditForm, creditFormSchema, type CreditFormValues } from "../credit-form";
+import {
+  AdjustmentForm,
+  adjustmentFormSchema,
+  type AdjustmentFormValues,
+} from "../adjustment-form";
 import { newActivitySchema } from "../schemas";
 import { ACTIVITY_FORM_CONFIG } from "../../../config/activity-form-config";
 import { ACTIVITY_SUBTYPES, ActivityType, METADATA_CONTRACT_MULTIPLIER } from "@/lib/constants";
 
 describe("Form Schemas Validation", () => {
+  describe("adjustment form", () => {
+    it("is registered as an editable desktop activity", () => {
+      expect(ACTIVITY_FORM_CONFIG.ADJUSTMENT.component).toBe(AdjustmentForm);
+    });
+
+    it("accepts calculation-neutral cash adjustments without an asset", () => {
+      const result = adjustmentFormSchema.safeParse({
+        adjustmentMode: "cash",
+        accountId: "acc-123",
+        activityDate: new Date(),
+        amount: 0,
+        currency: "USD",
+        subtype: "CASH_SWEEP",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires a symbol for security adjustments", () => {
+      const result = adjustmentFormSchema.safeParse({
+        adjustmentMode: "securities",
+        accountId: "acc-123",
+        activityDate: new Date(),
+        quantity: 1,
+        unitPrice: 0,
+        currency: "USD",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ path: ["assetId"] })]),
+        );
+      }
+    });
+
+    it("requires positive quantity for option expiry", () => {
+      const result = adjustmentFormSchema.safeParse({
+        adjustmentMode: "securities",
+        accountId: "acc-123",
+        activityDate: new Date(),
+        assetId: "AAPL260116C00200000",
+        quantity: 0,
+        unitPrice: 0,
+        currency: "USD",
+        subtype: ACTIVITY_SUBTYPES.OPTION_EXPIRY,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ path: ["quantity"] })]),
+        );
+      }
+    });
+
+    it("rejects option expiry for a known non-option security", () => {
+      const result = adjustmentFormSchema.safeParse({
+        adjustmentMode: "securities",
+        accountId: "acc-123",
+        activityDate: new Date(),
+        assetId: "AAPL",
+        symbolInstrumentType: "EQUITY",
+        quantity: 1,
+        unitPrice: 0,
+        currency: "USD",
+        subtype: ACTIVITY_SUBTYPES.OPTION_EXPIRY,
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ path: ["assetId"] })]),
+        );
+      }
+    });
+
+    it("derives cash and security edit modes without losing imported values", () => {
+      const cashDefaults = ACTIVITY_FORM_CONFIG.ADJUSTMENT.getDefaults(
+        {
+          activityType: ActivityType.ADJUSTMENT,
+          accountId: "acc-123",
+          date: new Date(),
+          amount: "0",
+          currency: "USD",
+          subtype: "CASH_SWEEP",
+        },
+        [],
+      ) as AdjustmentFormValues;
+      const securityDefaults = ACTIVITY_FORM_CONFIG.ADJUSTMENT.getDefaults(
+        {
+          activityType: ActivityType.ADJUSTMENT,
+          accountId: "acc-123",
+          date: new Date(),
+          assetId: "asset-option",
+          assetSymbol: "AAPL260116C00200000",
+          instrumentType: "OPTION",
+          quantity: "1",
+          unitPrice: "0",
+          amount: "0",
+          currency: "USD",
+          subtype: ACTIVITY_SUBTYPES.OPTION_EXPIRY,
+        },
+        [],
+      ) as AdjustmentFormValues;
+
+      expect(cashDefaults).toMatchObject({
+        adjustmentMode: "cash",
+        amount: 0,
+        subtype: "CASH_SWEEP",
+      });
+      expect(securityDefaults).toMatchObject({
+        adjustmentMode: "securities",
+        assetId: "AAPL260116C00200000",
+        quantity: 1,
+        unitPrice: 0,
+        subtype: ACTIVITY_SUBTYPES.OPTION_EXPIRY,
+        symbolInstrumentType: "OPTION",
+      });
+    });
+
+    it("treats a cash placeholder symbol as cash even when it has an opaque asset id", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.ADJUSTMENT.getDefaults(
+        {
+          activityType: ActivityType.ADJUSTMENT,
+          accountId: "acc-123",
+          date: new Date(),
+          assetId: "opaque-cash-asset-id",
+          assetSymbol: "$CASH-USD",
+          amount: "10",
+          currency: "USD",
+        },
+        [],
+      ) as AdjustmentFormValues;
+
+      expect(defaults).toMatchObject({
+        adjustmentMode: "cash",
+        amount: 10,
+        assetId: null,
+      });
+    });
+
+    it("clears asset fields when a security adjustment is changed to cash", () => {
+      const payload = ACTIVITY_FORM_CONFIG.ADJUSTMENT.toPayload({
+        adjustmentMode: "cash",
+        accountId: "acc-123",
+        activityDate: new Date(),
+        amount: 0,
+        assetId: "AAPL",
+        existingAssetId: "asset-aapl",
+        quantity: 2,
+        unitPrice: 100,
+        currency: "USD",
+        quoteMode: "MARKET",
+      } as AdjustmentFormValues) as Record<string, unknown>;
+
+      expect(payload).toMatchObject({ amount: 0, quantity: null, unitPrice: null });
+      expect(payload.assetId).toBeUndefined();
+      expect(payload).not.toHaveProperty("existingAssetId");
+    });
+  });
+
+  describe("credit form", () => {
+    it("is registered as an editable desktop activity", () => {
+      expect(ACTIVITY_FORM_CONFIG.CREDIT.component).toBe(CreditForm);
+    });
+
+    it("accepts a credit with a provider-supplied subtype", () => {
+      const result = creditFormSchema.safeParse({
+        accountId: "acc-123",
+        activityDate: new Date(),
+        amount: 25,
+        currency: "USD",
+        subtype: ACTIVITY_SUBTYPES.REBATE,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("preserves the subtype in defaults and payload", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.CREDIT.getDefaults(
+        {
+          activityType: ActivityType.CREDIT,
+          accountId: "acc-123",
+          date: new Date(),
+          amount: "25",
+          currency: "USD",
+          subtype: ACTIVITY_SUBTYPES.REBATE,
+        },
+        [],
+      ) as CreditFormValues;
+
+      expect(defaults).toMatchObject({
+        amount: 25,
+        subtype: ACTIVITY_SUBTYPES.REBATE,
+      });
+      expect(ACTIVITY_FORM_CONFIG.CREDIT.toPayload(defaults)).toMatchObject({
+        amount: 25,
+        subtype: ACTIVITY_SUBTYPES.REBATE,
+      });
+    });
+  });
+
   it("uses the asset-owned option multiplier in trade edit defaults", () => {
     for (const activityType of [ActivityType.BUY, ActivityType.SELL] as const) {
       const defaults = ACTIVITY_FORM_CONFIG[activityType].getDefaults(

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/simple-forms.test.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/simple-forms.test.tsx
@@ -5,6 +5,7 @@ import { WithdrawalForm } from "../withdrawal-form";
 import { FeeForm } from "../fee-form";
 import { InterestForm } from "../interest-form";
 import { TaxForm } from "../tax-form";
+import { AdjustmentForm } from "../adjustment-form";
 import type { AccountSelectOption } from "../fields";
 
 // Mock useSettings hook to avoid AuthProvider dependency
@@ -49,8 +50,19 @@ vi.mock("../fields", () => ({
       <textarea data-testid={`textarea-${name}`} name={name} id={name} />
     </div>
   ),
-  AdvancedOptionsSection: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="advanced-options-section">{children}</div>
+  AdvancedOptionsSection: ({
+    children,
+    subtypeOptions,
+  }: {
+    children?: React.ReactNode;
+    subtypeOptions?: readonly string[];
+  }) => (
+    <div data-testid="advanced-options-section">
+      {subtypeOptions?.map((option) => (
+        <span key={option}>{option}</span>
+      ))}
+      {children}
+    </div>
   ),
   FormSection: ({ action, children }: { action?: React.ReactNode; children?: React.ReactNode }) => (
     <div data-testid="form-section">
@@ -146,6 +158,66 @@ const mockAccounts: AccountSelectOption[] = [
   { value: "acc-1", label: "Savings Account", currency: "USD" },
   { value: "acc-2", label: "Investment Account", currency: "EUR" },
 ];
+
+describe("AdjustmentForm", () => {
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders cash adjustment fields by default", () => {
+    render(<AdjustmentForm accounts={mockAccounts} onSubmit={mockOnSubmit} isEditing />);
+
+    expect(screen.getByTestId("select-accountId")).toBeInTheDocument();
+    expect(screen.getByTestId("date-picker-activityDate")).toBeInTheDocument();
+    expect(screen.getByTestId("input-amount")).toBeInTheDocument();
+    expect(screen.queryByTestId("symbol-search-assetId")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+  });
+
+  it("renders security fields when selected", async () => {
+    const user = userEvent.setup();
+    render(<AdjustmentForm accounts={mockAccounts} onSubmit={mockOnSubmit} isEditing />);
+
+    await user.click(screen.getByRole("button", { name: /securities/i }));
+
+    expect(screen.getByTestId("symbol-search-assetId")).toBeInTheDocument();
+    expect(screen.getByTestId("input-quantity")).toBeInTheDocument();
+    expect(screen.getByTestId("input-unitPrice")).toBeInTheDocument();
+    expect(screen.getByTestId("input-amount")).toBeInTheDocument();
+  });
+
+  it("offers option expiry only for option securities", () => {
+    const baseDefaults = {
+      adjustmentMode: "securities" as const,
+      accountId: "acc-2",
+      activityDate: new Date(),
+      assetId: "AAPL",
+      currency: "USD",
+    };
+    const equityForm = render(
+      <AdjustmentForm
+        accounts={mockAccounts}
+        defaultValues={{ ...baseDefaults, symbolInstrumentType: "EQUITY" }}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    expect(screen.queryByText("OPTION_EXPIRY")).not.toBeInTheDocument();
+    equityForm.unmount();
+
+    render(
+      <AdjustmentForm
+        accounts={mockAccounts}
+        defaultValues={{ ...baseDefaults, symbolInstrumentType: "OPTION" }}
+        onSubmit={mockOnSubmit}
+      />,
+    );
+
+    expect(screen.getByText("OPTION_EXPIRY")).toBeInTheDocument();
+  });
+});
 
 describe("WithdrawalForm", () => {
   const mockOnSubmit = vi.fn();

--- a/apps/frontend/src/pages/activity/components/forms/adjustment-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/adjustment-form.tsx
@@ -1,0 +1,354 @@
+import { useSettings } from "@/hooks/use-settings";
+import { ACTIVITY_SUBTYPES, ActivityType, InstrumentType, QuoteMode } from "@/lib/constants";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AnimatedToggleGroup } from "@wealthfolio/ui/components/ui/animated-toggle-group";
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import type { TFunction } from "i18next";
+import { useMemo } from "react";
+import { FormProvider, useForm, type Resolver } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import {
+  AccountSelect,
+  AdvancedOptionsSection,
+  AmountInput,
+  createValidatedSubmit,
+  DatePicker,
+  FormSection,
+  NotesInput,
+  QuantityInput,
+  SymbolSearch,
+  type AccountSelectOption,
+} from "./fields";
+
+export type AdjustmentMode = "cash" | "securities";
+
+type MsgFn = TFunction | undefined;
+const msg = (t: MsgFn, key: string, en: string) => (t ? t(key) : en);
+
+const assetMetadataSchema = z
+  .object({
+    name: z.string().nullable().optional(),
+    kind: z.string().nullable().optional(),
+    exchangeMic: z.string().nullable().optional(),
+    providerId: z.string().nullable().optional(),
+    providerSymbol: z.string().nullable().optional(),
+  })
+  .optional();
+
+export const createAdjustmentFormSchema = (t?: TFunction) =>
+  z
+    .object({
+      adjustmentMode: z.enum(["cash", "securities"]).default("cash"),
+      accountId: z.string().min(1, {
+        message: msg(t, "activity:form.err_select_account", "Please select an account."),
+      }),
+      activityDate: z.date({
+        required_error: msg(t, "activity:form.err_select_date", "Please select a date."),
+      }),
+      amount: z.coerce
+        .number({
+          invalid_type_error: msg(t, "activity:form.err_amount_number", "Amount must be a number."),
+        })
+        .nonnegative({
+          message: msg(t, "activity:form.err_amount_non_negative", "Amount must be non-negative."),
+        })
+        .optional()
+        .nullable(),
+      assetId: z.string().optional().nullable(),
+      existingAssetId: z.string().nullable().optional(),
+      quantity: z.coerce
+        .number({
+          invalid_type_error: msg(
+            t,
+            "activity:form.err_quantity_number",
+            "Quantity must be a number.",
+          ),
+        })
+        .nonnegative()
+        .optional()
+        .nullable(),
+      unitPrice: z.coerce
+        .number({
+          invalid_type_error: msg(t, "activity:form.err_price_number", "Price must be a number."),
+        })
+        .nonnegative()
+        .optional()
+        .nullable(),
+      comment: z.string().optional().nullable(),
+      currency: z.string().min(1, {
+        message: msg(t, "activity:form.err_currency_required", "Currency is required."),
+      }),
+      fxRate: z.coerce
+        .number({
+          invalid_type_error: msg(
+            t,
+            "activity:form.err_fxrate_number",
+            "FX Rate must be a number.",
+          ),
+        })
+        .positive({
+          message: msg(t, "activity:form.err_fxrate_positive", "FX Rate must be positive."),
+        })
+        .optional(),
+      subtype: z.string().optional().nullable(),
+      quoteMode: z.enum([QuoteMode.MARKET, QuoteMode.MANUAL]).default(QuoteMode.MARKET),
+      exchangeMic: z.string().nullable().optional(),
+      symbolQuoteCcy: z.string().nullable().optional(),
+      symbolInstrumentType: z.string().nullable().optional(),
+      assetMetadata: assetMetadataSchema,
+    })
+    .superRefine((data, ctx) => {
+      if (data.adjustmentMode === "securities" && !data.assetId?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["assetId"],
+          message: msg(t, "activity:form.err_select_symbol", "Please select a symbol."),
+        });
+      }
+
+      if (data.subtype?.trim().toUpperCase() === ACTIVITY_SUBTYPES.OPTION_EXPIRY) {
+        if (data.adjustmentMode !== "securities") {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["assetId"],
+            message: msg(t, "activity:form.err_select_symbol", "Please select a symbol."),
+          });
+        }
+        if (
+          data.symbolInstrumentType?.trim() &&
+          data.symbolInstrumentType.trim().toUpperCase() !== InstrumentType.OPTION
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["assetId"],
+            message: msg(
+              t,
+              "activity:form.err_option_type_required",
+              "An option asset is required.",
+            ),
+          });
+        }
+        if (!(data.quantity != null && data.quantity > 0)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["quantity"],
+            message: msg(t, "activity:form.err_enter_quantity", "Please enter a quantity."),
+          });
+        }
+      }
+    });
+
+export const adjustmentFormSchema = createAdjustmentFormSchema();
+
+export type AdjustmentFormValues = z.infer<typeof adjustmentFormSchema>;
+
+interface AdjustmentFormProps {
+  accounts: AccountSelectOption[];
+  defaultValues?: Partial<AdjustmentFormValues>;
+  onSubmit: (data: AdjustmentFormValues) => void | Promise<void>;
+  onCancel?: () => void;
+  isLoading?: boolean;
+  isEditing?: boolean;
+}
+
+export function AdjustmentForm({
+  accounts,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+  isEditing = false,
+}: AdjustmentFormProps) {
+  const { t } = useTranslation(["activity"]);
+  const { data: settings } = useSettings();
+  const baseCurrency = settings?.baseCurrency;
+  const schema = useMemo(() => createAdjustmentFormSchema(t), [t]);
+
+  const initialAccountId =
+    defaultValues?.accountId ?? (accounts.length === 1 ? accounts[0].value : "");
+  const initialAccount = accounts.find((account) => account.value === initialAccountId);
+  const initialCurrency = defaultValues?.currency?.trim() || initialAccount?.currency;
+
+  const form = useForm<AdjustmentFormValues>({
+    resolver: zodResolver(schema) as Resolver<AdjustmentFormValues>,
+    mode: "onSubmit",
+    defaultValues: {
+      adjustmentMode: "cash",
+      accountId: initialAccountId,
+      activityDate: new Date(),
+      amount: null,
+      assetId: null,
+      quantity: null,
+      unitPrice: null,
+      comment: null,
+      fxRate: undefined,
+      subtype: null,
+      quoteMode: QuoteMode.MARKET,
+      ...defaultValues,
+      currency: defaultValues?.currency?.trim() || initialCurrency,
+    },
+  });
+
+  const adjustmentMode = form.watch("adjustmentMode");
+  const accountId = form.watch("accountId");
+  const currency = form.watch("currency");
+  const subtype = form.watch("subtype");
+  const symbolInstrumentType = form.watch("symbolInstrumentType");
+  const selectedAccount = useMemo(
+    () => accounts.find((account) => account.value === accountId),
+    [accounts, accountId],
+  );
+  const accountCurrency = selectedAccount?.currency;
+  const isCashMode = adjustmentMode === "cash";
+  const subtypeOptions = useMemo(() => {
+    const currentSubtype = subtype?.trim();
+    const isCurrentOptionExpiry = currentSubtype?.toUpperCase() === ACTIVITY_SUBTYPES.OPTION_EXPIRY;
+    const canSelectOptionExpiry =
+      symbolInstrumentType?.trim().toUpperCase() === InstrumentType.OPTION || isCurrentOptionExpiry;
+    const options: string[] = canSelectOptionExpiry
+      ? [isCurrentOptionExpiry && currentSubtype ? currentSubtype : ACTIVITY_SUBTYPES.OPTION_EXPIRY]
+      : [];
+    if (currentSubtype && !options.includes(currentSubtype)) {
+      return [currentSubtype, ...options];
+    }
+    return options;
+  }, [subtype, symbolInstrumentType]);
+
+  const handleModeChange = (mode: AdjustmentMode) => {
+    form.setValue("adjustmentMode", mode, { shouldValidate: false });
+    if (mode === "cash") {
+      form.setValue("assetId", null);
+      form.setValue("existingAssetId", undefined);
+      form.setValue("exchangeMic", undefined);
+      form.setValue("symbolQuoteCcy", undefined);
+      form.setValue("symbolInstrumentType", undefined);
+      form.setValue("assetMetadata", undefined);
+      form.setValue("quantity", null);
+      form.setValue("unitPrice", null);
+      if (subtype?.trim().toUpperCase() === ACTIVITY_SUBTYPES.OPTION_EXPIRY) {
+        form.setValue("subtype", null);
+      }
+    }
+  };
+
+  const handleSubmit = createValidatedSubmit(form, async (data) => {
+    if (data.adjustmentMode === "securities" && !data.symbolQuoteCcy && data.currency) {
+      data.symbolQuoteCcy = data.currency;
+    }
+    await onSubmit(data);
+  });
+
+  const modeItems = [
+    { value: "cash" as const, label: t("activity:form.transfer_mode_cash") },
+    { value: "securities" as const, label: t("activity:form.transfer_mode_securities") },
+  ];
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormSection
+          title={t("activity:type_adjustment")}
+          action={
+            <AnimatedToggleGroup
+              items={modeItems}
+              value={adjustmentMode}
+              onValueChange={handleModeChange}
+              size="sm"
+              rounded="lg"
+            />
+          }
+        >
+          <AccountSelect name="accountId" accounts={accounts} currencyName="currency" />
+          <DatePicker name="activityDate" label={t("activity:field_date")} />
+        </FormSection>
+
+        <FormSection
+          title={
+            isCashMode ? t("activity:form.section_amount") : t("activity:form.section_securities")
+          }
+        >
+          {isCashMode ? (
+            <AmountInput
+              name="amount"
+              label={t("activity:form.label_amount")}
+              currency={currency}
+            />
+          ) : (
+            <>
+              <SymbolSearch
+                name="assetId"
+                isManualAsset={form.watch("quoteMode") === QuoteMode.MANUAL}
+                exchangeMicName="exchangeMic"
+                quoteModeName="quoteMode"
+                currencyName="currency"
+                quoteCcyName="symbolQuoteCcy"
+                instrumentTypeName="symbolInstrumentType"
+                existingAssetIdName="existingAssetId"
+                assetMetadataName="assetMetadata"
+              />
+              <input type="hidden" {...form.register("assetMetadata.name")} />
+              <input type="hidden" {...form.register("assetMetadata.kind")} />
+              <input type="hidden" {...form.register("symbolQuoteCcy")} />
+              <input type="hidden" {...form.register("symbolInstrumentType")} />
+              <input type="hidden" {...form.register("existingAssetId")} />
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <QuantityInput name="quantity" label={t("activity:form.label_quantity")} />
+                <AmountInput
+                  name="unitPrice"
+                  label={t("activity:form.label_price")}
+                  currency={currency}
+                  maxDecimalPlaces={4}
+                />
+              </div>
+              <AmountInput
+                name="amount"
+                label={t("activity:form.label_amount")}
+                currency={currency}
+              />
+            </>
+          )}
+        </FormSection>
+
+        <AdvancedOptionsSection
+          title={t("activity:form.section_advanced_notes")}
+          dashed
+          currencyName="currency"
+          fxRateName="fxRate"
+          subtypeName="subtype"
+          activityType={ActivityType.ADJUSTMENT}
+          subtypeOptions={subtypeOptions}
+          accountCurrency={accountCurrency}
+          baseCurrency={baseCurrency}
+          showSubtype={!isCashMode}
+        >
+          <NotesInput
+            name="comment"
+            label={t("activity:form.label_notes")}
+            placeholder={t("activity:form.placeholder_note")}
+          />
+        </AdvancedOptionsSection>
+
+        <div className="flex justify-end gap-2">
+          {onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
+              {t("activity:cancel")}
+            </Button>
+          )}
+          <Button type="submit" disabled={isLoading}>
+            {isLoading && <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />}
+            {isEditing ? (
+              <Icons.Check className="mr-2 h-4 w-4" />
+            ) : (
+              <Icons.Plus className="mr-2 h-4 w-4" />
+            )}
+            {isEditing
+              ? t("activity:form.button_update")
+              : t("activity:form.button_add_prefixed", { action: t("activity:type_adjustment") })}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/apps/frontend/src/pages/activity/components/forms/credit-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/credit-form.tsx
@@ -1,0 +1,164 @@
+import { useSettings } from "@/hooks/use-settings";
+import { ActivityType } from "@/lib/constants";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import type { TFunction } from "i18next";
+import { useMemo } from "react";
+import { FormProvider, useForm, type Resolver } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { z } from "zod";
+import {
+  AccountSelect,
+  AdvancedOptionsSection,
+  AmountInput,
+  createValidatedSubmit,
+  DatePicker,
+  FormSection,
+  NotesInput,
+  type AccountSelectOption,
+} from "./fields";
+
+type MsgFn = TFunction | undefined;
+const msg = (t: MsgFn, key: string, en: string) => (t ? t(key) : en);
+
+export const createCreditFormSchema = (t?: TFunction) =>
+  z.object({
+    accountId: z
+      .string()
+      .min(1, { message: msg(t, "activity:form.err_select_account", "Please select an account.") }),
+    activityDate: z.date({
+      required_error: msg(t, "activity:form.err_select_date", "Please select a date."),
+    }),
+    amount: z.coerce
+      .number({
+        required_error: msg(t, "activity:form.err_enter_amount", "Please enter an amount."),
+        invalid_type_error: msg(t, "activity:form.err_amount_number", "Amount must be a number."),
+      })
+      .min(0, {
+        message: msg(t, "activity:form.err_amount_non_negative", "Amount must be non-negative."),
+      }),
+    comment: z.string().optional().nullable(),
+    currency: z
+      .string()
+      .min(1, { message: msg(t, "activity:form.err_currency_required", "Currency is required.") }),
+    fxRate: z.coerce
+      .number({
+        invalid_type_error: msg(t, "activity:form.err_fxrate_number", "FX Rate must be a number."),
+      })
+      .positive({
+        message: msg(t, "activity:form.err_fxrate_positive", "FX Rate must be positive."),
+      })
+      .optional(),
+    subtype: z.string().optional().nullable(),
+  });
+
+export const creditFormSchema = createCreditFormSchema();
+
+export type CreditFormValues = z.infer<typeof creditFormSchema>;
+
+interface CreditFormProps {
+  accounts: AccountSelectOption[];
+  defaultValues?: Partial<CreditFormValues>;
+  onSubmit: (data: CreditFormValues) => void | Promise<void>;
+  onCancel?: () => void;
+  isLoading?: boolean;
+  isEditing?: boolean;
+}
+
+export function CreditForm({
+  accounts,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+  isEditing = false,
+}: CreditFormProps) {
+  const { t } = useTranslation(["activity"]);
+  const { data: settings } = useSettings();
+  const baseCurrency = settings?.baseCurrency;
+  const schema = useMemo(() => createCreditFormSchema(t), [t]);
+
+  const initialAccountId =
+    defaultValues?.accountId ?? (accounts.length === 1 ? accounts[0].value : "");
+  const initialAccount = accounts.find((account) => account.value === initialAccountId);
+  const initialCurrency = defaultValues?.currency?.trim() || initialAccount?.currency;
+
+  const form = useForm<CreditFormValues>({
+    resolver: zodResolver(schema) as Resolver<CreditFormValues>,
+    mode: "onSubmit",
+    defaultValues: {
+      accountId: initialAccountId,
+      activityDate: new Date(),
+      amount: undefined,
+      comment: null,
+      fxRate: undefined,
+      subtype: null,
+      ...defaultValues,
+      currency: defaultValues?.currency?.trim() || initialCurrency,
+    },
+  });
+
+  const accountId = form.watch("accountId");
+  const currency = form.watch("currency");
+  const selectedAccount = useMemo(
+    () => accounts.find((account) => account.value === accountId),
+    [accounts, accountId],
+  );
+  const accountCurrency = selectedAccount?.currency;
+
+  const handleSubmit = createValidatedSubmit(form, async (data) => {
+    await onSubmit(data);
+  });
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormSection title={t("activity:form.section_account")}>
+          <AccountSelect name="accountId" accounts={accounts} currencyName="currency" />
+          <DatePicker name="activityDate" label={t("activity:field_date")} />
+        </FormSection>
+
+        <FormSection title={t("activity:form.section_amount")}>
+          <AmountInput name="amount" label={t("activity:form.label_amount")} currency={currency} />
+        </FormSection>
+
+        <AdvancedOptionsSection
+          title={t("activity:form.section_advanced_notes")}
+          dashed
+          currencyName="currency"
+          fxRateName="fxRate"
+          subtypeName="subtype"
+          activityType={ActivityType.CREDIT}
+          accountCurrency={accountCurrency}
+          baseCurrency={baseCurrency}
+        >
+          <NotesInput
+            name="comment"
+            label={t("activity:form.label_notes")}
+            placeholder={t("activity:form.placeholder_note")}
+          />
+        </AdvancedOptionsSection>
+
+        <div className="flex justify-end gap-2">
+          {onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
+              {t("activity:cancel")}
+            </Button>
+          )}
+          <Button type="submit" disabled={isLoading}>
+            {isLoading && <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />}
+            {isEditing ? (
+              <Icons.Check className="mr-2 h-4 w-4" />
+            ) : (
+              <Icons.Plus className="mr-2 h-4 w-4" />
+            )}
+            {isEditing
+              ? t("activity:form.button_update")
+              : t("activity:form.button_add_prefixed", { action: t("activity:type_credit") })}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -795,14 +795,19 @@ export function MobileActivityForm({
         );
         const currentAssetId =
           wasAssetBackedIncome && !isAssetBackedIncome ? undefined : activity?.assetId;
+        const clearAsset = Boolean(
+          activity?.assetId && wasAssetBackedIncome && !isAssetBackedIncome,
+        );
 
         await updateActivityMutation.mutateAsync({
           id,
           ...submitData,
           currentAssetId,
+          clearAsset,
         } as NewActivityFormValues & {
           id: string;
           currentAssetId?: string;
+          clearAsset?: boolean;
         });
       } else {
         await addActivityMutation.mutateAsync(submitData);

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -6,7 +6,7 @@ import {
   METADATA_CONTRACT_MULTIPLIER,
   QuoteMode,
 } from "@/lib/constants";
-import { isSecuritiesTransfer } from "@/lib/activity-utils";
+import { isCashSymbol, isSecuritiesTransfer } from "@/lib/activity-utils";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import type { ActivityDetails } from "@/lib/types";
 import { BuyForm, type BuyFormValues } from "../components/forms/buy-form";
@@ -19,6 +19,8 @@ import { SplitForm, type SplitFormValues } from "../components/forms/split-form"
 import { FeeForm, type FeeFormValues } from "../components/forms/fee-form";
 import { InterestForm, type InterestFormValues } from "../components/forms/interest-form";
 import { TaxForm, type TaxFormValues } from "../components/forms/tax-form";
+import { CreditForm, type CreditFormValues } from "../components/forms/credit-form";
+import { AdjustmentForm, type AdjustmentFormValues } from "../components/forms/adjustment-form";
 import type { AccountSelectOption } from "../components/forms/fields";
 import type { NewActivityFormValues } from "../components/forms/schemas";
 
@@ -33,7 +35,9 @@ export type PickerActivityType =
   | typeof ActivityType.SPLIT
   | typeof ActivityType.FEE
   | typeof ActivityType.INTEREST
-  | typeof ActivityType.TAX;
+  | typeof ActivityType.TAX
+  | typeof ActivityType.CREDIT
+  | typeof ActivityType.ADJUSTMENT;
 
 // Form values union type
 export type ActivityFormValues =
@@ -46,7 +50,9 @@ export type ActivityFormValues =
   | SplitFormValues
   | FeeFormValues
   | InterestFormValues
-  | TaxFormValues;
+  | TaxFormValues
+  | CreditFormValues
+  | AdjustmentFormValues;
 
 // Common form props interface
 export interface ActivityFormComponentProps<T> {
@@ -98,6 +104,19 @@ function selectedExistingAsset(
 
   const id = existingAssetId?.trim();
   return id ? { existingAssetId: id } : {};
+}
+
+function hasConcreteAdjustmentAsset(
+  assetSymbol: string | null | undefined,
+  assetId: string | null | undefined,
+): boolean {
+  const symbol = assetSymbol?.trim();
+  if (symbol) {
+    return symbol.toUpperCase() !== "CASH" && !isCashSymbol(symbol);
+  }
+
+  const id = assetId?.trim();
+  return Boolean(id && id.toUpperCase() !== "CASH" && !isCashSymbol(id));
 }
 
 // Configuration for each activity type
@@ -580,6 +599,85 @@ export const ACTIVITY_FORM_CONFIG: Record<
         exchangeMic: d.exchangeMic ?? undefined,
         symbolQuoteCcy: d.symbolQuoteCcy ?? undefined,
         symbolInstrumentType: d.symbolInstrumentType ?? undefined,
+      };
+    },
+  },
+
+  CREDIT: {
+    component: CreditForm as ComponentType<ActivityFormComponentProps<ActivityFormValues>>,
+    activityType: ActivityType.CREDIT,
+    getDefaults: (activity, accounts) => ({
+      ...getBaseDefaults(activity, accounts),
+      amount: absNum(activity?.amount),
+      currency: activity?.currency,
+      fxRate: activity?.fxRate ?? undefined,
+      subtype: activity?.subtype ?? null,
+    }),
+    toPayload: (data) => {
+      const d = data as CreditFormValues;
+      return {
+        accountId: d.accountId,
+        activityDate: d.activityDate,
+        amount: d.amount,
+        comment: d.comment,
+        currency: d.currency,
+        fxRate: d.fxRate,
+        subtype: d.subtype,
+      };
+    },
+  },
+
+  ADJUSTMENT: {
+    component: AdjustmentForm as ComponentType<ActivityFormComponentProps<ActivityFormValues>>,
+    activityType: ActivityType.ADJUSTMENT,
+    getDefaults: (activity, accounts) => {
+      const isSecurity = hasConcreteAdjustmentAsset(activity?.assetSymbol, activity?.assetId);
+      return {
+        ...getBaseDefaults(activity, accounts),
+        adjustmentMode: isSecurity ? "securities" : "cash",
+        amount: absNum(activity?.amount),
+        assetId: isSecurity ? (activity?.assetSymbol ?? activity?.assetId ?? null) : null,
+        quantity: isSecurity ? (absNum(activity?.quantity) ?? null) : null,
+        unitPrice: isSecurity ? (absNum(activity?.unitPrice) ?? null) : null,
+        currency: activity?.currency,
+        fxRate: activity?.fxRate ?? undefined,
+        subtype: activity?.subtype ?? null,
+        quoteMode:
+          activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        exchangeMic: activity?.exchangeMic,
+        symbolInstrumentType: activity?.instrumentType,
+      };
+    },
+    toPayload: (data) => {
+      const d = data as AdjustmentFormValues;
+      const isSecurity = d.adjustmentMode === "securities";
+      return {
+        accountId: d.accountId,
+        activityDate: d.activityDate,
+        amount: d.amount ?? null,
+        assetId: isSecurity ? d.assetId?.trim() || undefined : undefined,
+        ...(isSecurity &&
+          selectedExistingAsset(d.assetId, d.existingAssetId, d.symbolInstrumentType)),
+        quantity: isSecurity ? (d.quantity ?? null) : null,
+        unitPrice: isSecurity ? (d.unitPrice ?? null) : null,
+        comment: d.comment,
+        currency: d.currency,
+        fxRate: d.fxRate,
+        subtype: d.subtype ?? null,
+        quoteMode: isSecurity ? d.quoteMode : undefined,
+        exchangeMic: isSecurity ? (d.exchangeMic ?? undefined) : undefined,
+        symbolQuoteCcy: isSecurity ? (d.symbolQuoteCcy ?? undefined) : undefined,
+        symbolInstrumentType: isSecurity ? (d.symbolInstrumentType ?? undefined) : undefined,
+        assetMetadata:
+          isSecurity && d.assetMetadata
+            ? {
+                name: d.assetMetadata.name ?? undefined,
+                kind: d.assetMetadata.kind ?? undefined,
+                exchangeMic: d.assetMetadata.exchangeMic ?? undefined,
+                providerId: d.assetMetadata.providerId ?? undefined,
+                providerSymbol: d.assetMetadata.providerSymbol ?? undefined,
+              }
+            : undefined,
       };
     },
   },

--- a/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import type { AccountSelectOption } from "../components/forms/fields";
 import type { NewActivityFormValues } from "../components/forms/schemas";
 import type { TransferFormValues } from "../components/forms/transfer-form";
+import type { AdjustmentFormValues } from "../components/forms/adjustment-form";
 import {
   ACTIVITY_FORM_CONFIG,
   type ActivityFormValues,
@@ -355,9 +356,14 @@ export function useActivityForm({
         }
 
         if (isEditing && activity?.id) {
+          const currentAssetId =
+            selectedType === ActivityType.ADJUSTMENT &&
+            (formData as AdjustmentFormValues).adjustmentMode === "cash"
+              ? undefined
+              : activity.assetId;
           await updateActivityMutation.mutateAsync({
             id: activity.id,
-            currentAssetId: activity.assetId,
+            currentAssetId,
             ...submitData,
           } as NewActivityFormValues & { id: string; currentAssetId?: string });
         } else {

--- a/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
@@ -361,11 +361,21 @@ export function useActivityForm({
             (formData as AdjustmentFormValues).adjustmentMode === "cash"
               ? undefined
               : activity.assetId;
+          const clearAsset = Boolean(
+            activity.assetId &&
+            selectedType === ActivityType.ADJUSTMENT &&
+            (formData as AdjustmentFormValues).adjustmentMode === "cash",
+          );
           await updateActivityMutation.mutateAsync({
             id: activity.id,
             currentAssetId,
+            clearAsset,
             ...submitData,
-          } as NewActivityFormValues & { id: string; currentAssetId?: string });
+          } as NewActivityFormValues & {
+            id: string;
+            currentAssetId?: string;
+            clearAsset?: boolean;
+          });
         } else {
           await addActivityMutation.mutateAsync(submitData);
         }

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.test.tsx
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.test.tsx
@@ -99,6 +99,27 @@ describe("useActivityMutations", () => {
     );
   });
 
+  it("sends an explicit empty asset patch when an edit clears the asset", async () => {
+    const { result } = renderHook(() => useActivityMutations(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.updateActivityMutation.mutateAsync({
+        id: "adjustment-1",
+        accountId: "acc-1",
+        activityType: ActivityType.ADJUSTMENT,
+        activityDate: new Date("2026-04-30T16:00:00Z"),
+        amount: 25,
+        currency: "USD",
+        currentAssetId: "asset-aapl",
+        clearAsset: true,
+      } as any);
+    });
+
+    expect(adapterMocks.updateActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ asset: {} }),
+    );
+  });
+
   it("ignores stale selected asset id for option identities", async () => {
     const { result } = renderHook(() => useActivityMutations(), { wrapper: createWrapper() });
 

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
@@ -195,6 +195,7 @@ export function useActivityMutations(
       const {
         assetId,
         currentAssetId,
+        clearAsset,
         exchangeMic,
         metadata,
         assetMetadata,
@@ -216,6 +217,7 @@ export function useActivityMutations(
         id: string;
         assetId?: string;
         currentAssetId?: string;
+        clearAsset?: boolean;
         exchangeMic?: string;
         metadata?: Record<string, unknown>;
         assetMetadata?: {
@@ -256,18 +258,20 @@ export function useActivityMutations(
         fee: toDecimalPayload(fee),
         tax: toDecimalPayload(tax),
         fxRate: toDecimalPayload(fxRate),
-        asset: buildActivityAssetInput({
-          assetId,
-          existingAssetId,
-          currentAssetId,
-          exchangeMic,
-          quoteMode,
-          assetKind,
-          assetMetadata,
-          symbolQuoteCcy,
-          symbolInstrumentType,
-          includeId: true,
-        }),
+        asset: clearAsset
+          ? {}
+          : buildActivityAssetInput({
+              assetId,
+              existingAssetId,
+              currentAssetId,
+              exchangeMic,
+              quoteMode,
+              assetKind,
+              assetMetadata,
+              symbolQuoteCcy,
+              symbolInstrumentType,
+              includeId: true,
+            }),
         // Serialize metadata object to JSON string for backend
         metadata: metadata ? JSON.stringify(metadata) : undefined,
       };

--- a/apps/frontend/src/pages/activity/import/activity-import-page.tsx
+++ b/apps/frontend/src/pages/activity/import/activity-import-page.tsx
@@ -1,6 +1,6 @@
 import { getAccounts, logger } from "@/adapters";
 import { usePlatform } from "@/hooks/use-platform";
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { shouldResolveImportAsset } from "@/lib/activity-utils";
 import { canImportCSV } from "@/lib/activity-restrictions";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Account } from "@/lib/types";
@@ -247,10 +247,7 @@ function useStepValidation(
                   csvActivityType,
                   mapping.activityMappings || {},
                 );
-                if (
-                  mappedType &&
-                  (!needsImportAssetResolution(mappedType, csvSubtype) || isCashSymbol(symbol))
-                ) {
+                if (mappedType && !shouldResolveImportAsset(mappedType, csvSubtype, symbol)) {
                   return;
                 }
               }

--- a/apps/frontend/src/pages/activity/import/components/import-columns.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-columns.tsx
@@ -4,9 +4,9 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { Checkbox, type SymbolSearchResult } from "@wealthfolio/ui";
 import { ActivityType, INSTRUMENT_TYPE_OPTIONS, SUBTYPES_BY_ACTIVITY_TYPE } from "@/lib/constants";
 import {
+  isAssetIdentityRequired,
   localizeActivitySubtypeName,
   localizeActivityTypeName,
-  needsImportAssetResolution,
   supportsPerformanceBoundary,
 } from "@/lib/activity-utils";
 import { ActivityTypeBadge } from "../../components/activity-type-badge";
@@ -272,7 +272,7 @@ export function useImportColumns<T extends ImportRowData>({
           onCreateCustomAsset,
           isClearable: (rowData: unknown) => {
             const row = rowData as ImportRowData;
-            return !needsImportAssetResolution(row.activityType ?? "", row.subtype);
+            return !isAssetIdentityRequired(row.activityType ?? "", row.subtype);
           },
         },
       },

--- a/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
@@ -15,9 +15,9 @@ import {
 
 import { ActivityType, INSTRUMENT_TYPE_OPTIONS, SUBTYPES_BY_ACTIVITY_TYPE } from "@/lib/constants";
 import {
+  isAssetIdentityRequired,
   localizeActivitySubtypeName,
   localizeActivityTypeName,
-  needsImportAssetResolution,
   supportsPerformanceBoundary,
 } from "@/lib/activity-utils";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
@@ -354,7 +354,7 @@ function useImportReviewColumns({
             onCreateCustomAsset,
             isClearable: (rowData: unknown) => {
               const row = rowData as DraftActivity;
-              return !needsImportAssetResolution(row.activityType ?? "", row.subtype);
+              return !isAssetIdentityRequired(row.activityType ?? "", row.subtype);
             },
           },
         },

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -12,7 +12,7 @@ import {
   type SymbolSearchResult,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { shouldResolveImportAsset } from "@/lib/activity-utils";
 import {
   Badge,
   SearchableSelect,
@@ -440,7 +440,7 @@ export function MappingCell({
     const csvType = getMappedValue(row, ImportFormat.ACTIVITY_TYPE)?.trim();
     const csvSubtype = getMappedValue(row, ImportFormat.SUBTYPE)?.trim();
     const appType = csvType ? findMappedActivityType(csvType, mapping.activityMappings) : null;
-    if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
+    if (appType && !shouldResolveImportAsset(appType, csvSubtype, symbol)) {
       return <span className="text-muted-foreground text-xs">-</span>;
     }
 

--- a/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
@@ -46,7 +46,7 @@ import {
   sanitizeImportMappingForProfile,
 } from "../utils/activity-import-profile";
 
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { shouldResolveImportAsset } from "@/lib/activity-utils";
 import { ImportFormat, type ActivityType } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Account, CsvRowData, ImportTemplateData } from "@/lib/types";
@@ -222,7 +222,7 @@ export function MappingStepUnified() {
         ? findMappedActivityType(csvType, effectiveActivityMappings || {})
         : null;
 
-      if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
+      if (appType && !shouldResolveImportAsset(appType, csvSubtype, symbol)) {
         return;
       }
 
@@ -384,7 +384,7 @@ export function MappingStepUnified() {
         ? findMappedActivityType(csvType, effectiveActivityMappings || {})
         : null;
 
-      if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
+      if (appType && !shouldResolveImportAsset(appType, csvSubtype, symbol)) {
         return;
       }
       if (validateTickerSymbol(symbol) || localMapping.symbolMappings?.[symbol]) return;

--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -1,4 +1,4 @@
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { shouldResolveImportAsset } from "@/lib/activity-utils";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { ActivityType } from "@/lib/constants";
 import { getQuoteUnitCurrency } from "@wealthfolio/ui/lib/currencies";
@@ -158,10 +158,7 @@ export function buildImportAssetCandidateFromDraft(
   if (!draft.symbol || !draft.activityType) {
     return null;
   }
-  if (
-    !needsImportAssetResolution(draft.activityType, draft.subtype) ||
-    isCashSymbol(draft.symbol)
-  ) {
+  if (!shouldResolveImportAsset(draft.activityType, draft.subtype, draft.symbol)) {
     return null;
   }
   if (!draft.accountId) {

--- a/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
@@ -59,6 +59,21 @@ describe("import asset rules", () => {
     expect(candidate?.symbol).toBe("AAPL");
   });
 
+  it.each(["----", "$FOO"])(
+    "does not build an asset candidate for adjustment placeholder %s",
+    (symbol) => {
+      const candidate = buildImportAssetCandidateFromDraft(
+        createDraft({
+          activityType: ActivityType.ADJUSTMENT,
+          subtype: "CASH_SWEEP",
+          symbol,
+        }),
+      );
+
+      expect(candidate).toBeNull();
+    },
+  );
+
   it("keeps otherwise identical candidates distinct when their ISIN differs", () => {
     const first = buildImportAssetCandidateFromDraft(
       createDraft({

--- a/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
@@ -45,6 +45,20 @@ describe("import asset rules", () => {
     expect(candidate?.symbol).toBe("SOL");
   });
 
+  it("builds asset candidates for symbol-backed adjustments", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        activityType: ActivityType.ADJUSTMENT,
+        subtype: "CORPORATE_ACTION",
+        symbol: "AAPL",
+        instrumentType: "EQUITY",
+      }),
+    );
+
+    expect(candidate).not.toBeNull();
+    expect(candidate?.symbol).toBe("AAPL");
+  });
+
   it("keeps otherwise identical candidates distinct when their ISIN differs", () => {
     const first = buildImportAssetCandidateFromDraft(
       createDraft({

--- a/apps/frontend/src/pages/activity/utils/activity-form-utils.ts
+++ b/apps/frontend/src/pages/activity/utils/activity-form-utils.ts
@@ -7,6 +7,7 @@ const PURE_CASH_ACTIVITY_TYPES: readonly string[] = [
   ActivityType.FEE,
   ActivityType.INTEREST,
   ActivityType.TAX,
+  ActivityType.CREDIT,
 ];
 
 /**

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -302,6 +302,23 @@ pub struct AssetResolutionInput {
     pub provider_symbol: Option<String>,
 }
 
+impl AssetResolutionInput {
+    /// An empty object is the explicit PATCH representation for removing an
+    /// activity's optional asset. Omitting the object preserves the asset.
+    pub fn is_empty(&self) -> bool {
+        self.id.is_none()
+            && self.symbol.is_none()
+            && self.exchange_mic.is_none()
+            && self.kind.is_none()
+            && self.name.is_none()
+            && self.quote_mode.is_none()
+            && self.quote_ccy.is_none()
+            && self.instrument_type.is_none()
+            && self.provider_id.is_none()
+            && self.provider_symbol.is_none()
+    }
+}
+
 /// Input model for creating a new activity
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -310,7 +327,7 @@ pub struct NewActivity {
     pub account_id: String,
 
     /// Asset resolution input. Accepts the old `symbol` JSON field during transition.
-    /// Optional for cash activities which don't require an asset
+    /// Optional for cash activities which don't require an asset.
     #[serde(alias = "symbol")]
     pub asset: Option<AssetResolutionInput>,
 
@@ -575,8 +592,9 @@ pub struct ActivityUpdate {
     pub id: String,
     pub account_id: String,
 
-    /// Asset resolution input. Accepts the old `symbol` JSON field during transition.
-    /// Optional for cash activities which don't require an asset
+    /// Asset patch. Omit to preserve, provide identity to replace, or provide
+    /// an empty object to explicitly clear an optional asset. Accepts the old
+    /// `symbol` JSON field during transition.
     #[serde(alias = "symbol")]
     pub asset: Option<AssetResolutionInput>,
 

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -476,6 +476,19 @@ impl ActivityService {
         activity: &mut ActivityUpdate,
         existing: &Activity,
     ) -> Result<()> {
+        // PATCH semantics: omission preserves the current asset. Hydrate the
+        // existing id before validation/resolution; an explicit empty object
+        // remains empty and is handled as a clear by the repository.
+        if activity.asset.is_none() {
+            activity.asset = existing
+                .asset_id
+                .as_ref()
+                .map(|asset_id| AssetResolutionInput {
+                    id: Some(asset_id.clone()),
+                    ..Default::default()
+                });
+        }
+
         // A metadata patch carries only the keys its writer owns (e.g. the
         // option form's contract multiplier); merge it over the stored blob
         // so unrelated keys - the migration's legacy_amount breadcrumb,
@@ -505,10 +518,13 @@ impl ActivityService {
             Some(subtype) => Some(subtype),
             None => existing.subtype.as_deref(),
         };
-        let effective_asset_id = activity
-            .get_symbol_id()
-            .map(str::to_string)
-            .or_else(|| existing.asset_id.clone());
+        let effective_asset_id = match activity.asset.as_ref() {
+            Some(asset) if asset.is_empty() => None,
+            _ => activity
+                .get_symbol_id()
+                .map(str::to_string)
+                .or_else(|| existing.asset_id.clone()),
+        };
         let is_security_transfer =
             is_securities_transfer(&activity.activity_type, effective_asset_id.as_deref());
         let quantity = activity
@@ -696,7 +712,10 @@ impl ActivityService {
         if activity.amount.is_some() {
             return false;
         }
-        let asset_id = activity.get_symbol_id().or(existing.asset_id.as_deref());
+        let asset_id = match activity.asset.as_ref() {
+            Some(asset) if asset.is_empty() => None,
+            _ => activity.get_symbol_id().or(existing.asset_id.as_deref()),
+        };
         if !is_securities_transfer(&activity.activity_type, asset_id)
             || self.is_bond_asset(asset_id)
         {
@@ -2942,6 +2961,21 @@ impl ActivityService {
         let base_ccy = self.account_service.get_base_currency().unwrap_or_default();
         let account_currency = resolve_currency(&[&account.currency, &base_ccy]);
         let currency = resolve_currency(&[&activity.currency, &account_currency]);
+
+        if activity.asset.as_ref().is_some_and(|asset| {
+            !asset.is_empty()
+                && asset.id.as_deref().is_none_or(|id| id.trim().is_empty())
+                && asset
+                    .symbol
+                    .as_deref()
+                    .is_none_or(|symbol| symbol.trim().is_empty())
+        }) {
+            return Err(ActivityError::InvalidData(
+                "Asset updates need either asset_id or symbol; use an empty asset object to clear"
+                    .to_string(),
+            )
+            .into());
+        }
 
         if activity.activity_type == ACTIVITY_TYPE_SPLIT {
             activity.amount = activity.amount.map(|v| v.map(|d| d.abs()));

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -41,7 +41,8 @@ use std::sync::{Arc, RwLock};
 use crate::accounts::{account_types, Account, AccountServiceTrait};
 use crate::activities::activities_constants::{
     classify_import_activity, is_cash_symbol, is_garbage_symbol, is_securities_transfer,
-    requires_final_cash_amount, requires_symbol, ImportSymbolDisposition, ACTIVITY_TYPE_BUY,
+    requires_final_cash_amount, requires_symbol, ImportSymbolDisposition,
+    ACTIVITY_SUBTYPE_OPTION_EXPIRY, ACTIVITY_TYPE_ADJUSTMENT, ACTIVITY_TYPE_BUY,
     ACTIVITY_TYPE_CREDIT, ACTIVITY_TYPE_FEE, ACTIVITY_TYPE_INTEREST, ACTIVITY_TYPE_SELL,
     ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TAX, ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT,
     ACTIVITY_TYPE_WITHDRAWAL, PRICE_BEARING_ACTIVITY_TYPES,
@@ -803,6 +804,11 @@ impl ActivityService {
     }
 
     fn requires_asset_identity(activity_type: &str, subtype: Option<&str>) -> bool {
+        if activity_type.eq_ignore_ascii_case(ACTIVITY_TYPE_ADJUSTMENT) {
+            return subtype.is_some_and(|subtype| {
+                subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_OPTION_EXPIRY)
+            });
+        }
         requires_symbol(activity_type)
             || NewActivity::is_asset_backed_income_subtype(activity_type, subtype)
     }

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -754,7 +754,7 @@ impl ActivityService {
         activity
     }
 
-    fn downgrade_unresolvable_sync_asset_income(activity: &mut NewActivity) {
+    fn prepare_incomplete_sync_asset_income_for_review(activity: &mut NewActivity) {
         if activity.amount.is_none() {
             activity.amount = ActivityEconomicsResolver::calculate_composite_final_cash(
                 &activity.activity_type,
@@ -764,11 +764,9 @@ impl ActivityService {
                 Decimal::ONE,
             );
         }
-
-        activity.subtype = None;
     }
 
-    fn sync_asset_income_needs_downgrade(
+    fn sync_asset_income_needs_review(
         activity: &NewActivity,
         resolved_asset_id: Option<&str>,
     ) -> bool {
@@ -6575,9 +6573,9 @@ impl ActivityService {
             }
 
             if mode.is_sync()
-                && Self::sync_asset_income_needs_downgrade(&activity, resolved_asset_id.as_deref())
+                && Self::sync_asset_income_needs_review(&activity, resolved_asset_id.as_deref())
             {
-                Self::downgrade_unresolvable_sync_asset_income(&mut activity);
+                Self::prepare_incomplete_sync_asset_income_for_review(&mut activity);
                 sync_review_indices.insert(idx);
             }
 

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -6277,7 +6277,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sync_prepare_keeps_incomplete_valid_asset_backed_subtype_for_review() {
+    async fn test_sync_prepare_preserves_incomplete_asset_backed_subtype_for_review() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());
         let fx_service = Arc::new(MockFxService::new());
@@ -6329,11 +6329,82 @@ mod tests {
         assert_eq!(result.prepared.len(), 1);
         let prepared = &result.prepared[0].activity;
         assert_eq!(prepared.activity_type, "INTEREST");
-        assert_eq!(prepared.subtype, None);
+        assert_eq!(prepared.subtype.as_deref(), Some("STAKING_REWARD"));
         assert_eq!(prepared.amount, Some(dec!(25)));
         assert_eq!(prepared.quantity, None);
         assert_eq!(prepared.needs_review, Some(true));
         assert_eq!(prepared.status, Some(ActivityStatus::Draft));
+    }
+
+    #[tokio::test]
+    async fn test_sync_prepare_preserves_zero_value_staking_reward_subtype_for_review() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "CAD");
+        account_service.add_account(account.clone());
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "SOL",
+            "SOL",
+            None,
+            Some(InstrumentType::Crypto),
+            "CAD",
+        ));
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("activity-staking-sol".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: Some(AssetResolutionInput {
+                        id: Some("SOL".to_string()),
+                        ..Default::default()
+                    }),
+                    activity_type: "INTEREST".to_string(),
+                    subtype: Some("STAKING_REWARD".to_string()),
+                    activity_date: "2024-06-04".to_string(),
+                    quantity: Some(dec!(0.000000329)),
+                    unit_price: Some(dec!(0)),
+                    currency: "CAD".to_string(),
+                    fee: Some(dec!(0)),
+                    tax: None,
+                    amount: Some(dec!(0)),
+                    status: None,
+                    notes: Some("SOL Staking Reward".to_string()),
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: Some(false),
+                    source_system: Some("SNAPTRADE".to_string()),
+                    source_record_id: Some("c243110e-9bac-581d-b2d7-0c490ee06870".to_string()),
+                    source_group_id: None,
+                    idempotency_key: None,
+                    import_run_id: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("sync preparation should keep zero-value staking rewards for review");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        let prepared = &result.prepared[0];
+        assert_eq!(prepared.resolved_asset_id.as_deref(), Some("SOL"));
+        assert_eq!(prepared.activity.subtype.as_deref(), Some("STAKING_REWARD"));
+        assert_eq!(prepared.activity.quantity, Some(dec!(0.000000329)));
+        assert_eq!(prepared.activity.unit_price, Some(dec!(0)));
+        assert_eq!(prepared.activity.amount, Some(dec!(0)));
+        assert_eq!(prepared.activity.needs_review, Some(true));
+        assert_eq!(prepared.activity.status, Some(ActivityStatus::Draft));
     }
 
     #[tokio::test]
@@ -6392,7 +6463,7 @@ mod tests {
         assert_eq!(result.prepared.len(), 1);
         let prepared = &result.prepared[0];
         assert_eq!(prepared.resolved_asset_id, None);
-        assert_eq!(prepared.activity.subtype, None);
+        assert_eq!(prepared.activity.subtype.as_deref(), Some("STAKING_REWARD"));
         assert_eq!(prepared.activity.amount, Some(dec!(25.00)));
         assert_eq!(prepared.activity.needs_review, Some(true));
         assert_eq!(prepared.activity.status, Some(ActivityStatus::Draft));

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -7233,6 +7233,98 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_cash_adjustment_without_asset_can_be_saved() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let created = activity_service
+            .create_activity(NewActivity {
+                id: Some("cash-adjustment".to_string()),
+                account_id: "acc-1".to_string(),
+                asset: None,
+                activity_type: "ADJUSTMENT".to_string(),
+                subtype: Some("CASH_SWEEP".to_string()),
+                activity_date: "2024-01-15".to_string(),
+                quantity: None,
+                unit_price: None,
+                currency: "USD".to_string(),
+                fee: None,
+                tax: None,
+                amount: Some(Decimal::ZERO),
+                status: None,
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+                needs_review: None,
+                source_system: None,
+                source_record_id: None,
+                source_group_id: None,
+                idempotency_key: None,
+                import_run_id: None,
+            })
+            .await
+            .expect("cash-style adjustments should not require an asset");
+
+        assert_eq!(created.asset_id, None);
+        assert_eq!(created.subtype.as_deref(), Some("CASH_SWEEP"));
+        assert_eq!(created.amount, Some(Decimal::ZERO));
+    }
+
+    #[tokio::test]
+    async fn test_option_expiry_adjustment_without_asset_is_rejected() {
+        let account_service = Arc::new(MockAccountService::new());
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        let activity_service = ActivityService::new(
+            Arc::new(MockActivityRepository::new()),
+            account_service,
+            Arc::new(MockAssetService::new()),
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+
+        let error = activity_service
+            .create_activity(NewActivity {
+                id: Some("option-expiry".to_string()),
+                account_id: "acc-1".to_string(),
+                asset: None,
+                activity_type: "ADJUSTMENT".to_string(),
+                subtype: Some("OPTION_EXPIRY".to_string()),
+                activity_date: "2024-01-15".to_string(),
+                quantity: Some(Decimal::ONE),
+                unit_price: Some(Decimal::ZERO),
+                currency: "USD".to_string(),
+                fee: None,
+                tax: None,
+                amount: Some(Decimal::ZERO),
+                status: None,
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+                needs_review: None,
+                source_system: None,
+                source_record_id: None,
+                source_group_id: None,
+                idempotency_key: None,
+                import_run_id: None,
+            })
+            .await
+            .expect_err("option expiry still requires an asset");
+
+        assert!(error.to_string().contains("asset_id or symbol"));
+    }
+
     /// Test: Cash activity (WITHDRAWAL) has no asset_id
     #[tokio::test]
     async fn test_resolve_asset_id_cash_withdrawal_no_asset() {

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -1466,10 +1466,12 @@ mod tests {
                 .iter_mut()
                 .find(|activity| activity.id == activity_update.id)
                 .ok_or_else(|| Error::Unexpected("Activity not found".to_string()))?;
-            let asset_id = activity_update.get_symbol_id().map(|s| s.to_string());
+            let asset_id_patch = activity_update.asset.as_ref().map(|asset| asset.id.clone());
 
             existing.account_id = activity_update.account_id;
-            existing.asset_id = asset_id;
+            if let Some(asset_id) = asset_id_patch {
+                existing.asset_id = asset_id;
+            }
             existing.activity_type = activity_update.activity_type;
             existing.activity_date = parse_test_activity_datetime(&activity_update.activity_date);
             existing.subtype = match activity_update.subtype {
@@ -5450,7 +5452,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_bulk_update_preserves_existing_asset_backed_subtype_when_omitted() {
+    async fn test_bulk_update_preserves_existing_asset_and_subtype_when_omitted() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());
         let fx_service = Arc::new(MockFxService::new());
@@ -5482,15 +5484,7 @@ mod tests {
             quote_service,
         );
 
-        let mut update = create_test_activity_update(
-            "staking-1",
-            "acc-1",
-            Some(AssetResolutionInput {
-                id: Some("ETH".to_string()),
-                ..Default::default()
-            }),
-            "USD",
-        );
+        let mut update = create_test_activity_update("staking-1", "acc-1", None, "USD");
         update.activity_type = "INTEREST".to_string();
         update.subtype = None;
         update.quantity = None;
@@ -5508,9 +5502,60 @@ mod tests {
 
         assert!(result.errors.is_empty());
         assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0].asset_id.as_deref(), Some("ETH"));
         assert_eq!(result.updated[0].subtype.as_deref(), Some("STAKING_REWARD"));
         assert_eq!(result.updated[0].quantity, Some(dec!(1)));
         assert_eq!(result.updated[0].unit_price, Some(dec!(100)));
+    }
+
+    #[tokio::test]
+    async fn test_update_requires_explicit_clear_and_rejects_clear_for_required_asset() {
+        let account_service = Arc::new(MockAccountService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+        account_service.add_account(create_test_account("acc-1", "USD"));
+
+        let mut existing = create_stored_activity("adjustment-1", "acc-1", Some("AAPL"));
+        existing.activity_type = "ADJUSTMENT".to_string();
+        existing.subtype = Some("CASH_SWEEP".to_string());
+        activity_repository.add_activity(existing);
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            Arc::new(MockAssetService::new()),
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+
+        let mut clear = create_test_activity_update(
+            "adjustment-1",
+            "acc-1",
+            Some(AssetResolutionInput::default()),
+            "USD",
+        );
+        clear.activity_type = "ADJUSTMENT".to_string();
+        clear.subtype = Some("CASH_SWEEP".to_string());
+        clear.quantity = Some(None);
+        clear.unit_price = Some(None);
+        clear.amount = Some(Some(dec!(25)));
+
+        let cleared = activity_service
+            .update_activity(clear)
+            .await
+            .expect("optional adjustment asset should clear explicitly");
+        assert_eq!(cleared.asset_id, None);
+
+        let required_clear = create_test_activity_update(
+            "adjustment-1",
+            "acc-1",
+            Some(AssetResolutionInput::default()),
+            "USD",
+        );
+        let error = activity_service
+            .update_activity(required_clear)
+            .await
+            .expect_err("BUY must reject an explicit asset clear");
+        assert!(error.to_string().contains("asset_id or symbol"));
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/activities/model.rs
+++ b/crates/storage-sqlite/src/activities/model.rs
@@ -78,6 +78,7 @@ fn parse_decimal_string_tolerant(value_str: &str, field_name: &str) -> Decimal {
 pub struct ActivityDB {
     pub id: String,
     pub account_id: String,
+    #[diesel(treat_none_as_null = true)]
     pub asset_id: Option<String>, // NOW NULLABLE
 
     // Classification

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -864,6 +864,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
     async fn update_activity(&self, activity_update: ActivityUpdate) -> Result<Activity> {
         activity_update.validate()?;
+        let asset_patch_supplied = activity_update.asset.is_some();
         let activity_update_owned = activity_update.clone();
         let activity_db_owned: ActivityDB = activity_update.into();
         let activity_id_owned = activity_db_owned.id.clone();
@@ -884,6 +885,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
                 // Preserve fields from existing record that shouldn't be overwritten
                 let ActivityDB {
+                    asset_id,
                     created_at,
                     fx_rate,
                     source_system,
@@ -907,6 +909,9 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 } = existing;
 
                 activity_to_update.created_at = created_at;
+                if !asset_patch_supplied {
+                    activity_to_update.asset_id = asset_id;
+                }
                 activity_to_update.quantity =
                     apply_decimal_patch(quantity, activity_update_owned.quantity);
                 activity_to_update.unit_price =
@@ -1292,6 +1297,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
                 for update in updates {
                     update.validate()?;
+                    let asset_patch_supplied = update.asset.is_some();
                     let update_owned = update.clone();
                     let subtype_patch = update_owned.subtype.clone();
                     let mut activity_db: ActivityDB = update.into();
@@ -1307,6 +1313,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
                     // Preserve fields from existing record
                     let ActivityDB {
+                        asset_id,
                         created_at,
                         source_system,
                         source_record_id,
@@ -1330,6 +1337,9 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     } = existing;
 
                     activity_db.created_at = created_at;
+                    if !asset_patch_supplied {
+                        activity_db.asset_id = asset_id;
+                    }
                     activity_db.quantity = apply_decimal_patch(quantity, update_owned.quantity);
                     activity_db.unit_price =
                         apply_decimal_patch(unit_price, update_owned.unit_price);
@@ -4397,7 +4407,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_activity_can_clear_asset_id() {
+    async fn update_activity_preserves_omitted_asset_and_clears_explicit_patch() {
         let (pool, writer) = setup_db();
         let repo = ActivityRepository::new(pool.clone(), writer);
         let mut conn = get_connection(&pool).expect("conn");
@@ -4425,11 +4435,48 @@ mod tests {
         );
         drop(conn);
 
+        let omitted_update = || ActivityUpdate {
+            id: "security-adjustment".to_string(),
+            account_id: "acc-adjustment".to_string(),
+            asset: None,
+            activity_type: "ADJUSTMENT".to_string(),
+            subtype: Some("CASH_SWEEP".to_string()),
+            activity_date: "2024-01-15".to_string(),
+            quantity: Some(None),
+            unit_price: Some(None),
+            currency: "USD".to_string(),
+            fee: None,
+            tax: None,
+            amount: Some(Some(Decimal::new(25, 0))),
+            status: None,
+            needs_review: Some(false),
+            notes: None,
+            fx_rate: None,
+            metadata: None,
+        };
+
+        let preserved = repo
+            .update_activity(omitted_update())
+            .await
+            .expect("preserve omitted adjustment asset");
+
+        assert_eq!(preserved.asset_id.as_deref(), Some("asset-aapl"));
+
+        let bulk_preserved = repo
+            .bulk_mutate_activities(Vec::new(), vec![omitted_update()], Vec::new())
+            .await
+            .expect("bulk preserve omitted adjustment asset")
+            .updated
+            .into_iter()
+            .next()
+            .expect("bulk update result");
+        assert_eq!(bulk_preserved.asset_id.as_deref(), Some("asset-aapl"));
+
         let updated = repo
             .update_activity(ActivityUpdate {
                 id: "security-adjustment".to_string(),
                 account_id: "acc-adjustment".to_string(),
-                asset: None,
+                asset: Some(wealthfolio_core::activities::AssetResolutionInput::default()),
                 activity_type: "ADJUSTMENT".to_string(),
                 subtype: Some("CASH_SWEEP".to_string()),
                 activity_date: "2024-01-15".to_string(),
@@ -4446,7 +4493,7 @@ mod tests {
                 metadata: None,
             })
             .await
-            .expect("clear adjustment asset");
+            .expect("clear explicit adjustment asset patch");
 
         assert_eq!(updated.asset_id, None);
         assert_eq!(updated.quantity, None);

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -4397,6 +4397,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_activity_can_clear_asset_id() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-adjustment");
+        diesel::insert_into(assets::table)
+            .values((
+                assets::id.eq("asset-aapl"),
+                assets::kind.eq("INVESTMENT"),
+                assets::is_active.eq(1),
+                assets::quote_mode.eq("MARKET"),
+                assets::quote_ccy.eq("USD"),
+                assets::created_at.eq("2024-01-15T00:00:00+00:00"),
+                assets::updated_at.eq("2024-01-15T00:00:00+00:00"),
+            ))
+            .execute(&mut conn)
+            .expect("insert asset");
+        insert_activity_with_subtype(
+            &mut conn,
+            "security-adjustment",
+            "acc-adjustment",
+            "ADJUSTMENT",
+            Some("asset-aapl"),
+            Some("CASH_SWEEP"),
+        );
+        drop(conn);
+
+        let updated = repo
+            .update_activity(ActivityUpdate {
+                id: "security-adjustment".to_string(),
+                account_id: "acc-adjustment".to_string(),
+                asset: None,
+                activity_type: "ADJUSTMENT".to_string(),
+                subtype: Some("CASH_SWEEP".to_string()),
+                activity_date: "2024-01-15".to_string(),
+                quantity: Some(None),
+                unit_price: Some(None),
+                currency: "USD".to_string(),
+                fee: None,
+                tax: None,
+                amount: Some(Some(Decimal::new(25, 0))),
+                status: None,
+                needs_review: Some(false),
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+            })
+            .await
+            .expect("clear adjustment asset");
+
+        assert_eq!(updated.asset_id, None);
+        assert_eq!(updated.quantity, None);
+        assert_eq!(updated.unit_price, None);
+        assert_eq!(updated.amount, Some(Decimal::new(25, 0)));
+    }
+
+    #[tokio::test]
     async fn final_cash_migration_updates_are_local_only() {
         let (pool, writer) = setup_db();
         let repo = ActivityRepository::new(pool.clone(), writer);

--- a/e2e/02-activities.spec.ts
+++ b/e2e/02-activities.spec.ts
@@ -1,5 +1,6 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, type Locator, Page, test } from "@playwright/test";
 import {
+  BASE_URL,
   completeOnboardingIfNeeded,
   createAccount,
   gotoActivities,
@@ -11,6 +12,7 @@ test.describe.configure({ mode: "serial" });
 
 test.describe("Activity Creation Tests", () => {
   let page: Page;
+  const runId = Date.now().toString(36);
 
   // Test data for activities
   const TEST_DATA = {
@@ -131,6 +133,29 @@ test.describe("Activity Creation Tests", () => {
         amount: 100,
         notes: "Withholding tax",
       },
+      credit: {
+        account: "Test USD Account",
+        currency: "USD",
+        amount: 75.25,
+        updatedAmount: 80.5,
+        notes: `E2E credit ${runId}`,
+        updatedNotes: `E2E credit updated ${runId}`,
+      },
+      cashAdjustment: {
+        amount: 10,
+        securitiesAmount: 360,
+        finalCashAmount: 25,
+        symbol: "AAPL",
+        quantity: 2,
+        unitPrice: 180,
+        notes: `E2E cash adjustment ${runId}`,
+      },
+      optionExpiryAdjustment: {
+        symbol: "AAPL270115C00200000",
+        quantity: 1,
+        updatedQuantity: 2,
+        notes: `E2E option expiry ${runId}`,
+      },
       split: {
         account: "Test USD Account",
         currency: "USD",
@@ -168,6 +193,7 @@ test.describe("Activity Creation Tests", () => {
     Fee: "activity-type-fee",
     Interest: "activity-type-interest",
     Tax: "activity-type-tax",
+    Credit: "activity-type-credit",
   };
 
   async function waitForOverlayClose() {
@@ -186,6 +212,9 @@ test.describe("Activity Creation Tests", () => {
 
   async function selectActivityType(type: string) {
     const typeButton = page.getByTestId(activityTypeTestIds[type]);
+    if (!(await typeButton.isVisible().catch(() => false))) {
+      await page.getByRole("button", { name: "Expand to show all types" }).click();
+    }
     await expect(typeButton).toBeVisible();
     await typeButton.click();
     await page.waitForTimeout(200);
@@ -268,10 +297,10 @@ test.describe("Activity Creation Tests", () => {
     await page.waitForTimeout(100);
   }
 
-  async function searchAndSelectSymbol(symbol: string) {
+  async function searchAndSelectSymbol(symbol: string, dialogName = "Add Activity") {
     const escapedSymbol = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const exactSymbolPattern = new RegExp(`^${escapedSymbol}$`, "i");
-    const activityDialog = page.getByRole("dialog", { name: "Add Activity" });
+    const activityDialog = page.getByRole("dialog", { name: dialogName });
     const symbolCombobox = activityDialog
       .getByRole("combobox")
       .filter({ hasText: /Select symbol/i });
@@ -420,7 +449,92 @@ test.describe("Activity Creation Tests", () => {
     INTEREST: "Interest",
     TAX: "Tax",
     SPLIT: "Split",
+    CREDIT: "Credit",
+    ADJUSTMENT: "Adjustment",
   };
+
+  interface ActivityApiResponse {
+    id: string;
+    activityType: string;
+    subtype: string | null;
+    assetId: string | null;
+    assetSymbol: string | null;
+    instrumentType: string | null;
+    quantity: string | null;
+    unitPrice: string | null;
+    amount: string | null;
+    comment: string | null;
+  }
+
+  async function getTestAccountId() {
+    const response = await page.request.get(`${BASE_URL}/api/v1/accounts`);
+    expect(response.ok()).toBeTruthy();
+    const accounts = (await response.json()) as Array<{
+      id: string;
+      name: string;
+      currency: string;
+    }>;
+    const account = accounts.find(
+      (item) => item.name === "Test USD Account" && item.currency === "USD",
+    );
+    expect(account, "Expected the activities E2E account to exist").toBeTruthy();
+    return account!.id;
+  }
+
+  async function seedActivity(data: Record<string, unknown>) {
+    const response = await page.request.post(`${BASE_URL}/api/v1/activities`, { data });
+    expect(response.ok(), await response.text()).toBeTruthy();
+    return (await response.json()) as ActivityApiResponse;
+  }
+
+  async function getActivity(activityId: string) {
+    const response = await page.request.post(`${BASE_URL}/api/v1/activities/search`, {
+      data: { page: 0, pageSize: 10, activityIdFilter: [activityId] },
+    });
+    expect(response.ok()).toBeTruthy();
+    const body = (await response.json()) as { data: ActivityApiResponse[] };
+    expect(body.data).toHaveLength(1);
+    return body.data[0];
+  }
+
+  async function openActivityEditor(...rowText: string[]) {
+    await gotoActivities(page);
+    let row = page.locator("tbody tr");
+    for (const text of rowText) {
+      row = row.filter({ hasText: text });
+    }
+    const targetRow = row.first();
+    await expect(targetRow).toBeVisible({ timeout: 10000 });
+    const dialog = page.getByRole("dialog", { name: "Update Activity" });
+    await expect(async () => {
+      await targetRow.getByRole("button", { name: "Open", exact: true }).press("Enter");
+      await page
+        .getByRole("menuitem", { name: "Edit", exact: true })
+        .evaluate((element: HTMLElement) => element.click());
+      await expect(dialog).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 10000 });
+    return dialog;
+  }
+
+  async function updateActivity(dialog: Locator) {
+    const updateButton = dialog.getByRole("button", { name: "Update", exact: true });
+    await expect(updateButton).toBeEnabled({ timeout: 5000 });
+    await updateButton.click();
+    await expect(dialog).not.toBeVisible({ timeout: 20000 });
+  }
+
+  async function expectInputNumber(dialog: Locator, testId: string, expected: number) {
+    const input = dialog.getByTestId(testId);
+    await expect(input).toBeVisible({ timeout: 5000 });
+    expect(Number(await input.inputValue())).toBeCloseTo(expected, 8);
+    return input;
+  }
+
+  async function selectAdvancedSubtype(dialog: Locator, subtype: string) {
+    await dialog.getByTestId("subtype-select").click();
+    await page.getByRole("option", { name: subtype, exact: true }).click();
+    await expect(dialog.getByTestId("subtype-select")).toContainText(subtype);
+  }
 
   async function verifyActivityInTable(
     type: string,
@@ -765,6 +879,154 @@ test.describe("Activity Creation Tests", () => {
     await verifyActivityInTable("FEE", null, { amount: fee.amount });
   });
 
+  test("12. Create and edit CREDIT with subtype and populated account", async () => {
+    const credit = TEST_DATA.activities.credit;
+
+    await gotoActivities(page);
+    await openAddActivitySheet();
+    await selectActivityType("Credit");
+    await selectAccount(credit.account, credit.currency);
+    await selectDate();
+    await fillAmount(credit.amount);
+    await expandAdvancedOptions();
+    const addDialog = page.getByRole("dialog", { name: "Add Activity" });
+    await selectAdvancedSubtype(addDialog, "Trading Rebate");
+    await fillNotes(credit.notes);
+    await submitActivity("Credit");
+
+    await verifyActivityInTable("CREDIT", null, { amount: credit.amount });
+    const editDialog = await openActivityEditor("Credit", credit.notes);
+    await expect(editDialog.getByTestId("account-select")).toContainText(credit.account);
+    const amountInput = await expectInputNumber(editDialog, "amount-input", credit.amount);
+    await editDialog.getByTestId("advanced-options-button").click();
+    await expect(editDialog.getByTestId("subtype-select")).toContainText("Trading Rebate");
+    await expect(editDialog.getByTestId("notes-input")).toHaveValue(credit.notes);
+
+    await amountInput.fill(String(credit.updatedAmount));
+    await selectAdvancedSubtype(editDialog, "Fee Refund");
+    await editDialog.getByTestId("notes-input").fill(credit.updatedNotes);
+    await updateActivity(editDialog);
+
+    const row = page.locator("tbody tr").filter({ hasText: credit.updatedNotes }).first();
+    await expect(row).toContainText("Credit", { timeout: 10000 });
+    await expect(row).toContainText("Fee Refund");
+  });
+
+  test("13. Edit ADJUSTMENT through cash and securities modes", async () => {
+    const adjustment = TEST_DATA.activities.cashAdjustment;
+    const accountId = await getTestAccountId();
+    const seeded = await seedActivity({
+      accountId,
+      activityType: "ADJUSTMENT",
+      subtype: "CASH_SWEEP",
+      activityDate: new Date().toISOString(),
+      currency: "USD",
+      amount: adjustment.amount,
+      comment: adjustment.notes,
+      needsReview: false,
+    });
+
+    const cashDialog = await openActivityEditor("Adjustment", "CASH_SWEEP", "$10.00");
+    await expect(cashDialog.getByTestId("account-select")).toContainText("Test USD Account");
+    await expect(cashDialog.getByRole("button", { name: "Cash", exact: true })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expectInputNumber(cashDialog, "amount-input", adjustment.amount);
+
+    await cashDialog.getByRole("button", { name: "Securities", exact: true }).click();
+    await searchAndSelectSymbol(adjustment.symbol, "Update Activity");
+    await cashDialog.getByTestId("quantity-input").fill(String(adjustment.quantity));
+    await cashDialog.getByTestId("unit-price-input").fill(String(adjustment.unitPrice));
+    await cashDialog.getByTestId("amount-input").fill(String(adjustment.securitiesAmount));
+    await cashDialog.getByTestId("advanced-options-button").click();
+    await cashDialog.getByTestId("subtype-select").click();
+    await expect(page.getByRole("option", { name: "Option Expiry", exact: true })).toHaveCount(0);
+    await page.keyboard.press("Escape");
+    await updateActivity(cashDialog);
+
+    let persisted = await getActivity(seeded.id);
+    expect(persisted.assetSymbol).toBe(adjustment.symbol);
+    expect(persisted.instrumentType).toBe("EQUITY");
+    expect(Number(persisted.quantity)).toBe(adjustment.quantity);
+    expect(Number(persisted.unitPrice)).toBe(adjustment.unitPrice);
+    expect(Number(persisted.amount)).toBe(adjustment.securitiesAmount);
+
+    const securitiesDialog = await openActivityEditor("Adjustment", adjustment.symbol);
+    await expect(
+      securitiesDialog.getByRole("button", { name: "Securities", exact: true }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(securitiesDialog.getByTestId("account-select")).toContainText("Test USD Account");
+    await expectInputNumber(securitiesDialog, "quantity-input", adjustment.quantity);
+    await expectInputNumber(securitiesDialog, "unit-price-input", adjustment.unitPrice);
+    await expectInputNumber(securitiesDialog, "amount-input", adjustment.securitiesAmount);
+
+    await securitiesDialog.getByRole("button", { name: "Cash", exact: true }).click();
+    await securitiesDialog.getByTestId("amount-input").fill(String(adjustment.finalCashAmount));
+    const cashUpdateRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "PUT" && new URL(request.url()).pathname === "/api/v1/activities",
+    );
+    await updateActivity(securitiesDialog);
+    const cashUpdatePayload = (await cashUpdateRequest).postDataJSON() as Record<string, unknown>;
+    expect(cashUpdatePayload.asset).toBeUndefined();
+
+    persisted = await getActivity(seeded.id);
+    expect(persisted.assetId).toBe("");
+    expect(persisted.assetSymbol).toBe("");
+    expect(persisted.quantity).toBeNull();
+    expect(persisted.unitPrice).toBeNull();
+    expect(Number(persisted.amount)).toBe(adjustment.finalCashAmount);
+  });
+
+  test("14. Edit option-expiry ADJUSTMENT with option-only subtype", async () => {
+    const adjustment = TEST_DATA.activities.optionExpiryAdjustment;
+    const accountId = await getTestAccountId();
+    const seeded = await seedActivity({
+      accountId,
+      activityType: "ADJUSTMENT",
+      subtype: "OPTION_EXPIRY",
+      activityDate: new Date().toISOString(),
+      currency: "USD",
+      quantity: adjustment.quantity,
+      unitPrice: 0,
+      amount: 0,
+      comment: adjustment.notes,
+      needsReview: false,
+      asset: {
+        symbol: adjustment.symbol,
+        name: "AAPL Jan 2027 200 Call",
+        kind: "INVESTMENT",
+        quoteMode: "MANUAL",
+        quoteCcy: "USD",
+        instrumentType: "OPTION",
+      },
+    });
+
+    const dialog = await openActivityEditor("Adjustment", "Option Expiry");
+    await expect(dialog.getByTestId("account-select")).toContainText("Test USD Account");
+    await expect(dialog.getByRole("button", { name: "Securities", exact: true })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expectInputNumber(dialog, "quantity-input", adjustment.quantity);
+    await expectInputNumber(dialog, "unit-price-input", 0);
+    await expectInputNumber(dialog, "amount-input", 0);
+    await dialog.getByTestId("advanced-options-button").click();
+    await expect(dialog.getByTestId("subtype-select")).toContainText("Option Expiry");
+
+    await dialog.getByTestId("quantity-input").fill(String(adjustment.updatedQuantity));
+    await updateActivity(dialog);
+
+    const persisted = await getActivity(seeded.id);
+    expect(persisted.subtype).toBe("OPTION_EXPIRY");
+    expect(persisted.instrumentType).toBe("OPTION");
+    expect(persisted.assetSymbol).toBe(adjustment.symbol);
+    expect(Number(persisted.quantity)).toBe(adjustment.updatedQuantity);
+    expect(Number(persisted.unitPrice)).toBe(0);
+    expect(Number(persisted.amount)).toBe(0);
+  });
+
   test("15. Create INTEREST activity", async () => {
     await gotoActivities(page);
 
@@ -960,12 +1222,12 @@ test.describe("Activity Creation Tests", () => {
     // deposit, withdrawal, 2 buys, sell, 2 dividends,
     // internal cash transfer (creates 2), external cash transfer out (1), external cash transfer in (1),
     // internal securities transfer (creates 2), external securities transfer in (1),
-    // 1 fee, interest, 1 tax, split, custom buy
-    // Total: 1 + 1 + 2 + 1 + 2 + 2 + 1 + 1 + 2 + 1 + 1 + 1 + 1 + 1 + 1 = 19
+    // 1 fee, credit, cash adjustment, option-expiry adjustment, interest, 1 tax, split, custom buy
+    // Total: 19 existing activities + 3 new-form activities = 22
     const activityRows = page.locator("tbody tr");
     const rowCount = await activityRows.count();
 
-    // We should have at least 19 activities
-    expect(rowCount).toBeGreaterThanOrEqual(19);
+    // We should have at least 22 activities
+    expect(rowCount).toBeGreaterThanOrEqual(22);
   });
 });

--- a/e2e/02-activities.spec.ts
+++ b/e2e/02-activities.spec.ts
@@ -969,7 +969,7 @@ test.describe("Activity Creation Tests", () => {
     );
     await updateActivity(securitiesDialog);
     const cashUpdatePayload = (await cashUpdateRequest).postDataJSON() as Record<string, unknown>;
-    expect(cashUpdatePayload.asset).toBeUndefined();
+    expect(cashUpdatePayload.asset).toEqual({});
 
     persisted = await getActivity(seeded.id);
     expect(persisted.assetId).toBe("");

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -322,6 +322,7 @@ export interface ActivityUpdate {
   subtype?: string | null;
   activityDate: string | Date;
   sourceGroupId?: string;
+  /** Omit to preserve the current asset; pass an empty object to clear it. */
   asset?: AssetResolutionInput;
   /** @deprecated Use asset. */
   symbol?: AssetResolutionInput;

--- a/packages/ui/src/components/data-grid/data-grid-cell.tsx
+++ b/packages/ui/src/components/data-grid/data-grid-cell.tsx
@@ -19,7 +19,7 @@ import {
 } from "./data-grid-cell-variants";
 import type { DataGridCellProps } from "./data-grid-types";
 
-export const DataGridCell = React.memo(DataGridCellImpl, (prev, next) => {
+function areDataGridCellPropsEqual<TData>(prev: DataGridCellProps<TData>, next: DataGridCellProps<TData>): boolean {
   // Fast path: check stable primitive props first
   if (prev.isFocused !== next.isFocused) return false;
   if (prev.isEditing !== next.isEditing) return false;
@@ -43,8 +43,20 @@ export const DataGridCell = React.memo(DataGridCellImpl, (prev, next) => {
   // Check cell/row identity
   if (prev.cell.row.id !== next.cell.row.id) return false;
 
+  // Re-render when an explicitly tracked display dependency changes. The cell
+  // value can stay the same while a visibility-dependent renderer changes.
+  if (prev.cell.column.columnDef.meta?.renderKey !== next.cell.column.columnDef.meta?.renderKey) return false;
+
+  // Some renderers depend on other fields from row.original. Compare only the
+  // primitive dependency they opt into so unrelated row updates stay memoized.
+  const prevRowRenderKey = prev.cell.column.columnDef.meta?.getRenderKey?.(prev.cell.row.original);
+  const nextRowRenderKey = next.cell.column.columnDef.meta?.getRenderKey?.(next.cell.row.original);
+  if (prevRowRenderKey !== nextRowRenderKey) return false;
+
   return true;
-}) as typeof DataGridCellImpl;
+}
+
+export const DataGridCell = React.memo(DataGridCellImpl, areDataGridCellPropsEqual) as typeof DataGridCellImpl;
 
 function DataGridCellImpl<TData>({
   cell,

--- a/packages/ui/src/components/data-grid/data-grid-types.ts
+++ b/packages/ui/src/components/data-grid/data-grid-types.ts
@@ -132,6 +132,10 @@ declare module "@tanstack/react-table" {
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string;
     helpText?: string;
+    /** Primitive dependency used to invalidate a memoized cell when display configuration changes. */
+    renderKey?: string | number | boolean;
+    /** Row-derived primitive used when a renderer depends on fields outside its accessor value. */
+    getRenderKey?: (rowData: TData) => string | number | boolean | null | undefined;
     cell?: CellOpts;
   }
 


### PR DESCRIPTION
## Summary
- stabilize activity-page infinite scrolling and align the Spending and Investments scroll behavior
- preserve synced provider subtypes, surface provider review reasons, and refresh subtype display when column visibility changes
- add editable Credit and cash/security Adjustment forms, including archived account handling and asset clearing
- extend unit, service, storage, and end-to-end coverage for the new workflows

## Testing
- pnpm type-check
- pnpm --filter frontend exec vitest run ... (204 tests)
- cargo test -p wealthfolio-core activities_service_tests (178 tests)
- cargo test -p wealthfolio-storage-sqlite (253 unit tests and 5 integration tests)
- pnpm test:e2e e2e/02-activities.spec.ts (25 tests)
- cargo fmt --all -- --check
- git diff --check