### PR TITLE
fix(performance): anchor ALL custom-range calendar at account inception instead of 1970 sentinel

### DIFF
--- a/apps/frontend/src/pages/performance/performance-chart-series.test.ts
+++ b/apps/frontend/src/pages/performance/performance-chart-series.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { PerformanceResult } from "@/lib/types";
-import { comparablePerformanceChartData } from "./performance-chart-series";
+import {
+  comparablePerformanceChartData,
+  earliestPerformanceStartDate,
+} from "./performance-chart-series";
 
 function result(
   id: string,
@@ -173,5 +176,39 @@ describe("comparablePerformanceChartData", () => {
     );
 
     expect(data.map((item) => item.id)).toEqual(["portfolio", "SPY"]);
+  });
+});
+
+describe("earliestPerformanceStartDate", () => {
+  it("returns undefined when there is no data", () => {
+    expect(earliestPerformanceStartDate(undefined)).toBeUndefined();
+    expect(earliestPerformanceStartDate([])).toBeUndefined();
+    expect(earliestPerformanceStartDate([null])).toBeUndefined();
+  });
+
+  it("prefers period.startDate and picks the earliest across items", () => {
+    const older = result("older", "timeWeighted", { twr: 0.1 }, [{ date: "2020-06-15", value: 0 }]);
+    // period.startDate is authoritative even when series starts later
+    older.period.startDate = "2019-03-04";
+    const newer = result("newer", "timeWeighted", { twr: 0.2 }, [{ date: "2023-01-02", value: 0 }]);
+    const date = earliestPerformanceStartDate([newer, older])!;
+    expect(date.getFullYear()).toBe(2019);
+    expect(date.getMonth()).toBe(2);
+    expect(date.getDate()).toBe(4);
+  });
+
+  it("falls back to the first series point without period.startDate", () => {
+    const item = result("item", "timeWeighted", { twr: 0 }, [{ date: "2021-11-30", value: 0 }]);
+    item.period.startDate = null;
+    const date = earliestPerformanceStartDate([item])!;
+    expect(date.getFullYear()).toBe(2021);
+    expect(date.getMonth()).toBe(10); // November, 0-based
+    expect(date.getDate()).toBe(30);
+  });
+
+  it("ignores unparseable dates", () => {
+    const item = result("item", "timeWeighted", { twr: 0 }, [{ date: "not-a-date", value: 0 }]);
+    item.period.startDate = undefined;
+    expect(earliestPerformanceStartDate([item])).toBeUndefined();
   });
 });

--- a/apps/frontend/src/pages/performance/performance-chart-series.ts
+++ b/apps/frontend/src/pages/performance/performance-chart-series.ts
@@ -166,3 +166,26 @@ export function comparablePerformanceChartData(
     };
   });
 }
+
+/**
+ * Earliest data date across the given results. For all-time queries the
+ * backend returns series starting at each item's inception, so this resolves
+ * the selected items' earliest start (e.g. an account's first data point).
+ * Used to anchor the custom-range calendar when the ALL preset is active,
+ * instead of the 1970-01-01 sentinel kept in state.
+ */
+export function earliestPerformanceStartDate(
+  results: (PerformanceResult | null | undefined)[] | null | undefined,
+): Date | undefined {
+  let earliestMs: number | undefined;
+  for (const result of results ?? []) {
+    const iso = result?.period?.startDate ?? result?.series?.[0]?.date;
+    if (!iso) continue;
+    const ms = new Date(`${iso.slice(0, 10)}T00:00:00`).getTime();
+    if (Number.isNaN(ms)) continue;
+    if (earliestMs === undefined || ms < earliestMs) {
+      earliestMs = ms;
+    }
+  }
+  return earliestMs === undefined ? undefined : new Date(earliestMs);
+}

--- a/apps/frontend/src/pages/performance/performance-page.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.tsx
@@ -70,6 +70,7 @@ import { BenchmarkSymbolSelectorMobile } from "../../components/benchmark-symbol
 import { useCalculatePerformanceHistory } from "./hooks/use-performance-data";
 import {
   comparablePerformanceChartData,
+  earliestPerformanceStartDate,
   type ComparableChartDataItem as ChartDataItem,
   type PerformanceMetric,
 } from "./performance-chart-series";
@@ -1128,6 +1129,15 @@ export default function PerformancePage() {
   const selectedChartMetric = selectedPerformanceData?.chartMetric ?? "twr";
   const activeChartAnchorId = selectedPerformanceData?.result.id ?? selectedItemId;
 
+  // Earliest start across the selected items' loaded results. With the ALL
+  // preset active (all-time query) this is the portfolio's/account's first
+  // data point, used to anchor the custom-range calendar instead of the
+  // 1970-01-01 sentinel.
+  const allTimeFrom = useMemo(
+    () => earliestPerformanceStartDate(performanceData),
+    [performanceData],
+  );
+
   // Calculate derived chart data
   const chartData = useMemo(() => {
     return comparablePerformanceChartData(
@@ -1416,6 +1426,7 @@ export default function PerformancePage() {
           value={dateRange}
           onChange={setDateRange}
           hiddenRanges={PERFORMANCE_HIDDEN_DATE_RANGES}
+          allTimeFrom={allTimeFrom}
         />
       </div>
 
@@ -1425,6 +1436,7 @@ export default function PerformancePage() {
             value={dateRange}
             onChange={setDateRange}
             hiddenRanges={PERFORMANCE_HIDDEN_DATE_RANGES}
+            allTimeFrom={allTimeFrom}
           />
         </div>
 

--- a/packages/ui/src/components/common/date-range-selector.tsx
+++ b/packages/ui/src/components/common/date-range-selector.tsx
@@ -77,9 +77,16 @@ interface DateRangeSelectorProps {
   value: DateRange | undefined;
   onChange: (range: DateRange | undefined) => void;
   hiddenRanges?: readonly DateRangePresetLabel[];
+  /**
+   * Earliest date represented by the ALL preset (e.g. the selected account's
+   * first data point). Only affects what the calendar displays and anchors to;
+   * the stored ALL value keeps its sentinel start so consumers can still
+   * detect all-time ranges.
+   */
+  allTimeFrom?: Date;
 }
 
-export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRangeSelectorProps) {
+export function DateRangeSelector({ value, onChange, hiddenRanges = [], allTimeFrom }: DateRangeSelectorProps) {
   const { t } = useTranslation();
   const formatting = useDateFormatting();
   const isMobile = useIsMobile();
@@ -110,11 +117,15 @@ export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRa
   const isCustomRange = !selectedLabel;
   const isDraftRangeComplete = !draftRange || (!!draftRange.from && !!draftRange.to);
   const allTimeRange = visibleRanges.find((range) => range.label === "ALL")?.getValue();
-  const appliedDraftRange = draftRange ?? allTimeRange;
+  const allTimeDisplayRange = allTimeFrom ? { from: allTimeFrom, to: new Date() } : allTimeRange;
+  // When ALL is active, show the caller's dynamic start in the calendar
+  // instead of the 1970-01-01 sentinel that is kept in state.
+  const calendarRange = selectedLabel === "ALL" ? allTimeDisplayRange : value;
+  const appliedDraftRange = draftRange ?? allTimeDisplayRange;
 
   const handleCustomPickerOpenChange = (open: boolean) => {
     if (open) {
-      setDraftRange(value ?? allTimeRange);
+      setDraftRange(calendarRange ?? allTimeRange);
     }
     setIsCustomPickerOpen(open);
   };
@@ -213,8 +224,8 @@ export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRa
                 type="button"
                 variant="ghost"
                 className="text-muted-foreground hover:text-foreground"
-                onClick={() => setDraftRange(allTimeRange)}
-                disabled={!draftRange && !allTimeRange}
+                onClick={() => setDraftRange(allTimeDisplayRange)}
+                disabled={!draftRange && !allTimeDisplayRange}
               >
                 {t("ui:dateRange.clear", "Clear")}
               </Button>
@@ -238,8 +249,8 @@ export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRa
           >
             <Calendar
               mode="range"
-              defaultMonth={value?.from}
-              selected={value as DayPickerDateRange | undefined}
+              defaultMonth={calendarRange?.from}
+              selected={calendarRange as DayPickerDateRange | undefined}
               onSelect={(selectedRange: DayPickerDateRange | undefined) => {
                 onChange(selectedRange as DateRange | undefined);
               }}


### PR DESCRIPTION
Fixes #1616

## Summary

When the **ALL** preset is active on Insights → Performance, the custom date-range calendar opened at **January 1970** and highlighted the range from the 1970-01-01 sentinel, instead of anchoring at the selected items' earliest data point.

This PR keeps the 1970-01-01 sentinel as the **stored state contract** (so `isAllTimeDateRange()` detection and all-time query semantics are untouched) and only changes what the calendar *displays* and anchors to: callers can now pass the actual earliest date, derived from the loaded all-time results.

## Root cause

`DateRangeSelector` stores ALL as `{ from: new Date(1970, 0, 1), to: new Date() }` (a sentinel the performance layer converts back to `undefined` for all-time queries). The calendar, however, used the raw sentinel for display:

```tsx
<Calendar
  mode="range"
  defaultMonth={value?.from}   // ← Jan 1970
  selected={value}             // ← range highlighted from Jan 1 1970
```

## Changes

- **`packages/ui` `DateRangeSelector`**: new optional `allTimeFrom?: Date` prop. When the current selection is ALL, the calendar display range and `defaultMonth` use `{ from: allTimeFrom, to: new Date() }` instead of the sentinel. The mobile sheet draft seed and the "Clear" button use the same dynamic range. Clicking the ALL toggle still emits the sentinel — the state contract is unchanged.
- **`performance-chart-series.ts`**: new `earliestPerformanceStartDate()` helper — earliest across the selected comparison items, preferring `period.startDate`, falling back to `series[0].date` (all-time queries return series starting at each item's inception).
- **`performance-page.tsx`**: derives `allTimeFrom` from the loaded results and passes it to both (desktop/mobile) selector instances.
- **Tests**: 4 new unit tests for `earliestPerformanceStartDate` (empty input, multi-item minimum, series fallback, unparseable-date tolerance).

## Testing

- `pnpm vitest run src/pages/performance/` — 17/17 pass (13 existing + 4 new)
- `tsc --noEmit` (frontend + ui), ESLint and Prettier clean on changed files
- Verified end-to-end on a self-hosted instance (Playwright), account data starting 2020-04-06:
  - Before: calendar captions `January 1970 / February 1970 / March 1970`, range starts Jan 1
  - After: calendar captions `April 2020 / May 2020 / June 2020`, first selected day = `6` (2020-04-06, the account's first data point)
  - Bounded presets (e.g. 1Y) anchor as before

## Notes

- The derivation is the *minimum* across all currently selected comparison items, so the calendar always covers every charted series; with a single account selected it is exactly that account's first data point.
- While all-time data is loading or on query errors, the calendar falls back to the previous sentinel display.
- `interval-selector.tsx` has a similar hardcoded `new Date("1970-01-01")` for its ALL range — left untouched here, happy to follow up if wanted.
