### PR TITLE
fix(performance): align benchmark all-time start with account inception

### DIFF
--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -4634,9 +4634,15 @@ impl PerformanceService {
         start_date_opt: Option<NaiveDate>,
         end_date_opt: Option<NaiveDate>,
     ) -> Result<PerformanceResult> {
+        // All-time (no explicit start date): symbols follow the same inception
+        // semantics as accounts — request from the earliest date the quote layer
+        // can serve (1970-01-01 sentinel, matching the frontend all-time
+        // contract) instead of degrading the window to a single year. The
+        // window self-corrects below: `quote_points.first()` becomes the
+        // actual start date of the returned series.
+        let all_time_start = NaiveDate::from_ymd_opt(1970, 1, 1).expect("valid date");
         let effective_end_date = end_date_opt.unwrap_or_else(|| self.today_in_user_timezone());
-        let effective_start_date =
-            start_date_opt.unwrap_or_else(|| effective_end_date - chrono::Duration::days(365));
+        let effective_start_date = start_date_opt.unwrap_or(all_time_start);
 
         if effective_start_date > effective_end_date {
             return Err(errors::Error::Validation(ValidationError::InvalidInput(
@@ -7033,6 +7039,48 @@ mod tests {
         assert_eq!(
             performance.series.last().unwrap().value.round_dp(4),
             dec!(0.2)
+        );
+    }
+
+    #[tokio::test]
+    async fn symbol_performance_all_time_requests_earliest_history() {
+        let performance_service = PerformanceService::new(
+            Arc::new(TestValuationService::new(vec![])),
+            Arc::new(TestQuoteService),
+        );
+
+        // TestQuoteService serves no quotes, so the empty response echoes the
+        // effective request window — enough to assert that an all-time query
+        // (no start date) requests earliest history instead of a 1Y window.
+        let result = performance_service
+            .calculate_symbol_performance("BENCH", None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.series.len(), 0);
+        assert_eq!(
+            result.period.start_date,
+            NaiveDate::from_ymd_opt(1970, 1, 1)
+        );
+        assert!(result.period.end_date.is_some());
+    }
+
+    #[tokio::test]
+    async fn symbol_performance_explicit_start_date_is_preserved() {
+        let performance_service = PerformanceService::new(
+            Arc::new(TestValuationService::new(vec![])),
+            Arc::new(TestQuoteService),
+        );
+
+        let result = performance_service
+            .calculate_symbol_performance("BENCH", NaiveDate::from_ymd_opt(2020, 4, 6), None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.series.len(), 0);
+        assert_eq!(
+            result.period.start_date,
+            NaiveDate::from_ymd_opt(2020, 4, 6)
         );
     }
 


### PR DESCRIPTION
Fixes #1613

## Summary

Fixes the benchmark alignment bug reported in #1613: when the Performance view's date range is **ALL** and a benchmark symbol is tracked, the whole chart was clipped to the benchmark's ~1-year window instead of spanning the portfolio's full history (benchmark line could not be compared from the portfolio's inception).

## Root cause

`calculate_symbol_performance` fell back to `end - 365 days` when no start date was supplied, while accounts apply inception semantics. The frontend rebases every charted series to the date intersection of all selected items (`comparableDateIntersection` + `rebaseSeriesToDates`), so the 365-day-capped benchmark defined the entire chart's x-axis domain.

## Fix

When `start_date_opt` is `None` (all-time query), request from a `1970-01-01` sentinel — the same all-time convention the frontend already uses — instead of the 1-year fallback. The quote layer returns only what it can serve, and `quote_points.first()` becomes the actual series start, so the window self-corrects to real data coverage.

This is fix direction #1 from #1613.

## Notes / trade-off

- The sentinel assumes the configured quote provider can serve deep history. If a provider truncates very wide ranges (e.g. returns only the *oldest* N rows), the result degrades — in our self-hosted setup we hit exactly this with a custom provider and fixed it on the provider side. Worth keeping in mind for the built-in Yahoo provider.
- Benchmark symbols with inherently short history (e.g. a recently-listed ETF) still shorten the chart via the date intersection — that is the separate frontend-domain concern (fix direction #2 in #1613), out of scope here.

## Tests

- `symbol_performance_all_time_requests_earliest_history`
- `symbol_performance_explicit_start_date_is_preserved`

Both assert the effective request window via the empty-response period echo.
