### PR TITLE
fix(import): support two-digit years in CSV dates

### DIFF
--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -218,7 +218,7 @@ export function tryParseDate(dateStr: string, order?: DateOrder): Date | null {
 }
 
 // Helper to check if date is within reasonable range (1900-2100)
-function isDateInRange(date: Date): boolean {
+export function isDateInRange(date: Date): boolean {
   const year = date.getFullYear();
   return year >= 1900 && year <= 2100;
 }

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -22,11 +22,10 @@ export type DateOrder = "DMY" | "MDY";
 
 /**
  * Numeric dates the formats below can actually parse: two small fields, a
- * repeated separator, four-digit year. Detection deliberately matches no more
- * than parsing supports — claiming an order for "03/08/26" would be useless,
- * since no pattern here reads a two-digit year.
+ * repeated separator, and a two- or four-digit year. Detection deliberately
+ * matches no more than parsing supports.
  */
-const NUMERIC_DATE_RE = /^(\d{1,2})([/.-])(\d{1,2})\2(\d{4})(?:\D|$)/;
+const NUMERIC_DATE_RE = /^(\d{1,2})([/.-])(\d{1,2})\2(\d{4}|\d{2})(?:\D|$)/;
 
 /**
  * The two field orders NUMERIC_DATE_RE can report, each covering every
@@ -40,6 +39,9 @@ export const MONTH_FIRST_NUMERIC_FORMATS = [
   "M.d.yyyy", // "5.1.2024"
   "MM-dd-yyyy", // "05-01-2024"
   "M-d-yyyy", // "5-1-2024"
+  "MM/dd/yy", // "05/01/24"
+  "MM.dd.yy", // "05.01.24"
+  "MM-dd-yy", // "05-01-24"
 ];
 
 export const DAY_FIRST_NUMERIC_FORMATS = [
@@ -49,6 +51,9 @@ export const DAY_FIRST_NUMERIC_FORMATS = [
   "d.M.yyyy", // "1.5.2024" - German/Swiss Relaxed
   "dd-MM-yyyy", // "01-05-2024" - Dutch/Danish
   "d-M-yyyy", // "1-5-2024"
+  "dd/MM/yy", // "01/05/24"
+  "dd.MM.yy", // "01.05.24"
+  "dd-MM-yy", // "01-05-24"
 ];
 
 /**
@@ -65,6 +70,12 @@ const NUMERIC_FORMATS_BY_ORDER = {
     "dd.MM.yyyy",
     "d.M.yyyy",
     "dd-MM-yyyy",
+    "MM/dd/yy",
+    "dd/MM/yy",
+    "dd.MM.yy",
+    "MM.dd.yy",
+    "dd-MM-yy",
+    "MM-dd-yy",
   ],
   DMY: [...DAY_FIRST_NUMERIC_FORMATS, ...MONTH_FIRST_NUMERIC_FORMATS],
   MDY: [...MONTH_FIRST_NUMERIC_FORMATS, ...DAY_FIRST_NUMERIC_FORMATS],

--- a/apps/frontend/src/pages/activity/import/steps/holdings-review-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/holdings-review-step.tsx
@@ -179,13 +179,13 @@ export function HoldingsReviewStep() {
   // Backend check state
   const [checkResult, setCheckResult] = useState<CheckHoldingsImportResult | null>(null);
   const [checkLoading, setCheckLoading] = useState(
-    () => Boolean(accountId) && validationSnapshots.length > 0,
+    () => Boolean(accountId) && validationSnapshots.length > 0 && !dateColumn.needsExplicitFormat,
   );
   const [checkFailed, setCheckFailed] = useState(false);
   const [checkRetryRevision, setCheckRetryRevision] = useState(0);
 
   useEffect(() => {
-    if (!accountId || validationSnapshots.length === 0) {
+    if (!accountId || validationSnapshots.length === 0 || dateColumn.needsExplicitFormat) {
       setCheckLoading(false);
       setCheckFailed(false);
       setCheckResult(null);
@@ -229,7 +229,7 @@ export function HoldingsReviewStep() {
       dispatch(setIsValidating(false));
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accountId, validationSnapshots, checkRetryRevision]);
+  }, [accountId, validationSnapshots, checkRetryRevision, dateColumn.needsExplicitFormat]);
 
   // Handle data changes from the grid (quantity, avgCost, currency edits)
   const handleDataChange = useCallback(
@@ -299,62 +299,63 @@ export function HoldingsReviewStep() {
           icon={Icons.Wallet}
           className="mb-0"
         />
-        {checkLoading ? (
-          <div role="status" aria-live="polite">
+        {!dateColumn.needsExplicitFormat &&
+          (checkLoading ? (
+            <div role="status" aria-live="polite">
+              <ImportAlert
+                variant="info"
+                size="sm"
+                title={t("activity:import.holdings.validating")}
+                description={t("activity:import.holdings.validatingRows", {
+                  count: holdingsRows.length,
+                })}
+                icon={Icons.Spinner}
+                iconClassName="animate-spin"
+                className="mb-0"
+              />
+            </div>
+          ) : checkFailed ? (
             <ImportAlert
-              variant="info"
+              variant="destructive"
               size="sm"
-              title={t("activity:import.holdings.validating")}
-              description={t("activity:import.holdings.validatingRows", {
-                count: holdingsRows.length,
+              title={t("activity:import.holdings.validationFailed")}
+              description={t("activity:import.holdings.validationFailedDescription")}
+              icon={Icons.AlertTriangle}
+              className="mb-0"
+            >
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2 h-7"
+                onClick={() => setCheckRetryRevision((revision) => revision + 1)}
+              >
+                <Icons.RefreshCw className="mr-2 h-3.5 w-3.5" />
+                {t("activity:import.validationAlert.retry")}
+              </Button>
+            </ImportAlert>
+          ) : checkResult?.validationErrors.length ? (
+            <ImportAlert
+              variant={checkResult.validSnapshotDates.length > 0 ? "warning" : "destructive"}
+              size="sm"
+              title={t("activity:import.holdings.validationErrors")}
+              description={t("activity:import.holdings.validationErrorsCount", {
+                count: checkResult.validationErrors.length,
               })}
-              icon={Icons.Spinner}
-              iconClassName="animate-spin"
+              icon={Icons.AlertTriangle}
               className="mb-0"
             />
-          </div>
-        ) : checkFailed ? (
-          <ImportAlert
-            variant="destructive"
-            size="sm"
-            title={t("activity:import.holdings.validationFailed")}
-            description={t("activity:import.holdings.validationFailedDescription")}
-            icon={Icons.AlertTriangle}
-            className="mb-0"
-          >
-            <Button
-              type="button"
-              variant="outline"
+          ) : (
+            <ImportAlert
+              variant="success"
               size="sm"
-              className="mt-2 h-7"
-              onClick={() => setCheckRetryRevision((revision) => revision + 1)}
-            >
-              <Icons.RefreshCw className="mr-2 h-3.5 w-3.5" />
-              {t("activity:import.validationAlert.retry")}
-            </Button>
-          </ImportAlert>
-        ) : checkResult?.validationErrors.length ? (
-          <ImportAlert
-            variant={checkResult.validSnapshotDates.length > 0 ? "warning" : "destructive"}
-            size="sm"
-            title={t("activity:import.holdings.validationErrors")}
-            description={t("activity:import.holdings.validationErrorsCount", {
-              count: checkResult.validationErrors.length,
-            })}
-            icon={Icons.AlertTriangle}
-            className="mb-0"
-          />
-        ) : (
-          <ImportAlert
-            variant="success"
-            size="sm"
-            title={t("activity:import.holdings.readyToImport")}
-            description={t("activity:import.holdings.readyRows", { count: holdingsRows.length })}
-            icon={Icons.CheckCircle}
-            className="mb-0"
-            rightIcon={Icons.CheckCircle}
-          />
-        )}
+              title={t("activity:import.holdings.readyToImport")}
+              description={t("activity:import.holdings.readyRows", { count: holdingsRows.length })}
+              icon={Icons.CheckCircle}
+              className="mb-0"
+              rightIcon={Icons.CheckCircle}
+            />
+          ))}
       </div>
 
       {/* Backend check alerts */}

--- a/apps/frontend/src/pages/activity/import/steps/holdings-review-step.ui.test.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/holdings-review-step.ui.test.tsx
@@ -104,6 +104,47 @@ describe("HoldingsReviewStep validation feedback", () => {
     });
   });
 
+  it("shows only format guidance when the date column is ambiguous", async () => {
+    useImportContextMock.mockReturnValue({
+      dispatch,
+      state: {
+        headers: ["Date", "Symbol", "Quantity", "Currency"],
+        parsedRows: [
+          ["01/02/26", "IUIT", "301", "USD"],
+          ["03/04/26", "IUIT", "302", "USD"],
+          ["05/06/26", "IUIT", "303", "USD"],
+        ],
+        mapping: {
+          fieldMappings: {
+            [HoldingsFormat.DATE]: "Date",
+            [HoldingsFormat.SYMBOL]: "Symbol",
+            [HoldingsFormat.QUANTITY]: "Quantity",
+            [HoldingsFormat.CURRENCY]: "Currency",
+          },
+          symbolMappings: {},
+        },
+        parseConfig: {
+          dateFormat: "auto",
+          decimalSeparator: ".",
+          thousandsSeparator: ",",
+          defaultCurrency: "USD",
+        },
+        accountId: "account-1",
+        draftActivities: [],
+      },
+    });
+
+    render(<HoldingsReviewStep />);
+
+    expect(await screen.findByText("Date order is ambiguous")).toBeInTheDocument();
+    expect(screen.queryByText(/Use YYYY-MM-DD/)).not.toBeInTheDocument();
+    expect(checkHoldingsImportMock).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "SET_HOLDINGS_CHECK_PASSED",
+      payload: false,
+    });
+  });
+
   it("clears the shared validating state when the step unmounts", async () => {
     const view = render(<HoldingsReviewStep />);
 

--- a/apps/frontend/src/pages/activity/import/utils/date-format-options.ts
+++ b/apps/frontend/src/pages/activity/import/utils/date-format-options.ts
@@ -97,6 +97,14 @@ export const DATE_FORMAT_OPTIONS: DateFormatOption[] = [
 
   // ── ISO 8601 ───────────────────────────────────────────────────────────────
   { value: "ISO8601", label: "ISO 8601 — 2024-05-01T14:30:00Z", dateFnsPattern: null },
+
+  // ── Date only (two-digit year) ─────────────────────────────────────────────
+  { value: "DD/MM/YY", label: "DD/MM/YY — 01/05/24", dateFnsPattern: "dd/MM/yy" },
+  { value: "MM/DD/YY", label: "MM/DD/YY — 05/01/24", dateFnsPattern: "MM/dd/yy" },
+  { value: "DD.MM.YY", label: "DD.MM.YY — 01.05.24", dateFnsPattern: "dd.MM.yy" },
+  { value: "MM.DD.YY", label: "MM.DD.YY — 05.01.24", dateFnsPattern: "MM.dd.yy" },
+  { value: "DD-MM-YY", label: "DD-MM-YY — 01-05-24", dateFnsPattern: "dd-MM-yy" },
+  { value: "MM-DD-YY", label: "MM-DD-YY — 05-01-24", dateFnsPattern: "MM-dd-yy" },
 ];
 
 /** Lookup map: config value → date-fns pattern */

--- a/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
@@ -39,9 +39,9 @@ describe("detectDateOrder", () => {
     expect(detectDateOrder(["13/08-2026"])).toBeNull();
   });
 
-  it("ignores two-digit years, which no pattern can parse", () => {
-    expect(detectDateOrder(["13/08/26"])).toBeNull();
-    expect(detectDateOrder(["08/13/26"])).toBeNull();
+  it("detects the order of two-digit-year dates", () => {
+    expect(detectDateOrder(["13/08/26"])).toBe("DMY");
+    expect(detectDateOrder(["08/13/26"])).toBe("MDY");
   });
 
   it("still reads a four-digit year followed by a time", () => {
@@ -82,6 +82,12 @@ describe("numeric format coverage", () => {
     expect(parseDateToYMD("3/8/2026", "auto", "DMY")).toBe("2026-08-03");
     expect(ymd(tryParseDate("3/8/2026", "DMY"))).toBe("2026-08-03");
   });
+
+  it("applies the order detected from a two-digit-year row to the whole column", () => {
+    const order = detectDateOrder(["03/08/26", "26/06/26"]);
+    expect(order).toBe("DMY");
+    expect(ymd(tryParseDate("03/08/26", order ?? undefined))).toBe("2026-08-03");
+  });
 });
 
 describe("isAmbiguousNumericDate", () => {
@@ -95,6 +101,11 @@ describe("isAmbiguousNumericDate", () => {
 
   it("does not flag ISO dates", () => {
     expect(isAmbiguousNumericDate("2026-08-03")).toBe(false);
+  });
+
+  it("checks ambiguity for two-digit-year dates", () => {
+    expect(isAmbiguousNumericDate("03/08/26")).toBe(true);
+    expect(isAmbiguousNumericDate("26/06/26")).toBe(false);
   });
 });
 

--- a/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/date-order.test.ts
@@ -86,6 +86,7 @@ describe("numeric format coverage", () => {
   it("applies the order detected from a two-digit-year row to the whole column", () => {
     const order = detectDateOrder(["03/08/26", "26/06/26"]);
     expect(order).toBe("DMY");
+    expect(parseDateToYMD("03/08/26", "auto", order ?? undefined)).toBe("2026-08-03");
     expect(ymd(tryParseDate("03/08/26", order ?? undefined))).toBe("2026-08-03");
   });
 });
@@ -122,6 +123,17 @@ describe("parseDateToYMD", () => {
     expect(parseDateToYMD("03/08/2026", "MM/DD/YYYY", "DMY")).toBe("2026-03-08");
   });
 
+  it.each([
+    ["DD/MM/YY", "03/08/26", "2026-08-03"],
+    ["MM/DD/YY", "03/08/26", "2026-03-08"],
+    ["DD.MM.YY", "03.08.26", "2026-08-03"],
+    ["MM.DD.YY", "03.08.26", "2026-03-08"],
+    ["DD-MM-YY", "03-08-26", "2026-08-03"],
+    ["MM-DD-YY", "03-08-26", "2026-03-08"],
+  ])("supports the explicit %s preset", (dateFormat, value, expected) => {
+    expect(parseDateToYMD(value, dateFormat)).toBe(expected);
+  });
+
   it("leaves ISO dates alone", () => {
     expect(parseDateToYMD("2026-08-03", "auto", "DMY")).toBe("2026-08-03");
   });
@@ -130,6 +142,10 @@ describe("parseDateToYMD", () => {
     // Regression guard: "auto" must stay byte-for-byte the historical order,
     // where dd.MM precedes MM.dd.
     expect(parseDateToYMD("01.05.2024", "auto")).toBe("2024-05-01");
+  });
+
+  it("parses a dot date with a two-digit year instead of padding year 26", () => {
+    expect(parseDateToYMD("26.06.26", "auto", "DMY")).toBe("2026-06-26");
   });
 
   it("refuses a numeric date no pattern matched rather than guessing", () => {

--- a/apps/frontend/src/pages/activity/import/utils/holdings-import-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/holdings-import-utils.ts
@@ -7,6 +7,7 @@ import {
   MONTH_FIRST_NUMERIC_FORMATS,
   detectDateOrder,
   isAmbiguousNumericDate,
+  isDateInRange,
 } from "@/lib/utils";
 import type { DraftActivity } from "../context";
 import { HoldingsFormat } from "../steps/holdings-mapping-step";
@@ -225,7 +226,7 @@ export function parseDateToYMD(
   if (pattern) {
     try {
       const parsed = parse(trimmed, pattern, new Date());
-      if (isValid(parsed)) return formatDate(parsed, "yyyy-MM-dd");
+      if (isValid(parsed) && isDateInRange(parsed)) return formatDate(parsed, "yyyy-MM-dd");
     } catch {
       // fall through to auto-detection
     }
@@ -234,7 +235,7 @@ export function parseDateToYMD(
   if (dateFormat === "ISO8601") {
     try {
       const parsed = parseISO(trimmed);
-      if (isValid(parsed)) return formatDate(parsed, "yyyy-MM-dd");
+      if (isValid(parsed) && isDateInRange(parsed)) return formatDate(parsed, "yyyy-MM-dd");
     } catch {
       // fall through
     }
@@ -244,7 +245,7 @@ export function parseDateToYMD(
   if (isoMatch) {
     try {
       const parsed = parseISO(trimmed);
-      if (isValid(parsed)) return formatDate(parsed, "yyyy-MM-dd");
+      if (isValid(parsed) && isDateInRange(parsed)) return formatDate(parsed, "yyyy-MM-dd");
     } catch {
       // fall through
     }
@@ -257,7 +258,7 @@ export function parseDateToYMD(
   for (const p of commonPatterns) {
     try {
       const parsed = parse(trimmed, p, new Date());
-      if (isValid(parsed)) return formatDate(parsed, "yyyy-MM-dd");
+      if (isValid(parsed) && isDateInRange(parsed)) return formatDate(parsed, "yyyy-MM-dd");
     } catch {
       continue;
     }
@@ -268,7 +269,7 @@ export function parseDateToYMD(
   // just resolved. Anything still unparsed here is not a numeric date.
   if (!NUMERIC_DATE_SHAPE.test(trimmed)) {
     const date = new Date(trimmed);
-    if (!isNaN(date.getTime())) {
+    if (!isNaN(date.getTime()) && isDateInRange(date)) {
       return formatDate(date, "yyyy-MM-dd");
     }
   }

--- a/apps/frontend/src/pages/activity/import/utils/parse-date-value.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/parse-date-value.test.ts
@@ -72,3 +72,13 @@ describe("parseDateValue — month-name dates", () => {
     expect({ y: r.y, mo: r.mo, day: r.day }).toEqual({ y: 2023, mo: 5, day: 19 });
   });
 });
+
+describe("parseDateValue — two-digit years (issue #1341)", () => {
+  it("auto-detects a day-first dot date instead of interpreting it as a timestamp", () => {
+    expect(local(parseDateValue("26.06.26", "auto"))).toMatchObject({
+      y: 2026,
+      mo: 6,
+      day: 26,
+    });
+  });
+});


### PR DESCRIPTION
## Description

### Summary

Fix CSV date parsing for two-digit years such as `26.06.26`, which previously produced invalid
dates like `0026-06-26` or fell back to the Unix epoch.

Fixes #1341.

### Changes

- Support two-digit years with slash, dot, and dash separators.
- Detect day-first or month-first order using the entire date column.
- Apply an unambiguous row’s order to ambiguous rows in the same column.
- Detect columns where every date remains ambiguous.
- Add explicit short-year date formats to the format picker:
  - `DD/MM/YY` and `MM/DD/YY`
  - `DD.MM.YY` and `MM.DD.YY`
  - `DD-MM-YY` and `MM-DD-YY`
- Prevent holdings dates from being normalized to years such as `0026`.
- Skip backend validation while the date order is unresolved, avoiding the misleading “Use YYYY-
MM-DD” error.
- Add regression coverage for parsing, ambiguity detection, format selection, and holdings
validation feedback.

### Result

- `26.06.26` is parsed as `2026-06-26`.
- A column containing `03/08/26` and `26/06/26` is consistently parsed as day-first.
- A completely ambiguous column asks the user to choose an explicit date format.

### Testing

- [x] 62 focused frontend tests passed
- [x] Frontend type-check passed
- [x] ESLint passed with no new errors
- [x] Prettier and `git diff --check` passed

## Checklist

- [X] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
