### PR TITLE
fix(import): recognize legacy trade fingerprints with exported totals

### DIFF
--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -50,7 +50,7 @@ use crate::activities::activities_constants::{
 use crate::activities::activities_errors::ActivityError;
 use crate::activities::activities_model::*;
 use crate::activities::csv_parser::{self, ParseConfig, ParsedCsvResult};
-use crate::activities::idempotency::compute_idempotency_key;
+use crate::activities::idempotency::{compute_activity_idempotency_key, compute_idempotency_key};
 use crate::activities::{
     ActivityRepositoryTrait, ActivityServiceTrait, TransferPair, TransferPairResolution,
 };
@@ -1902,6 +1902,72 @@ impl ActivityService {
             None,
             activity.comment.as_deref(),
         ))
+    }
+
+    fn add_legacy_import_duplicates<'a>(
+        &self,
+        activities: impl Iterator<Item = &'a ActivityImport>,
+        existing: &mut HashMap<String, String>,
+    ) -> Result<()> {
+        let mut keys_by_legacy_key: HashMap<String, HashSet<String>> = HashMap::new();
+        for activity in activities {
+            if !matches!(
+                activity.activity_type.as_str(),
+                ACTIVITY_TYPE_BUY | ACTIVITY_TYPE_SELL
+            ) || activity.amount.is_none()
+                || activity.quantity.is_none()
+                || activity.unit_price.is_none()
+            {
+                continue;
+            }
+            let Some(account_id) = activity.account_id.as_deref() else {
+                continue;
+            };
+            let Some(key) = Self::build_import_idempotency_key(activity, account_id) else {
+                continue;
+            };
+            if existing.contains_key(&key) {
+                continue;
+            }
+
+            // Legacy trades could be keyed before their amount was derived. The
+            // final-cash migration intentionally preserves those stored keys.
+            let mut legacy = activity.clone();
+            legacy.amount = None;
+            if let Some(legacy_key) = Self::build_import_idempotency_key(&legacy, account_id) {
+                keys_by_legacy_key
+                    .entry(legacy_key)
+                    .or_default()
+                    .insert(key);
+            }
+        }
+        if keys_by_legacy_key.is_empty() {
+            return Ok(());
+        }
+
+        let candidates =
+            self.check_existing_duplicates(keys_by_legacy_key.keys().cloned().collect())?;
+        let candidate_ids: Vec<String> = candidates.into_values().collect();
+        for stored in self
+            .activity_repository
+            .get_activities_by_ids(&candidate_ids)?
+        {
+            let Some(requested_keys) = stored
+                .idempotency_key
+                .as_ref()
+                .and_then(|key| keys_by_legacy_key.get(key))
+            else {
+                continue;
+            };
+            // The amount-less key is only a lookup hint, not proof of a duplicate.
+            // Require the current stored fields, including final cash, to match.
+            // This also avoids matching an edited row using its stale legacy key.
+            let current_key = compute_activity_idempotency_key(&stored);
+            if requested_keys.contains(&current_key) {
+                existing.insert(current_key, stored.id);
+            }
+        }
+        Ok(())
     }
 
     fn add_activity_warning(activity: &mut ActivityImport, key: &str, message: &str) {
@@ -4210,12 +4276,19 @@ impl ActivityService {
         }
 
         let unique_keys: Vec<String> = first_index_by_key.into_keys().collect();
-        let existing = if unique_keys.is_empty() {
+        let mut existing = if unique_keys.is_empty() {
             HashMap::new()
         } else {
             self.check_existing_duplicates(unique_keys)
                 .unwrap_or_default()
         };
+        self.add_legacy_import_duplicates(
+            activities_with_status
+                .iter()
+                .zip(&keys)
+                .filter_map(|(activity, key)| key.as_ref().map(|_| activity)),
+            &mut existing,
+        )?;
 
         for (idx, maybe_key) in keys.iter().enumerate() {
             let Some(key) = maybe_key else {
@@ -5643,11 +5716,19 @@ impl ActivityServiceTrait for ActivityService {
             }
         }
 
-        let existing_duplicates = if first_index_by_key.is_empty() {
+        let mut existing_duplicates = if first_index_by_key.is_empty() {
             HashMap::new()
         } else {
             self.check_existing_duplicates(first_index_by_key.keys().cloned().collect())?
         };
+        self.add_legacy_import_duplicates(
+            source_slice
+                .iter()
+                .enumerate()
+                .filter(|(position, _)| !policy_failed_positions.contains(position))
+                .map(|(_, activity)| activity),
+            &mut existing_duplicates,
+        )?;
 
         let mut duplicate_count = 0u32;
         let mut insertable_positions: Vec<usize> = Vec::with_capacity(new_activities.len());

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -12656,6 +12656,225 @@ mod tests {
         }
     }
 
+    fn legacy_trade_import_fixture(
+        activity_type: &str,
+    ) -> (ActivityService, Arc<MockActivityRepository>, ActivityImport) {
+        let account_service = Arc::new(MockAccountService::new());
+        account_service.add_account(create_test_account("acc-1", "EUR"));
+        account_service.add_account(create_test_account("acc-2", "EUR"));
+        let asset_service = Arc::new(MockAssetService::new());
+        let mut asset = create_test_asset_with_instrument(
+            "asset-custom",
+            "CUSTOM",
+            None,
+            Some(InstrumentType::Equity),
+            "EUR",
+        );
+        asset.quote_mode = QuoteMode::Manual;
+        asset_service.add_asset(asset);
+
+        let mut stored = create_stored_activity("legacy-trade", "acc-1", Some("asset-custom"));
+        stored.activity_type = activity_type.to_string();
+        stored.activity_date = parse_test_activity_datetime("2024-01-15T06:11:20Z");
+        stored.quantity = Some(dec!(7));
+        stored.unit_price = Some(dec!(15));
+        stored.currency = "EUR".to_string();
+        stored.source_system = Some("MANUAL".to_string());
+        stored.amount = None;
+        stored.idempotency_key = Some(crate::activities::compute_activity_idempotency_key(&stored));
+        // The final-cash migration fills a legacy NULL amount without rewriting its key.
+        stored.amount = Some(dec!(105));
+        let activity_repository = Arc::new(MockActivityRepository::new());
+        activity_repository.activities.lock().unwrap().push(stored);
+
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+        let import = ActivityImport {
+            id: None,
+            date: "2024-01-15T06:11:20+00:00".to_string(),
+            symbol: "CUSTOM".to_string(),
+            activity_type: activity_type.to_string(),
+            quantity: Some(dec!(7)),
+            unit_price: Some(dec!(15)),
+            currency: "EUR".to_string(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(105)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: Some("EUR".to_string()),
+            instrument_type: Some("EQUITY".to_string()),
+            quote_mode: Some("MANUAL".to_string()),
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: Some("asset-custom".to_string()),
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+        (activity_service, activity_repository, import)
+    }
+
+    #[tokio::test]
+    async fn test_check_import_detects_legacy_trade_with_exported_amount() {
+        for activity_type in ["BUY", "SELL"] {
+            let (service, _, mut import) = legacy_trade_import_fixture(activity_type);
+            // Exercise asset resolution as in a CSV containing only the symbol.
+            import.asset_id = None;
+            let checked = service.check_activities_import(vec![import]).await.unwrap();
+            assert!(checked[0].is_valid);
+            assert_eq!(checked[0].duplicate_of_id.as_deref(), Some("legacy-trade"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_import_skips_legacy_trade_with_exported_amount() {
+        for activity_type in ["BUY", "SELL"] {
+            let (service, repository, import) = legacy_trade_import_fixture(activity_type);
+            let original_key = repository.get_activities().unwrap()[0]
+                .idempotency_key
+                .clone();
+            let result = service.import_activities(vec![import]).await.unwrap();
+            assert!(result.summary.success);
+            assert_eq!(result.summary.imported, 0);
+            assert_eq!(result.summary.duplicates, 1);
+            assert_eq!(
+                result.activities[0].duplicate_of_id.as_deref(),
+                Some("legacy-trade")
+            );
+            let stored = repository.get_activities().unwrap();
+            assert_eq!(stored.len(), 1);
+            assert_eq!(stored[0].idempotency_key, original_key);
+            assert_eq!(stored[0].amount, Some(dec!(105)));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_legacy_trade_import_keeps_different_amounts_and_accounts_distinct() {
+        for activity_type in ["BUY", "SELL"] {
+            for different_account in [false, true] {
+                let (service, repository, mut import) = legacy_trade_import_fixture(activity_type);
+                if different_account {
+                    import.account_id = Some("acc-2".to_string());
+                } else {
+                    import.amount = Some(dec!(104));
+                }
+                let checked = service
+                    .check_activities_import(vec![import.clone()])
+                    .await
+                    .unwrap();
+                assert!(checked[0].is_valid);
+                assert!(checked[0].duplicate_of_id.is_none());
+                let result = service.import_activities(vec![import]).await.unwrap();
+                assert!(result.summary.success);
+                assert_eq!(result.summary.duplicates, 0);
+                assert_eq!(result.summary.imported, 1);
+                assert_eq!(repository.get_activities().unwrap().len(), 2);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_legacy_trade_import_checks_each_amount_in_a_mixed_batch() {
+        let (service, repository, import) = legacy_trade_import_fixture("SELL");
+        let mut different = import.clone();
+        different.amount = Some(dec!(104));
+        different.line_number = Some(2);
+        let imports = vec![import, different];
+        let checked = service
+            .check_activities_import(imports.clone())
+            .await
+            .unwrap();
+        assert_eq!(checked[0].duplicate_of_id.as_deref(), Some("legacy-trade"));
+        assert!(checked[1].duplicate_of_id.is_none());
+        let result = service.import_activities(imports).await.unwrap();
+        assert!(result.summary.success);
+        assert_eq!(result.summary.duplicates, 1);
+        assert_eq!(result.summary.imported, 1);
+        assert_eq!(repository.get_activities().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_legacy_trade_import_does_not_trust_stale_keys_or_missing_totals() {
+        for missing_amount in [false, true] {
+            let (service, repository, import) = legacy_trade_import_fixture("SELL");
+            {
+                let mut stored = repository.activities.lock().unwrap();
+                if missing_amount {
+                    stored[0].amount = None;
+                } else {
+                    stored[0].quantity = Some(dec!(8));
+                }
+            }
+            let checked = service
+                .check_activities_import(vec![import.clone()])
+                .await
+                .unwrap();
+            assert!(checked[0].duplicate_of_id.is_none());
+            let result = service.import_activities(vec![import]).await.unwrap();
+            assert!(result.summary.success);
+            assert_eq!(result.summary.duplicates, 0);
+            assert_eq!(result.summary.imported, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_legacy_trade_import_matches_final_cash_with_charges() {
+        for (activity_type, final_cash) in [("BUY", dec!(108)), ("SELL", dec!(102))] {
+            let (service, repository, mut import) = legacy_trade_import_fixture(activity_type);
+            import.fee = Some(dec!(2));
+            import.tax = Some(dec!(1));
+            import.amount = Some(final_cash);
+            {
+                let mut stored = repository.activities.lock().unwrap();
+                stored[0].fee = import.fee;
+                stored[0].tax = import.tax;
+                stored[0].amount = None;
+                stored[0].idempotency_key = Some(
+                    crate::activities::compute_activity_idempotency_key(&stored[0]),
+                );
+                stored[0].amount = Some(final_cash);
+            }
+            let checked = service
+                .check_activities_import(vec![import.clone()])
+                .await
+                .unwrap();
+            assert_eq!(checked[0].duplicate_of_id.as_deref(), Some("legacy-trade"));
+            let result = service.import_activities(vec![import]).await.unwrap();
+            assert!(result.summary.success);
+            assert_eq!(result.summary.duplicates, 1);
+            assert_eq!(result.summary.imported, 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_force_import_still_allows_legacy_trade_duplicate() {
+        let (service, repository, mut import) = legacy_trade_import_fixture("SELL");
+        import.force_import = true;
+        let result = service.import_activities(vec![import]).await.unwrap();
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 1);
+        assert_eq!(result.summary.duplicates, 0);
+        assert_eq!(repository.get_activities().unwrap().len(), 2);
+    }
+
     #[tokio::test]
     async fn test_import_skips_existing_hard_duplicates_before_insert() {
         let account_service = Arc::new(MockAccountService::new());


### PR DESCRIPTION
## Description

Closes #1624.

Fix CSV duplicate detection for legacy BUY/SELL activities whose idempotency key was computed with a missing `amount`.

The final-cash migration in #1571 can fill that amount while deliberately preserving the original key. An exported CSV then contains the filled amount, so its import fingerprint differs from the stored key even when the account, resolved asset and economics are identical.

## Reproduction

Using synthetic data on `main` at `d3056da2`:

1. Seed a manual SELL of 7 units at EUR 15 with its original NULL-amount fingerprint.
2. Model the post-migration state: stored `amount = 105`, original fingerprint unchanged.
3. Import the equivalent CSV row, mapped to the same account and existing asset, with `amount = 105`.

Before the fix, review reports no duplicate and apply inserts another activity. Both regression tests failed on the unmodified core. BUY has the same failure.

## Changes

- Keep the existing exact-key lookup and all stored fingerprints unchanged.
- For unmatched complete BUY/SELL rows, also look up the historical NULL-amount fingerprint.
- Treat that fingerprint only as a candidate lookup: recompute the candidate's fingerprint from its current stored fields, including final cash, and require an exact match.
- Share this compatibility check between import review and apply. Preserve force-import behavior.

No schema migration, financial recalculation, global fingerprint change or amount-blind matching is introduced. This is intentionally limited to the missing-amount legacy fingerprint, not general semantic deduplication across arbitrary provider formats.

## Validation

Seven new regression tests cover review/apply for BUY and SELL, unchanged stored keys, different amounts and accounts, mixed batches, edited rows, missing stored totals, fees/taxes and force import.

- `CONNECT_API_URL=http://test.local cargo test --locked --workspace -- --quiet`: 3,132 passed, 16 existing ignored tests/examples, no failures.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo check --locked -p wealthfolio-server -p wealthfolio-app`: passed (web and desktop).
- `cargo build --locked -p wealthfolio-server --release` and `cargo check --locked -p wealthfolio-server --release`: passed.
- `pnpm install --frozen-lockfile`, `pnpm run build:types`, `pnpm format:check`, `pnpm lint`, `pnpm type-check`: passed.
- `pnpm test`: 215 test files, 1,749 tests passed.
- `pnpm build`: passed, including addon runtime verification.
- `WF_ADDON_SANDBOX_SKIP_BUILD=true pnpm test:e2e:addon-sandbox`: all 9 tests passed across Chromium, Firefox and WebKit.

Tested locally on macOS Apple Silicon with Rust 1.95.0, Node 24.19.0 and pnpm 10.33.4. Rust workspace checks used the CI flags `CARGO_INCREMENTAL=0` and `RUSTFLAGS='-C debuginfo=0'`; frontend checks used `CI=true`. Existing frontend lint/build warnings remain; no warning suppressions or test exclusions were added. The ignored Rust cases are four provider tests requiring an API key and 12 doctest examples. Fixtures contain no real financial data or credentials. GitHub's Ubuntu CI has not been run locally.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
