### PR TITLE
fix(core): stop an unrepresentable figure panicking the cash pipeline

### DIFF
--- a/crates/core/src/activities/activity_cash_migration.rs
+++ b/crates/core/src/activities/activity_cash_migration.rs
@@ -255,7 +255,10 @@ struct AccountCashFacts {
 struct LegacyCashDecision {
     final_amount: Option<Decimal>,
     needs_review: bool,
-    previous_cash_effect: Decimal,
+    /// `None` when the legacy effect could not be recomputed; treated as a
+    /// change, so the account rebuilds rather than being skipped on a
+    /// comparison nobody could make.
+    previous_cash_effect: Option<Decimal>,
     final_cash_effect: Decimal,
 }
 
@@ -305,7 +308,7 @@ pub(crate) async fn migrate_activities_to_final_cash(
         };
 
         if activity.status == ActivityStatus::Posted
-            && decision.previous_cash_effect != decision.final_cash_effect
+            && decision.previous_cash_effect != Some(decision.final_cash_effect)
         {
             affected_account_ids.insert(activity.account_id.clone());
         }
@@ -437,7 +440,10 @@ fn classify_legacy_activity_cash(
         .then(|| ActivityEconomicsResolver::derived_positive_gross(inputs))
         .flatten();
     let supplied = activity.amount.map(|amount| amount.abs());
-    let charges = activity.fee_amt() + activity.tax_amt();
+    // Only ever asked whether the row carries a charge at all. Both accessors
+    // return absolute values, so the sum is zero exactly when both are, and
+    // asking each in turn cannot overflow the way totalling them can.
+    let has_charges = !activity.fee_amt().is_zero() || !activity.tax_amt().is_zero();
     let tolerance = currency_minor_unit(&activity.currency) / Decimal::TWO;
 
     let (final_amount, needs_review) = if is_trade {
@@ -483,12 +489,12 @@ fn classify_legacy_activity_cash(
         match supplied {
             // A charged composite (e.g. DRIP with withholding) changes its
             // compiled cash effect under the final contract; surface it.
-            Some(amount) => (Some(amount), !charges.is_zero()),
+            Some(amount) => (Some(amount), has_charges),
             None => (derived_final, derived_final.is_none()),
         }
     } else {
         match supplied {
-            Some(amount) => (Some(amount), !charges.is_zero()),
+            Some(amount) => (Some(amount), has_charges),
             None => (None, true),
         }
     };
@@ -541,11 +547,16 @@ fn legacy_compiled_cash_effect(
     activity: &Activity,
     asset_facts: &AssetCashFacts,
     is_credit_card: bool,
-) -> Decimal {
+) -> Option<Decimal> {
     legacy_cash_postings(activity)
         .iter()
-        .map(|posting| legacy_runtime_cash_effect(posting, asset_facts, is_credit_card))
-        .sum()
+        .try_fold(Decimal::ZERO, |total, posting| {
+            total.checked_add(legacy_runtime_cash_effect(
+                posting,
+                asset_facts,
+                is_credit_card,
+            )?)
+        })
 }
 
 /// Reproduces only the pre-cutover asset-income expansion needed to compare
@@ -564,7 +575,11 @@ fn legacy_cash_postings(activity: &Activity) -> Vec<Activity> {
     }
 
     let quantity = activity.quantity.unwrap_or(Decimal::ZERO);
-    let derived_amount = activity.unit_price.map(|unit_price| quantity * unit_price);
+    // A figure that cannot be computed is simply not a candidate, which the
+    // `.or` chains below already handle.
+    let derived_amount = activity
+        .unit_price
+        .and_then(|unit_price| quantity.checked_mul(unit_price));
     let income_amount = activity
         .amount
         .filter(|amount| !amount.is_zero())
@@ -575,11 +590,13 @@ fn legacy_cash_postings(activity: &Activity) -> Vec<Activity> {
         .filter(|price| price.is_sign_positive() && !price.is_zero())
         .or_else(|| {
             income_amount.and_then(|amount| {
-                let reinvested_amount = amount - activity.fee_amt() - activity.tax_amt();
+                let reinvested_amount = amount
+                    .checked_sub(activity.fee_amt())?
+                    .checked_sub(activity.tax_amt())?;
                 if quantity.is_zero() || reinvested_amount <= Decimal::ZERO {
                     None
                 } else {
-                    Some(reinvested_amount / quantity)
+                    reinvested_amount.checked_div(quantity)
                 }
             })
         })
@@ -605,19 +622,23 @@ fn legacy_cash_postings(activity: &Activity) -> Vec<Activity> {
     vec![income_leg, buy_leg]
 }
 
+/// `None` when the legacy figures cannot be recombined inside `Decimal`. The
+/// caller reads that as "the effect may have changed", which is the safe
+/// answer for a value whose only job is to decide whether to rebuild.
 fn legacy_runtime_cash_effect(
     activity: &Activity,
     asset_facts: &AssetCashFacts,
     is_credit_card: bool,
-) -> Decimal {
+) -> Option<Decimal> {
     let activity_type = activity.effective_type();
     let fee = activity.fee_amt();
     let tax = activity.tax_amt();
     let amount = activity.amt();
+    let charges = fee.checked_add(tax);
 
     if is_credit_card && activity_type == ACTIVITY_TYPE_INTEREST {
         let charge = if !fee.is_zero() { fee } else { amount };
-        return -charge;
+        return Some(-charge);
     }
 
     match activity_type {
@@ -633,23 +654,26 @@ fn legacy_runtime_cash_effect(
             let gross = if use_amount {
                 amount
             } else {
-                activity.qty() * activity.price() * asset_facts.unit_multiplier
+                activity
+                    .qty()
+                    .checked_mul(activity.price())?
+                    .checked_mul(asset_facts.unit_multiplier)?
             };
             if activity_type == ACTIVITY_TYPE_BUY {
-                -(gross + fee + tax)
+                gross.checked_add(charges?).map(|total| -total)
             } else {
-                gross - fee - tax
+                gross.checked_sub(charges?)
             }
         }
         ACTIVITY_TYPE_DEPOSIT
         | ACTIVITY_TYPE_DIVIDEND
         | ACTIVITY_TYPE_INTEREST
         | ACTIVITY_TYPE_CREDIT
-        | ACTIVITY_TYPE_TRANSFER_IN => amount - fee - tax,
-        ACTIVITY_TYPE_WITHDRAWAL | ACTIVITY_TYPE_TRANSFER_OUT => -amount - fee - tax,
+        | ACTIVITY_TYPE_TRANSFER_IN => amount.checked_sub(charges?),
+        ACTIVITY_TYPE_WITHDRAWAL | ACTIVITY_TYPE_TRANSFER_OUT => (-amount).checked_sub(charges?),
         ACTIVITY_TYPE_FEE => {
             let charge = if !fee.is_zero() { fee } else { amount };
-            -charge
+            Some(-charge)
         }
         ACTIVITY_TYPE_TAX => {
             let charge = if !tax.is_zero() {
@@ -659,9 +683,9 @@ fn legacy_runtime_cash_effect(
             } else {
                 amount
             };
-            -charge
+            Some(-charge)
         }
-        _ => Decimal::ZERO,
+        _ => Some(Decimal::ZERO),
     }
 }
 
@@ -860,7 +884,7 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
-        assert_eq!(decision.previous_cash_effect, dec!(85));
+        assert_eq!(decision.previous_cash_effect, Some(dec!(85)));
         assert_eq!(decision.final_cash_effect, dec!(100));
     }
 
@@ -892,7 +916,7 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(23)));
         assert!(!decision.needs_review);
-        assert_eq!(decision.previous_cash_effect, dec!(-23));
+        assert_eq!(decision.previous_cash_effect, Some(dec!(-23)));
         assert_eq!(decision.final_cash_effect, dec!(-23));
     }
 
@@ -1086,8 +1110,25 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
-        assert_eq!(decision.previous_cash_effect, dec!(95));
+        assert_eq!(decision.previous_cash_effect, Some(dec!(95)));
         assert_eq!(decision.final_cash_effect, dec!(100));
+    }
+
+    #[test]
+    fn charges_too_large_to_total_still_classify() {
+        // The migration only asks whether the row carries a charge at all, so
+        // a pair that cannot be summed must not stop it classifying - this
+        // runs at startup over stored rows, where one such row would take the
+        // whole pass down rather than fail a single import.
+        let mut deposit = activity(ACTIVITY_TYPE_DEPOSIT);
+        deposit.amount = Some(dec!(100));
+        deposit.fee = Some(Decimal::MAX);
+        deposit.tax = Some(Decimal::MAX);
+
+        let decision = classify_legacy_activity_cash(&deposit, facts(), &account_facts()).unwrap();
+
+        assert_eq!(decision.final_amount, Some(dec!(100)));
+        assert!(decision.needs_review);
     }
 
     #[test]
@@ -1126,7 +1167,7 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(9850)));
         assert!(!decision.needs_review);
-        assert_eq!(decision.previous_cash_effect, dec!(-9850));
+        assert_eq!(decision.previous_cash_effect, Some(dec!(-9850)));
         assert_eq!(decision.final_cash_effect, dec!(-9850));
     }
 
@@ -1178,7 +1219,7 @@ mod tests {
         let decision = classify_legacy_activity_cash(&drip, facts(), &account_facts()).unwrap();
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
-        assert_eq!(decision.previous_cash_effect, Decimal::ZERO);
+        assert_eq!(decision.previous_cash_effect, Some(Decimal::ZERO));
         assert_eq!(decision.final_cash_effect, Decimal::ZERO);
         assert!(!decision.needs_review);
     }
@@ -1235,7 +1276,10 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
-        assert_ne!(decision.previous_cash_effect, decision.final_cash_effect);
+        assert_ne!(
+            decision.previous_cash_effect,
+            Some(decision.final_cash_effect)
+        );
     }
 
     #[test]

--- a/crates/core/src/activities/activity_cash_migration.rs
+++ b/crates/core/src/activities/activity_cash_migration.rs
@@ -259,7 +259,8 @@ struct LegacyCashDecision {
     /// change, so the account rebuilds rather than being skipped on a
     /// comparison nobody could make.
     previous_cash_effect: Option<Decimal>,
-    final_cash_effect: Decimal,
+    /// Unknown totals must also trigger review and a rebuild.
+    final_cash_effect: Option<Decimal>,
 }
 
 pub(crate) async fn migrate_activities_to_final_cash(
@@ -308,7 +309,9 @@ pub(crate) async fn migrate_activities_to_final_cash(
         };
 
         if activity.status == ActivityStatus::Posted
-            && decision.previous_cash_effect != Some(decision.final_cash_effect)
+            && (decision.previous_cash_effect.is_none()
+                || decision.final_cash_effect.is_none()
+                || decision.previous_cash_effect != decision.final_cash_effect)
         {
             affected_account_ids.insert(activity.account_id.clone());
         }
@@ -509,8 +512,7 @@ fn classify_legacy_activity_cash(
         account_facts.is_credit_card,
     )
     .ok()
-    .and_then(|resolved| resolved.signed_cash_effect)
-    .unwrap_or(Decimal::ZERO);
+    .and_then(|resolved| resolved.signed_cash_effect);
 
     // Before the cutover the review queue was `status = DRAFT`; after it,
     // `needs_review` is the only queue. Flag legacy drafts so they stay
@@ -519,7 +521,10 @@ fn classify_legacy_activity_cash(
 
     Some(LegacyCashDecision {
         final_amount,
-        needs_review: needs_review || activity.needs_review || is_legacy_draft,
+        needs_review: needs_review
+            || activity.needs_review
+            || is_legacy_draft
+            || final_cash_effect.is_none(),
         previous_cash_effect,
         final_cash_effect,
     })
@@ -885,7 +890,7 @@ mod tests {
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
         assert_eq!(decision.previous_cash_effect, Some(dec!(85)));
-        assert_eq!(decision.final_cash_effect, dec!(100));
+        assert_eq!(decision.final_cash_effect, Some(dec!(100)));
     }
 
     #[test]
@@ -900,7 +905,7 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
-        assert_eq!(decision.final_cash_effect, dec!(100));
+        assert_eq!(decision.final_cash_effect, Some(dec!(100)));
     }
 
     #[test]
@@ -917,7 +922,7 @@ mod tests {
         assert_eq!(decision.final_amount, Some(dec!(23)));
         assert!(!decision.needs_review);
         assert_eq!(decision.previous_cash_effect, Some(dec!(-23)));
-        assert_eq!(decision.final_cash_effect, dec!(-23));
+        assert_eq!(decision.final_cash_effect, Some(dec!(-23)));
     }
 
     #[test]
@@ -974,7 +979,7 @@ mod tests {
         let decision = classify_legacy_activity_cash(&sell, facts(), &account_facts()).unwrap();
 
         assert_eq!(decision.final_amount, Some(dec!(2)));
-        assert_eq!(decision.final_cash_effect, dec!(-2));
+        assert_eq!(decision.final_cash_effect, Some(dec!(-2)));
         assert!(!decision.needs_review);
     }
 
@@ -1111,7 +1116,7 @@ mod tests {
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
         assert_eq!(decision.previous_cash_effect, Some(dec!(95)));
-        assert_eq!(decision.final_cash_effect, dec!(100));
+        assert_eq!(decision.final_cash_effect, Some(dec!(100)));
     }
 
     #[test]
@@ -1128,6 +1133,38 @@ mod tests {
         let decision = classify_legacy_activity_cash(&deposit, facts(), &account_facts()).unwrap();
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
+        assert!(decision.needs_review);
+    }
+
+    #[test]
+    fn composite_price_division_overflow_still_classifies() {
+        let mut drip = activity(ACTIVITY_TYPE_DIVIDEND);
+        drip.subtype = Some("DRIP".to_string());
+        drip.quantity = Some(dec!(0.1));
+        drip.amount = Some(Decimal::MAX);
+        let decision = classify_legacy_activity_cash(&drip, facts(), &account_facts()).unwrap();
+        assert_eq!(decision.final_amount, Some(Decimal::MAX));
+        assert_eq!(decision.final_cash_effect, Some(Decimal::ZERO));
+    }
+
+    #[test]
+    fn credit_card_staking_overflow_stays_unknown_and_reviewable() {
+        let mut staking = activity(ACTIVITY_TYPE_INTEREST);
+        staking.subtype = Some("STAKING_REWARD".to_string());
+        staking.quantity = Some(dec!(1));
+        staking.unit_price = Some(Decimal::MAX);
+        staking.amount = Some(Decimal::MAX);
+        let decision = classify_legacy_activity_cash(
+            &staking,
+            facts(),
+            &AccountCashFacts {
+                is_credit_card: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(decision.final_amount, Some(Decimal::MAX));
+        assert_eq!(decision.previous_cash_effect, None);
+        assert_eq!(decision.final_cash_effect, None);
         assert!(decision.needs_review);
     }
 
@@ -1168,7 +1205,7 @@ mod tests {
         assert_eq!(decision.final_amount, Some(dec!(9850)));
         assert!(!decision.needs_review);
         assert_eq!(decision.previous_cash_effect, Some(dec!(-9850)));
-        assert_eq!(decision.final_cash_effect, dec!(-9850));
+        assert_eq!(decision.final_cash_effect, Some(dec!(-9850)));
     }
 
     #[test]
@@ -1220,7 +1257,7 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert_eq!(decision.previous_cash_effect, Some(Decimal::ZERO));
-        assert_eq!(decision.final_cash_effect, Decimal::ZERO);
+        assert_eq!(decision.final_cash_effect, Some(Decimal::ZERO));
         assert!(!decision.needs_review);
     }
 
@@ -1276,10 +1313,7 @@ mod tests {
 
         assert_eq!(decision.final_amount, Some(dec!(100)));
         assert!(decision.needs_review);
-        assert_ne!(
-            decision.previous_cash_effect,
-            Some(decision.final_cash_effect)
-        );
+        assert_ne!(decision.previous_cash_effect, decision.final_cash_effect);
     }
 
     #[test]

--- a/crates/core/src/activities/compiler.rs
+++ b/crates/core/src/activities/compiler.rs
@@ -149,7 +149,7 @@ impl DefaultActivityCompiler {
                         // Stored income amount is already final cash. When the
                         // acquisition price is missing, all of that final cash
                         // is what the synthetic purchase can reinvest.
-                        Some(amount / quantity)
+                        amount.checked_div(quantity)
                     }
                 })
             })

--- a/crates/core/src/portfolio/economic_events.rs
+++ b/crates/core/src/portfolio/economic_events.rs
@@ -211,8 +211,8 @@ impl ActivityEconomicsResolver {
             return Ok(resolved);
         }
 
-        let mut signed_cash_effect = Decimal::ZERO;
-        let mut signed_gross_effect = Decimal::ZERO;
+        let mut signed_cash_effect = Some(Decimal::ZERO);
+        let mut signed_gross_effect = Some(Decimal::ZERO);
         let mut has_cash_effect = false;
         let mut has_gross_effect = false;
         for posting in postings {
@@ -222,16 +222,17 @@ impl ActivityEconomicsResolver {
                 is_credit_card_account,
             );
             if let Some(effect) = posting_cash.signed_cash_effect {
-                signed_cash_effect += effect;
+                signed_cash_effect = signed_cash_effect.and_then(|total| total.checked_add(effect));
                 has_cash_effect = true;
             }
             if let Some(effect) = posting_cash.signed_gross_effect {
-                signed_gross_effect += effect;
+                signed_gross_effect =
+                    signed_gross_effect.and_then(|total| total.checked_add(effect));
                 has_gross_effect = true;
             }
         }
-        resolved.signed_cash_effect = has_cash_effect.then_some(signed_cash_effect);
-        resolved.signed_gross_effect = has_gross_effect.then_some(signed_gross_effect);
+        resolved.signed_cash_effect = has_cash_effect.then_some(signed_cash_effect).flatten();
+        resolved.signed_gross_effect = has_gross_effect.then_some(signed_gross_effect).flatten();
         Ok(resolved)
     }
 
@@ -458,6 +459,19 @@ impl ActivityEconomicsResolver {
         let lot_cost_basis_uses_legacy_amount =
             is_security_transfer && Self::lot_cost_basis_uses_legacy_amount(activity);
         let mut diagnostics = Vec::new();
+        let basis_status = if !is_security_transfer {
+            BasisStatus::NotApplicable
+        } else if lot_cost_basis_value.is_zero() {
+            if Self::security_transfer_has_book_basis(activity) {
+                diagnostics.push(format!(
+                    "Security transfer activity {} could not derive a usable cost basis from its supplied values.",
+                    activity.id
+                ));
+            }
+            BasisStatus::Unknown
+        } else {
+            BasisStatus::Complete
+        };
 
         if kind == EconomicEventKind::UnknownBoundaryTransfer {
             diagnostics.push(format!(
@@ -474,11 +488,7 @@ impl ActivityEconomicsResolver {
                 performance_flow_value: Decimal::ZERO,
                 performance_flow_currency: activity_currency,
                 performance_flow_source: ExternalFlowSource::Unknown,
-                basis_status: if is_security_transfer {
-                    Self::security_transfer_basis_status(activity)
-                } else {
-                    BasisStatus::NotApplicable
-                },
+                basis_status,
                 diagnostics,
             };
         }
@@ -510,7 +520,7 @@ impl ActivityEconomicsResolver {
                         } else {
                             ExternalFlowSource::QuoteDerivedMarketValue
                         },
-                        basis_status: Self::security_transfer_basis_status(activity),
+                        basis_status,
                         diagnostics,
                     };
                 }
@@ -686,14 +696,6 @@ impl ActivityEconomicsResolver {
             && (activity.unit_price.is_some_and(|price| !price.is_zero())
                 || (activity.effective_type() == ACTIVITY_TYPE_TRANSFER_IN
                     && activity.amount.is_some_and(|amount| !amount.is_zero())))
-    }
-
-    fn security_transfer_basis_status(activity: &Activity) -> BasisStatus {
-        if Self::security_transfer_has_book_basis(activity) {
-            BasisStatus::Complete
-        } else {
-            BasisStatus::Unknown
-        }
     }
 
     fn event_kind(activity: &Activity, transfer_boundary: TransferBoundary) -> EconomicEventKind {
@@ -1063,6 +1065,62 @@ mod cash_tests {
             ),
             dec!(500)
         );
+    }
+
+    #[test]
+    fn compiled_overflow_keeps_cash_and_gross_totals_unknown() {
+        let mut staking = stored_activity(ACTIVITY_TYPE_INTEREST);
+        staking.subtype = Some(ACTIVITY_SUBTYPE_STAKING_REWARD.to_string());
+        staking.quantity = Some(Decimal::ONE);
+        staking.unit_price = Some(Decimal::MAX);
+        staking.amount = Some(Decimal::MAX);
+
+        let resolved =
+            ActivityEconomicsResolver::resolve_compiled_cash(&staking, Decimal::ONE, true).unwrap();
+        assert_eq!(resolved.final_amount, Some(Decimal::MAX));
+        assert_eq!(resolved.signed_cash_effect, None);
+        assert_eq!(resolved.signed_gross_effect, None);
+
+        let ordinary_account =
+            ActivityEconomicsResolver::resolve_compiled_cash(&staking, Decimal::ONE, false)
+                .unwrap();
+        assert_eq!(ordinary_account.signed_cash_effect, Some(Decimal::ZERO));
+        assert_eq!(ordinary_account.signed_gross_effect, Some(Decimal::ZERO));
+    }
+
+    #[test]
+    fn overflowed_transfer_basis_is_unknown() {
+        let mut transfer = stored_activity(ACTIVITY_TYPE_TRANSFER_IN);
+        transfer.quantity = Some(Decimal::MAX);
+        transfer.unit_price = Some(dec!(2));
+        transfer.amount = None;
+        let quote = Quote {
+            close: Decimal::ONE,
+            currency: "USD".to_string(),
+            ..Default::default()
+        };
+        let resolved = ActivityEconomicsResolver::compile_activity_with_unit_multiplier(
+            &transfer,
+            Some(&quote),
+            TransferBoundary::External,
+            Decimal::ONE,
+        );
+        assert_eq!(resolved.lot_cost_basis_value, Decimal::ZERO);
+        assert_eq!(resolved.basis_status, BasisStatus::Unknown);
+        assert!(resolved
+            .diagnostics
+            .iter()
+            .any(|message| message.contains("could not derive a usable cost basis")));
+
+        transfer.amount = Some(dec!(500));
+        let fallback = ActivityEconomicsResolver::compile_activity_with_unit_multiplier(
+            &transfer,
+            Some(&quote),
+            TransferBoundary::External,
+            Decimal::ONE,
+        );
+        assert_eq!(fallback.lot_cost_basis_value, dec!(500));
+        assert_eq!(fallback.basis_status, BasisStatus::Complete);
     }
 
     #[test]

--- a/crates/core/src/portfolio/economic_events.rs
+++ b/crates/core/src/portfolio/economic_events.rs
@@ -211,28 +211,29 @@ impl ActivityEconomicsResolver {
             return Ok(resolved);
         }
 
+        // A compiled total is known only when every posting is known. Skipping
+        // an unavailable posting would misreport the remaining partial sum.
         let mut signed_cash_effect = Some(Decimal::ZERO);
         let mut signed_gross_effect = Some(Decimal::ZERO);
-        let mut has_cash_effect = false;
-        let mut has_gross_effect = false;
         for posting in postings {
             let posting_cash = Self::resolve_cash_with_account_context(
                 &posting,
                 unit_multiplier,
                 is_credit_card_account,
             );
-            if let Some(effect) = posting_cash.signed_cash_effect {
-                signed_cash_effect = signed_cash_effect.and_then(|total| total.checked_add(effect));
-                has_cash_effect = true;
-            }
-            if let Some(effect) = posting_cash.signed_gross_effect {
-                signed_gross_effect =
-                    signed_gross_effect.and_then(|total| total.checked_add(effect));
-                has_gross_effect = true;
-            }
+            signed_cash_effect = signed_cash_effect.and_then(|total| {
+                posting_cash
+                    .signed_cash_effect
+                    .and_then(|effect| total.checked_add(effect))
+            });
+            signed_gross_effect = signed_gross_effect.and_then(|total| {
+                posting_cash
+                    .signed_gross_effect
+                    .and_then(|effect| total.checked_add(effect))
+            });
         }
-        resolved.signed_cash_effect = has_cash_effect.then_some(signed_cash_effect).flatten();
-        resolved.signed_gross_effect = has_gross_effect.then_some(signed_gross_effect).flatten();
+        resolved.signed_cash_effect = signed_cash_effect;
+        resolved.signed_gross_effect = signed_gross_effect;
         Ok(resolved)
     }
 
@@ -1086,6 +1087,22 @@ mod cash_tests {
                 .unwrap();
         assert_eq!(ordinary_account.signed_cash_effect, Some(Decimal::ZERO));
         assert_eq!(ordinary_account.signed_gross_effect, Some(Decimal::ZERO));
+    }
+
+    #[test]
+    fn compiled_gross_is_unknown_when_any_posting_gross_is_unknown() {
+        let mut drip = stored_activity(ACTIVITY_TYPE_DIVIDEND);
+        drip.subtype = Some(ACTIVITY_SUBTYPE_DRIP.to_string());
+        drip.quantity = Some(Decimal::ONE);
+        drip.unit_price = Some(Decimal::MAX);
+        drip.amount = Some(Decimal::MAX);
+        drip.fee = Some(Decimal::ONE);
+
+        let resolved =
+            ActivityEconomicsResolver::resolve_compiled_cash(&drip, Decimal::ONE, false).unwrap();
+
+        assert_eq!(resolved.signed_cash_effect, Some(Decimal::ZERO));
+        assert_eq!(resolved.signed_gross_effect, None);
     }
 
     #[test]

--- a/crates/core/src/portfolio/economic_events.rs
+++ b/crates/core/src/portfolio/economic_events.rs
@@ -255,7 +255,9 @@ impl ActivityEconomicsResolver {
         }
 
         let tax = inputs.tax.unwrap_or(Decimal::ZERO).abs();
-        let charges = fee + tax;
+        // `None` when the two charges cannot be totalled; the gross derivation
+        // below is the only consumer, and it already models having no gross.
+        let charges = fee.checked_add(tax);
         let expected_effect = Self::calculate_trade_cash_effect(inputs)
             .or_else(|| Self::calculate_standalone_charge_amount(inputs).map(|amount| -amount));
         let final_amount = inputs.amount.map(|amount| amount.abs());
@@ -289,15 +291,19 @@ impl ActivityEconomicsResolver {
         });
 
         let gross_amount = signed_cash_effect.and_then(|signed_final| {
+            // Negation is always representable: `Decimal::MIN` is exactly
+            // `-Decimal::MAX`. Adding the charges back on is not.
             let gross = match inputs.activity_type {
-                ACTIVITY_TYPE_BUY => -signed_final - charges,
+                ACTIVITY_TYPE_BUY => (-signed_final).checked_sub(charges?)?,
                 ACTIVITY_TYPE_SELL
                 | ACTIVITY_TYPE_DEPOSIT
                 | ACTIVITY_TYPE_DIVIDEND
                 | ACTIVITY_TYPE_INTEREST
                 | ACTIVITY_TYPE_CREDIT
-                | ACTIVITY_TYPE_TRANSFER_IN => signed_final + charges,
-                ACTIVITY_TYPE_WITHDRAWAL | ACTIVITY_TYPE_TRANSFER_OUT => -signed_final - charges,
+                | ACTIVITY_TYPE_TRANSFER_IN => signed_final.checked_add(charges?)?,
+                ACTIVITY_TYPE_WITHDRAWAL | ACTIVITY_TYPE_TRANSFER_OUT => {
+                    (-signed_final).checked_sub(charges?)?
+                }
                 ACTIVITY_TYPE_FEE | ACTIVITY_TYPE_TAX => final_amount?,
                 _ => return None,
             };
@@ -356,8 +362,10 @@ impl ActivityEconomicsResolver {
             return None;
         }
 
-        let gross =
-            quantity?.abs() * unit_price?.abs() * Self::valid_unit_multiplier(unit_multiplier);
+        let gross = quantity?
+            .abs()
+            .checked_mul(unit_price?.abs())?
+            .checked_mul(Self::valid_unit_multiplier(unit_multiplier))?;
         (!gross.is_zero()).then_some(gross)
     }
 
@@ -374,9 +382,17 @@ impl ActivityEconomicsResolver {
         Self::cash_effect_from_trade_gross(inputs.activity_type, gross, fee, tax)
     }
 
+    /// `None` when the row carries no quantity or price, and equally when their
+    /// product cannot be represented: `rust_decimal` panics on overflow rather
+    /// than saturating, and a figure we cannot compute is not one to derive
+    /// cash from.
     pub(crate) fn derived_positive_gross(inputs: ActivityCashInputs<'_>) -> Option<Decimal> {
         let multiplier = Self::valid_unit_multiplier(inputs.unit_multiplier);
-        let gross = inputs.quantity?.abs() * inputs.unit_price?.abs() * multiplier;
+        let gross = inputs
+            .quantity?
+            .abs()
+            .checked_mul(inputs.unit_price?.abs())?
+            .checked_mul(multiplier)?;
         (gross > Decimal::ZERO).then_some(gross)
     }
 
@@ -386,10 +402,10 @@ impl ActivityEconomicsResolver {
         fee: Decimal,
         tax: Decimal,
     ) -> Option<Decimal> {
-        let charges = fee.abs() + tax.abs();
+        let charges = fee.abs().checked_add(tax.abs())?;
         match activity_type {
-            ACTIVITY_TYPE_BUY => Some(-(gross.abs() + charges)),
-            ACTIVITY_TYPE_SELL => Some(gross.abs() - charges),
+            ACTIVITY_TYPE_BUY => gross.abs().checked_add(charges).map(|total| -total),
+            ACTIVITY_TYPE_SELL => gross.abs().checked_sub(charges),
             _ => None,
         }
     }
@@ -471,8 +487,15 @@ impl ActivityEconomicsResolver {
             if let Some(quote) = quote {
                 let (normalized_price, normalized_currency) =
                     normalize_amount(quote.close, &quote.currency);
-                let market_value = activity.qty() * normalized_price * unit_multiplier;
-                if !market_value.is_zero() {
+                // An unrepresentable product is as unusable as a zero one, and
+                // takes the same route: the fallbacks below, which already
+                // exist for a transfer with no quote.
+                let market_value = activity
+                    .qty()
+                    .checked_mul(normalized_price)
+                    .and_then(|value| value.checked_mul(unit_multiplier))
+                    .filter(|value| !value.is_zero());
+                if let Some(market_value) = market_value {
                     return ResolvedActivityEconomics {
                         kind,
                         lot_cost_basis_value,
@@ -630,9 +653,11 @@ impl ActivityEconomicsResolver {
         unit_multiplier: Decimal,
     ) -> Decimal {
         let quantity = activity.qty();
-        let price_basis =
-            quantity * activity.price() * Self::valid_unit_multiplier(unit_multiplier);
-        if !price_basis.is_zero() {
+        let price_basis = quantity
+            .checked_mul(activity.price())
+            .and_then(|value| value.checked_mul(Self::valid_unit_multiplier(unit_multiplier)))
+            .filter(|value| !value.is_zero());
+        if let Some(price_basis) = price_basis {
             return price_basis;
         }
 
@@ -940,6 +965,131 @@ mod cash_tests {
         assert_eq!(resolved.final_amount, Some(dec!(1)));
         assert_eq!(resolved.signed_cash_effect, Some(dec!(-1)));
         assert_eq!(resolved.gross_amount, Some(dec!(1)));
+    }
+
+    #[test]
+    fn a_trade_gross_too_large_to_represent_derives_nothing() {
+        // `rust_decimal` panics on overflow rather than saturating, and nothing
+        // bounds quantity or unit price on the way in. A product we cannot
+        // represent is not a figure to claim anything about, so it derives
+        // nothing - the same answer a row with no quantity already gets.
+        let mut buy = inputs(ACTIVITY_TYPE_BUY);
+        buy.quantity = Some(Decimal::MAX);
+        buy.unit_price = Some(dec!(2));
+
+        assert_eq!(
+            ActivityEconomicsResolver::calculate_trade_final_cash(buy),
+            None
+        );
+    }
+
+    #[test]
+    fn a_multiplier_that_overflows_the_trade_gross_derives_nothing() {
+        // The quoted product fits; the contract multiplier is the third factor
+        // that takes it out of range.
+        let mut buy = inputs(ACTIVITY_TYPE_BUY);
+        buy.quantity = Some(Decimal::MAX);
+        buy.unit_price = Some(dec!(1));
+        buy.unit_multiplier = dec!(100);
+
+        assert_eq!(
+            ActivityEconomicsResolver::calculate_trade_final_cash(buy),
+            None
+        );
+    }
+
+    #[test]
+    fn charges_that_overflow_a_representable_gross_derive_nothing() {
+        // The gross itself is representable. Adding the buy's charges to it is
+        // not, and that sum is the number actually being stored.
+        let mut buy = inputs(ACTIVITY_TYPE_BUY);
+        buy.quantity = Some(Decimal::MAX);
+        buy.unit_price = Some(dec!(1));
+        buy.fee = Some(dec!(1));
+        buy.tax = None;
+
+        assert_eq!(
+            ActivityEconomicsResolver::calculate_trade_final_cash(buy),
+            None
+        );
+    }
+
+    #[test]
+    fn charges_too_large_to_total_derive_no_gross() {
+        // Reverse-deriving gross from an authoritative final amount adds the
+        // charges back on. Charges that cannot be totalled leave the stored
+        // final cash untouched and simply yield no gross.
+        let mut buy = inputs(ACTIVITY_TYPE_BUY);
+        buy.amount = Some(dec!(100));
+        buy.fee = Some(Decimal::MAX);
+        buy.tax = Some(Decimal::MAX);
+
+        let resolved = ActivityEconomicsResolver::resolve_cash_inputs(buy);
+
+        assert_eq!(resolved.final_amount, Some(dec!(100)));
+        assert_eq!(resolved.signed_cash_effect, Some(dec!(-100)));
+        assert_eq!(resolved.gross_amount, None);
+    }
+
+    #[test]
+    fn a_composite_gross_too_large_to_represent_derives_nothing() {
+        // Same exposure on the DRIP/staking path, which multiplies the same
+        // three factors.
+        assert_eq!(
+            ActivityEconomicsResolver::calculate_composite_final_cash(
+                ACTIVITY_TYPE_DIVIDEND,
+                Some(ACTIVITY_SUBTYPE_DRIP),
+                Some(Decimal::MAX),
+                Some(dec!(2)),
+                Decimal::ONE,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_lot_basis_too_large_to_represent_falls_back_like_a_zero_one() {
+        // An unrepresentable price basis is no more usable than a zero one, so
+        // it takes the same fallback: the transfer-in's stored amount.
+        let mut transfer = stored_activity(ACTIVITY_TYPE_TRANSFER_IN);
+        transfer.quantity = Some(Decimal::MAX);
+        transfer.unit_price = Some(dec!(2));
+        transfer.amount = Some(dec!(500));
+
+        assert_eq!(
+            ActivityEconomicsResolver::lot_cost_basis_value_with_unit_multiplier(
+                &transfer,
+                Decimal::ONE
+            ),
+            dec!(500)
+        );
+    }
+
+    #[test]
+    fn a_transfer_market_value_too_large_to_represent_defers_to_cost_basis() {
+        // A quote that cannot be multiplied out leaves the transfer exactly
+        // where an absent quote leaves it.
+        let mut transfer = stored_activity(ACTIVITY_TYPE_TRANSFER_IN);
+        transfer.quantity = Some(Decimal::MAX);
+        transfer.unit_price = Some(dec!(1));
+        let quote = Quote {
+            close: dec!(2),
+            currency: "USD".to_string(),
+            ..Default::default()
+        };
+
+        let compiled = ActivityEconomicsResolver::compile_activity_with_unit_multiplier(
+            &transfer,
+            Some(&quote),
+            TransferBoundary::External,
+            Decimal::ONE,
+        );
+
+        assert_eq!(
+            compiled.performance_flow_source,
+            ExternalFlowSource::CostBasisFallback
+        );
+        assert_eq!(compiled.performance_flow_value, Decimal::MAX);
     }
 
     #[test]

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/economics.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/economics.rs
@@ -47,7 +47,11 @@ impl AssetPositionInfo {
 #[inline]
 pub(crate) fn gross_trade_amount(activity: &Activity, asset_info: &AssetPositionInfo) -> Decimal {
     if ActivityEconomicsResolver::is_security_transfer(activity) {
-        return activity.qty() * activity.price() * asset_info.contract_multiplier;
+        return activity
+            .qty()
+            .checked_mul(activity.price())
+            .and_then(|value| value.checked_mul(asset_info.contract_multiplier))
+            .unwrap_or(Decimal::ZERO);
     }
 
     ActivityEconomicsResolver::resolve_cash(activity, asset_info.contract_multiplier)
@@ -90,10 +94,16 @@ pub(crate) fn storage_money(value: Decimal) -> Decimal {
 pub(crate) fn effective_unit_price(activity: &Activity, asset_info: &AssetPositionInfo) -> Decimal {
     let qty = activity.qty();
     let gross = gross_trade_amount(activity, asset_info);
+    // Keep a representable reported price as the fallback when gross cannot
+    // be divided into a per-unit value; otherwise leave the lot basis unknown.
+    let reported_price = activity
+        .price()
+        .checked_mul(asset_info.contract_multiplier)
+        .unwrap_or(Decimal::ZERO);
     if !qty.is_zero() && !gross.is_zero() {
-        gross / qty
+        gross.checked_div(qty).unwrap_or(reported_price)
     } else {
-        activity.price() * asset_info.contract_multiplier
+        reported_price
     }
 }
 

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/economics.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/economics.rs
@@ -142,8 +142,18 @@ pub(crate) fn proportional_amount(
 ) -> Decimal {
     if amount.is_zero() || part_quantity.is_zero() || total_quantity.is_zero() {
         Decimal::ZERO
+    } else if part_quantity == total_quantity {
+        amount
     } else {
-        amount * part_quantity / total_quantity
+        amount
+            .checked_mul(part_quantity)
+            .and_then(|value| value.checked_div(total_quantity))
+            .or_else(|| {
+                amount
+                    .checked_div(total_quantity)
+                    .and_then(|value| value.checked_mul(part_quantity))
+            })
+            .unwrap_or(Decimal::ZERO)
     }
 }
 

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -1119,41 +1119,46 @@ mod tests {
 
     #[test]
     fn drip_with_unrepresentable_acquisition_price_rebuilds_without_panicking() {
-        let mock_fx_service = MockFxService::new();
         let account_currency = "USD";
-        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
-        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
-
         let target_date_str = "2026-05-05";
         let target_date = NaiveDate::from_str(target_date_str).unwrap();
-        let previous_snapshot = create_initial_snapshot("acc_1", account_currency, "2026-05-04");
-        let mut drip = create_default_activity(
-            "overflow-drip-1",
-            ActivityType::Dividend,
-            "AAPL",
-            dec!(0.1),
-            Decimal::ZERO,
-            Decimal::ZERO,
-            account_currency,
-            target_date_str,
-        );
-        drip.subtype = Some("DRIP".to_string());
-        drip.unit_price = None;
-        drip.amount = Some(Decimal::MAX);
+        for (quantity, expected_basis, expected_status) in [
+            (dec!(0.1), Decimal::ZERO, BasisStatus::Unknown),
+            (dec!(2), Decimal::ZERO, BasisStatus::Unknown),
+            (dec!(3), Decimal::MAX, BasisStatus::Complete),
+        ] {
+            let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+            let mut calculator = create_calculator(Arc::new(MockFxService::new()), base_currency);
+            let previous_snapshot =
+                create_initial_snapshot("acc_1", account_currency, "2026-05-04");
+            let mut drip = create_default_activity(
+                "overflow-drip-1",
+                ActivityType::Dividend,
+                "AAPL",
+                quantity,
+                Decimal::ZERO,
+                Decimal::ZERO,
+                account_currency,
+                target_date_str,
+            );
+            drip.subtype = Some("DRIP".to_string());
+            drip.unit_price = None;
+            drip.amount = Some(Decimal::MAX);
 
-        let activities_today = DefaultActivityCompiler::new().compile(&drip).unwrap();
-        let result = calculator
-            .calculate_next_holdings(&previous_snapshot, &activities_today, target_date)
-            .unwrap();
+            let activities_today = DefaultActivityCompiler::new().compile(&drip).unwrap();
+            let result = calculator
+                .calculate_next_holdings(&previous_snapshot, &activities_today, target_date)
+                .unwrap();
 
-        let position = result.snapshot.positions.get("AAPL").unwrap();
-        assert_eq!(position.quantity, dec!(0.1));
-        assert_eq!(position.total_cost_basis, Decimal::ZERO);
-        assert_eq!(position.basis_status(), BasisStatus::Unknown);
-        assert_eq!(
-            result.snapshot.cash_balances.get(account_currency),
-            Some(&Decimal::ZERO)
-        );
+            let position = result.snapshot.positions.get("AAPL").unwrap();
+            assert_eq!(position.quantity, quantity);
+            assert_eq!(position.total_cost_basis, expected_basis);
+            assert_eq!(position.basis_status(), expected_status);
+            assert_eq!(
+                result.snapshot.cash_balances.get(account_currency),
+                Some(&Decimal::ZERO)
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -1118,6 +1118,45 @@ mod tests {
     }
 
     #[test]
+    fn drip_with_unrepresentable_acquisition_price_rebuilds_without_panicking() {
+        let mock_fx_service = MockFxService::new();
+        let account_currency = "USD";
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let target_date_str = "2026-05-05";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let previous_snapshot = create_initial_snapshot("acc_1", account_currency, "2026-05-04");
+        let mut drip = create_default_activity(
+            "overflow-drip-1",
+            ActivityType::Dividend,
+            "AAPL",
+            dec!(0.1),
+            Decimal::ZERO,
+            Decimal::ZERO,
+            account_currency,
+            target_date_str,
+        );
+        drip.subtype = Some("DRIP".to_string());
+        drip.unit_price = None;
+        drip.amount = Some(Decimal::MAX);
+
+        let activities_today = DefaultActivityCompiler::new().compile(&drip).unwrap();
+        let result = calculator
+            .calculate_next_holdings(&previous_snapshot, &activities_today, target_date)
+            .unwrap();
+
+        let position = result.snapshot.positions.get("AAPL").unwrap();
+        assert_eq!(position.quantity, dec!(0.1));
+        assert_eq!(position.total_cost_basis, Decimal::ZERO);
+        assert_eq!(position.basis_status(), BasisStatus::Unknown);
+        assert_eq!(
+            result.snapshot.cash_balances.get(account_currency),
+            Some(&Decimal::ZERO)
+        );
+    }
+
+    #[test]
     fn test_activity_buckets_to_user_local_day_boundary() {
         let mut calculator = create_calculator_with_timezone(
             Arc::new(MockFxService::new()),

--- a/crates/core/src/portfolio/snapshot/positions_model.rs
+++ b/crates/core/src/portfolio/snapshot/positions_model.rs
@@ -20,6 +20,18 @@ pub fn is_quantity_significant(quantity: &Decimal) -> bool {
     quantity.abs() >= threshold
 }
 
+fn checked_lot_cost_basis(
+    quantity: Decimal,
+    unit_price: Decimal,
+    fee: Decimal,
+    tax: Decimal,
+) -> Option<Decimal> {
+    quantity
+        .checked_mul(unit_price)?
+        .checked_add(fee)?
+        .checked_add(tax)
+}
+
 /// Sum a position's cost basis in `target_currency` from its materialized
 /// lots, anchoring each lot to its acquisition-date FX (stored lot rate
 /// preferred). `fx_fallback` supplies an acquisition-date market rate for a lot
@@ -568,7 +580,19 @@ impl Position {
         let acquisition_taxes = activity.tax_amt();
 
         // Cost basis includes acquisition trade charges for BUY activities.
-        let cost_basis = quantity * acquisition_price + acquisition_fees + acquisition_taxes;
+        let cost_basis = checked_lot_cost_basis(
+            quantity,
+            acquisition_price,
+            acquisition_fees,
+            acquisition_taxes,
+        )
+        .unwrap_or_else(|| {
+            warn!(
+                "Lot {} cost basis could not be represented; storing unknown zero basis",
+                activity.id
+            );
+            Decimal::ZERO
+        });
 
         let new_lot = Lot {
             id: activity.id.clone(), // Use activity ID as Lot ID
@@ -652,7 +676,14 @@ impl Position {
             );
         }
 
-        let cost_basis = quantity * unit_price + fee + tax;
+        let cost_basis =
+            checked_lot_cost_basis(quantity, unit_price, fee, tax).unwrap_or_else(|| {
+                warn!(
+                    "Lot {} cost basis could not be represented; storing unknown zero basis",
+                    lot_id
+                );
+                Decimal::ZERO
+            });
 
         let new_lot = Lot {
             id: lot_id,
@@ -725,7 +756,14 @@ impl Position {
             );
         }
 
-        let cost_basis = signed_quantity * unit_price + fee + tax;
+        let cost_basis = checked_lot_cost_basis(signed_quantity, unit_price, fee, tax)
+            .unwrap_or_else(|| {
+                warn!(
+                    "Lot {} cost basis could not be represented; storing unknown zero basis",
+                    lot_id
+                );
+                Decimal::ZERO
+            });
 
         let new_lot = Lot {
             id: lot_id,


### PR DESCRIPTION
`ActivityEconomicsResolver` and the final-cash migration combine user-supplied money fields with unchecked operators. `rust_decimal` panics on overflow rather than saturating, so a single activity whose figures leave `Decimal` range takes down whatever is walking the rows.

## Reproduce

```rust
let inputs = ActivityCashInputs {
    activity_type: "BUY",
    currency: "USD",
    is_security_transfer: false,
    quantity: Some(Decimal::MAX),
    unit_price: Some(dec!(2)),
    amount: Some(dec!(5)),
    fee: None,
    tax: None,
    unit_multiplier: Decimal::ONE,
};
ActivityEconomicsResolver::calculate_trade_final_cash(inputs);
```

```
panicked at rust_decimal-1.42.0/src/arithmetic_impls.rs:232:
Multiplication overflowed
```

Neither `ActivityImport::validate` nor the CSV parser bounds the magnitude of `quantity` or `unit_price`, so a CSV row reaches this. The values need not be absurd individually — two large-but-valid decimals are enough, and the contract multiplier is a third factor on top.

## Why this is worse than one rejected import

#1571 added `run_final_cash_migration`, called at startup from both hosts (`apps/tauri/src/context/providers.rs:384`, `apps/server/src/main_lib.rs:570`). It walks **stored** rows and calls the same helpers. So one such row already in the database panics the migration on every launch, and bounding the import path would do nothing for a row that is already there.

## The fix

Every site is the same shape: `checked_*`, and a figure that cannot be represented takes the route the function already has for "no usable figure". That fallback is not invented here — each of these already models the absence:

| Site | Already had | An unrepresentable result now means |
| --- | --- | --- |
| `derived_positive_gross` | `Option` | `None`, as for a row with no quantity |
| `calculate_composite_final_cash` | `Option` | `None`, as for an unrecognised subtype |
| `cash_effect_from_trade_gross` | `Option` | `None` |
| `resolve_cash_inputs` gross derivation | `Option` | `None`, as for an unhandled activity type |
| security-transfer market value | falls through when zero | falls through, exactly as an absent quote does |
| `lot_cost_basis_value_with_unit_multiplier` | falls back when zero | same fallback: the transfer-in's stored amount |
| `legacy_cash_postings` derived amount / reinvested price | `Option` candidates | not a candidate, so the `.or` chain moves on |

Additional overflow handling:

- **`classify_legacy_activity_cash`** totalled `fee + tax` only to ask `!charges.is_zero()`. Both accessors return absolute values, so the sum is zero exactly when both are; asking each in turn is equivalent and cannot overflow.
- **`legacy_runtime_cash_effect` / `legacy_compiled_cash_effect`** now return `Option`, and `LegacyCashDecision::previous_cash_effect` is `Option<Decimal>`. Neither cash-effect total is stored. The migration preserves unknown final totals as `Option<Decimal>` too, flags them for review, and rebuilds whenever either total is unknown or the known totals differ. This includes the case where both totals are `None`. That is the conservative direction.

The current composite compiler also uses `checked_div` when deriving an acquisition price from stored income. Compiled cash and gross totals use checked addition and require every posting effect to be available, so classification cannot panic or report a partial total when final postings exceed `Decimal` range. The holdings calculator carries the same checked division through its effective lot price and falls back to a representable reported price or unknown zero basis. Lot creation checks multiplication and charge addition, storing unknown zero basis when the result cannot be represented. Full-quantity cash allocation returns the original amount directly; partial allocation uses checked arithmetic with a divide-first fallback when multiplication would overflow. Transfer basis status uses the usable resolved basis: failed derivation without a usable fallback reports `Unknown` with a diagnostic; a usable stored amount still supplies complete basis.

Negation is left unchecked deliberately: `Decimal::MIN` is exactly `-Decimal::MAX`, so it cannot overflow. There is a comment saying so where it would otherwise look like an oversight.

Nothing changes for any input that was already representable, which is every real activity.

## Tests

The original eight regression tests cover:

- a trade gross too large to represent
- a contract multiplier that is the factor taking it out of range
- charges that overflow an otherwise representable gross
- charges too large to total, on the reverse-derivation path
- the same overflow on the DRIP/staking composite path
- a lot basis too large to represent, falling back like a zero one
- a transfer market value too large to represent, deferring to cost basis
- a stored row the startup migration must still classify rather than die on

Six additional regression tests cover composite division through migration classification, unknown credit-card staking totals and review state, checked cash/gross aggregation, propagation of an unknown posting gross, the full holdings rebuild path across quantities `0.1`, `2`, and `3`, and transfer basis status with and without a usable stored amount.

`cargo test --workspace` passes. `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo check -p wealthfolio-server --release` are clean.

## Provenance

This is the arithmetic-hardening half of #1499. Codex flagged the FX-rate division there, I fixed it together with the multiplication that reaches it earlier, and #1499 was then closed as superseded by #1571 — correctly, since #1571 fixes the underlying cost-basis defect at the root instead of warning about it. The hardening did not come across with the feature, so this raises it against the code that replaced it.
