### PR TITLE
fix(i18n): add allocation_other_in_category to the zh-Hant catalog

### DIFF
--- a/apps/frontend/src/i18n/locales/zh-Hant/common.json
+++ b/apps/frontend/src/i18n/locales/zh-Hant/common.json
@@ -364,5 +364,6 @@
   "navStyle": {
     "sidebar": "側邊欄",
     "floating": "浮動欄"
-  }
+  },
+  "allocation_other_in_category": "其他{{category}}"
 }


### PR DESCRIPTION
Fixes #1632.

`main` fails its own Traditional Chinese parity test, so every open PR that merges `main` in goes red on a job unrelated to its changes.

#1498 added the residual-child label to `en`, `de`, `es`, `fr`, `it`, `ja`, `ko` and `zh`, but not `zh-Hant`. `src/i18n/traditional-chinese.test.ts` asserts the zh-Hant catalog carries every key in `en/`, so the missing key fails the suite on `main` at `bcc0a2de4`.

### Change

One key in `apps/frontend/src/i18n/locales/zh-Hant/common.json`, placed last to match `en` and `zh`:

```json
"allocation_other_in_category": "其他{{category}}"
```

Same rendering as `zh` — the phrase needs no conversion between scripts, and the `{{category}}` interpolation matches, which the same test also checks.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).