### PR TITLE
fix(ui): prevent dialog content overflow

### DIFF
--- a/apps/frontend/src/components/dialog-layout.test.tsx
+++ b/apps/frontend/src/components/dialog-layout.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@wealthfolio/ui";
+import { describe, expect, it } from "vitest";
+
+const useDesktopDialog = () => false;
+
+describe("dialog overflow containment", () => {
+  it("constrains dialog children and allows footer actions to wrap", () => {
+    render(
+      <Dialog open useIsMobile={useDesktopDialog}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Long dialog title</DialogTitle>
+            <DialogDescription>Long dialog description</DialogDescription>
+          </DialogHeader>
+          <DialogFooter data-testid="dialog-footer">
+            <div>
+              <Button>First action</Button>
+              <Button>Second action</Button>
+              <Button>Third action</Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toHaveClass("[&>*]:min-w-0");
+    expect(screen.getByTestId("dialog-footer")).toHaveClass(
+      "max-sm:[&_button]:whitespace-normal",
+      "max-sm:[&_button]:shrink",
+      "sm:flex-wrap",
+    );
+  });
+
+  it("constrains alert dialog children and allows footer actions to wrap", () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Long alert title</AlertDialogTitle>
+            <AlertDialogDescription>Long alert description</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter data-testid="alert-dialog-footer">
+            <AlertDialogCancel>First action</AlertDialogCancel>
+            <AlertDialogAction>Second action</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    expect(screen.getByRole("alertdialog")).toHaveClass(
+      "[&>*]:min-w-0",
+      "max-h-[calc(100dvh-env(safe-area-inset-bottom,0px)-2rem)]",
+      "overflow-y-auto",
+    );
+    expect(screen.getByTestId("alert-dialog-footer")).toHaveClass(
+      "max-sm:[&_button]:whitespace-normal",
+      "max-sm:[&_button]:shrink",
+      "sm:flex-wrap",
+    );
+  });
+});

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
@@ -145,6 +145,56 @@ describe("DeviceSyncSection", () => {
     });
   });
 
+  it("keeps ready-state overwrite actions responsive", async () => {
+    vi.useFakeTimers();
+    try {
+      const bootstrapSync = {
+        mutateAsync: vi.fn().mockResolvedValue({
+          status: "overwrite_required",
+          localRows: 12,
+          nonEmptyTables: [{ table: "accounts", rows: 1 }],
+        }),
+        isPending: false,
+        error: null,
+      };
+
+      hookMocks.useSyncStatus.mockReturnValue({
+        isLoading: false,
+        error: null,
+        syncState: "READY",
+        trustedDevices: [{ id: "trusted-1", name: "Laptop", platform: "mac", lastSeenAt: null }],
+        device: { trustState: "trusted" },
+        engineStatus: {
+          lastCycleStatus: "stale_cursor",
+          bootstrapRequired: true,
+          backgroundRunning: false,
+        },
+        engineIsFetching: false,
+        refetch: vi.fn(),
+      });
+      hookMocks.useDevices.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+      hookMocks.useSyncActions.mockReturnValue(createActions({ bootstrapSync }));
+
+      renderWithQueryClient(<DeviceSyncSection />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      await flushAsyncWork();
+
+      expect(screen.getByRole("button", { name: "Back up first" }).parentElement).toHaveClass(
+        "max-sm:[&>button]:whitespace-normal",
+        "sm:flex-wrap",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("requires confirmation when any other non-revoked device exists", async () => {
     const reinitializeSync = {
       mutateAsync: vi.fn().mockResolvedValue(undefined),

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -1025,7 +1025,7 @@ export function DeviceSyncSection() {
               )}
             </AlertDialogHeader>
 
-            <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-center max-sm:[&>button]:h-auto max-sm:[&>button]:min-h-11 max-sm:[&>button]:max-w-full max-sm:[&>button]:whitespace-normal">
               <Button
                 variant="ghost"
                 onClick={() => handleBootstrapOverwriteDialogOpenChange(false)}
@@ -1077,7 +1077,7 @@ export function DeviceSyncSection() {
                 {t("sync:reinit.description")}
               </AlertDialogDescription>
             </AlertDialogHeader>
-            <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-center max-sm:[&>button]:h-auto max-sm:[&>button]:min-h-11 max-sm:[&>button]:max-w-full max-sm:[&>button]:whitespace-normal">
               <Button variant="ghost" onClick={() => setShowReinitConfirmDialog(false)}>
                 {t("sync:reinit.notNow")}
               </Button>

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/index.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/index.test.tsx
@@ -194,7 +194,12 @@ describe("PairingFlow", () => {
     render(<PairingFlow />);
 
     expect(screen.getByText("Replace data on this device?")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Replace & Sync" }));
+    const replaceButton = screen.getByRole("button", { name: "Replace & Sync" });
+    expect(replaceButton.parentElement).toHaveClass(
+      "max-sm:[&>button]:whitespace-normal",
+      "sm:flex-wrap",
+    );
+    fireEvent.click(replaceButton);
     expect(approveOverwrite).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
@@ -334,7 +334,7 @@ function PairingOverwriteConsent({
   const isBusy = isBackingUp || isApproving;
 
   return (
-    <div className="flex flex-col items-center gap-6 px-4 py-2 text-center">
+    <div className="flex min-w-0 flex-col items-center gap-6 px-4 py-2 text-center">
       <div className="border-warning/30 bg-warning/10 dark:border-warning/20 dark:bg-warning/15 flex h-14 w-14 items-center justify-center rounded-full border">
         <Icons.AlertTriangle className="h-6 w-6 text-amber-500" />
       </div>
@@ -350,7 +350,7 @@ function PairingOverwriteConsent({
         )}
         {error && <p className="text-destructive text-sm">{error}</p>}
       </div>
-      <div className="flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-center max-sm:[&>button]:h-auto max-sm:[&>button]:min-h-11 max-sm:[&>button]:max-w-full max-sm:[&>button]:whitespace-normal">
         <Button variant="ghost" onClick={onCancel} disabled={isBusy}>
           {t("sync:overwrite.notNow")}
         </Button>

--- a/apps/frontend/src/features/devices-sync/components/recovery-dialog.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/recovery-dialog.test.tsx
@@ -31,6 +31,10 @@ describe("RecoveryDialog", () => {
       ),
     ).toBeInTheDocument();
 
+    expect(
+      screen.getByRole("button", { name: "Set Up This Device Again" }).parentElement,
+    ).toHaveClass("max-sm:[&>button]:whitespace-normal", "sm:flex-wrap");
+
     fireEvent.click(screen.getByRole("button", { name: "Set Up This Device Again" }));
 
     expect(hookMocks.mutateAsync).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/features/devices-sync/components/recovery-dialog.tsx
+++ b/apps/frontend/src/features/devices-sync/components/recovery-dialog.tsx
@@ -43,7 +43,7 @@ export function RecoveryDialog({ open, onOpenChange }: RecoveryDialogProps) {
             {t("sync:recovery.description")}
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-center max-sm:[&>button]:h-auto max-sm:[&>button]:min-h-11 max-sm:[&>button]:max-w-full max-sm:[&>button]:whitespace-normal">
           <Button variant="ghost" onClick={() => onOpenChange?.(false)}>
             {t("sync:recovery.notNow")}
           </Button>

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 max-sm:bottom-[calc(env(safe-area-inset-bottom)+1rem)] max-sm:left-4 max-sm:right-4 max-sm:top-auto max-sm:w-auto max-sm:translate-x-0 max-sm:translate-y-0 max-sm:rounded-3xl max-sm:shadow-2xl sm:rounded-lg",
+        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-env(safe-area-inset-bottom,0px)-2rem)] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border p-6 shadow-lg duration-200 max-sm:bottom-[calc(env(safe-area-inset-bottom)+1rem)] max-sm:left-4 max-sm:right-4 max-sm:top-auto max-sm:w-auto max-sm:translate-x-0 max-sm:translate-y-0 max-sm:rounded-3xl max-sm:shadow-2xl sm:rounded-lg [&>*]:min-w-0",
         className,
       )}
       {...props}
@@ -50,7 +50,10 @@ AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("flex flex-col-reverse gap-3 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2", className)}
+    className={cn(
+      "flex flex-col-reverse gap-3 sm:flex-row sm:flex-wrap sm:justify-end sm:gap-2 max-sm:[&_button]:h-auto max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-0 max-sm:[&_button]:max-w-full max-sm:[&_button]:shrink max-sm:[&_button]:whitespace-normal",
+      className,
+    )}
     {...props}
   />
 );

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -154,7 +154,7 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
           ref={ref}
           data-slot="dialog-content"
           className={cn(
-            "bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200",
+            "bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 [&>*]:min-w-0",
             className,
           )}
           {...props}
@@ -194,7 +194,10 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-footer"
-      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:flex-wrap sm:justify-end max-sm:[&_button]:h-auto max-sm:[&_button]:min-h-11 max-sm:[&_button]:min-w-0 max-sm:[&_button]:max-w-full max-sm:[&_button]:shrink max-sm:[&_button]:whitespace-normal",
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- prevent localized dialog actions from forcing content beyond the dialog bounds
- allow standard dialog and alert-dialog footers to wrap, including nested buttons
- constrain alert dialogs to the viewport and make oversized content scrollable
- harden the device-sync overwrite, reinitialize, pairing, and recovery action layouts
- add regression coverage for shared dialog containment and device-sync variants

## Root cause

The shared button style uses `whitespace-nowrap` and `shrink-0`, while the shadcn-derived dialog footers did not wrap. Multiple or longer translated actions could therefore establish a minimum content width larger than the dialog.

## Validation

- `pnpm --filter @wealthfolio/ui build`
- `pnpm --filter @wealthfolio/ui type-check`
- `pnpm --filter frontend type-check`
- focused dialog/device-sync tests: 18 passed
- browser verification at `http://localhost:1430/`: footer actions remain contained and the alert-dialog max height resolves to the viewport minus 32px with vertical scrolling enabled
- full frontend suite with bounded workers: 1,922 passed; 1 unrelated existing failure in `traditional-chinese.test.ts` because `allocation_other_in_category` is missing from the Traditional Chinese catalog on `main`
