### PR TITLE
docs(addons): align documentation with SDK 3.8

### DIFF
--- a/docs/addons/addon-api-reference.md
+++ b/docs/addons/addon-api-reference.md
@@ -2,8 +2,8 @@
 
 Complete reference for Wealthfolio addon APIs. Data APIs require an appropriate
 permission entry in `manifest.json`. The baseline capabilities — `query`,
-`storage`, `toast`, `logger`, UI integration, and packaged assets — are
-available to every addon and need no declaration.
+`storage`, `toast`, `logger`, navigation, UI integration, and packaged assets —
+are available to every addon and need no declaration.
 
 ## Context Overview
 
@@ -12,11 +12,11 @@ The `AddonContext` is provided to your addon's `enable` function:
 ```typescript
 export interface AddonContext {
   api: HostAPI;
-  sidebar: SidebarAPI;
-  router: RouterAPI;
+  sidebar: SidebarManager;
+  router: RouterManager;
   ui: { root: HTMLElement };
   assets: AddonAssets;
-  onDisable: (callback: () => void) => void;
+  onDisable(callback: () => void): void;
 }
 ```
 
@@ -155,14 +155,18 @@ host.
 
 ### Methods
 
-#### `getClient(): QueryClient`
+#### `getClient(): unknown`
 
-Gets the sandbox's addon-local QueryClient. It is reused across this addon's
-routes, but its cache is not shared with the host or other addons. Calls to the
-client's `invalidateQueries()` and `refetchQueries()` are mirrored to the host.
+Gets the sandbox's addon-local QueryClient as an opaque bridge value. Cast it to
+the exported `QueryClient` type before using TanStack Query methods or passing
+it to `QueryClientProvider`. It is reused across this addon's routes, but its
+cache is not shared with the host or other addons. Calls to the client's
+`invalidateQueries()` and `refetchQueries()` are mirrored to the host.
 
 ```typescript
-const queryClient = ctx.api.query.getClient();
+import type { QueryClient } from "@wealthfolio/addon-sdk";
+
+const queryClient = ctx.api.query.getClient() as QueryClient;
 
 // Use standard React Query methods
 const accounts = await queryClient.fetchQuery({
@@ -263,7 +267,7 @@ which is what enables lazy activation. Two primitives:
 Runtime sidebar registration still exists for **genuinely dynamic** items;
 static nav should be declared in the manifest instead.
 
-#### `addItem(item: SidebarItem): SidebarItemHandle`
+#### `addItem(config: SidebarItemConfig): SidebarItemHandle`
 
 ```typescript
 const sidebarItem = ctx.sidebar.addItem({
@@ -577,7 +581,7 @@ import type {
   Account,
   Activity,
   Holding,
-  PerformanceHistory,
+  PerformanceResult,
   PerformanceSummary,
   // ... and many more
 } from "@wealthfolio/addon-sdk";
@@ -602,30 +606,29 @@ const holdings: Holding[] = await ctx.api.portfolio.getHoldings(accounts[0].id);
 [official addon examples](https://github.com/wealthfolio/wealthfolio-addons/tree/main/official)
 to see these APIs in action.
 
-````
-
 ---
 
 ## Performance API
 
 Calculate portfolio and account performance metrics with historical analysis.
-`returns.irr` is the selected-period money-weighted return. `returns.annualizedIrr`
-is the annualized XIRR on the same dated cash flows.
+`returns.irr` is the selected-period money-weighted return.
+`returns.annualizedIrr` is the annualized XIRR on the same dated cash flows.
 
 ### Methods
 
-#### `calculateHistory(itemType: 'account' | 'symbol', itemId: string, startDate: string, endDate: string): Promise<PerformanceResult>`
+#### `calculateHistory(itemType: 'account' | 'symbol', itemId: string, startDate?: string, endDate?: string): Promise<PerformanceResult>`
+
 Calculates detailed performance history for charts and analysis.
 
 ```typescript
 const history = await ctx.api.performance.calculateHistory(
-  'account',
-  'account-123',
-  '2024-01-01',
-  '2024-12-31'
+  "account",
+  "account-123",
+  "2024-01-01",
+  "2024-12-31",
 );
 console.log(history.returns.twr, history.returns.irr, history.series);
-````
+```
 
 #### `calculateSummary(args: { itemType: 'account' | 'symbol'; itemId: string; startDate?: string | null; endDate?: string | null; }): Promise<PerformanceResult>`
 
@@ -682,7 +685,8 @@ const updatedRate = await ctx.api.exchangeRates.update({
   fromCurrency: "USD",
   toCurrency: "EUR",
   rate: 0.85,
-  // ... other rate data
+  source: "MANUAL",
+  timestamp: "2024-12-01T00:00:00Z",
 });
 ```
 
@@ -695,7 +699,8 @@ const newRate = await ctx.api.exchangeRates.add({
   fromCurrency: "USD",
   toCurrency: "GBP",
   rate: 0.75,
-  // ... other rate data
+  source: "MANUAL",
+  timestamp: "2024-12-01T00:00:00Z",
 });
 ```
 
@@ -844,11 +849,9 @@ Creates a new contribution limit.
 
 ```typescript
 const limit = await ctx.api.contributionLimits.create({
-  name: "RRSP 2024",
-  limitType: "RRSP",
-  maxAmount: 30000,
-  year: 2024,
-  // ... other limit data
+  groupName: "RRSP",
+  contributionYear: 2024,
+  limitAmount: 30000,
 });
 ```
 
@@ -858,9 +861,9 @@ Updates an existing contribution limit.
 
 ```typescript
 const updatedLimit = await ctx.api.contributionLimits.update("limit-123", {
-  name: "Updated RRSP 2024",
-  maxAmount: 31000,
-  // ... other updated data
+  groupName: "RRSP",
+  contributionYear: 2024,
+  limitAmount: 31000,
 });
 ```
 
@@ -889,16 +892,16 @@ Gets all goals.
 const goals = await ctx.api.goals.getAll();
 ```
 
-#### `create(goal: any): Promise<Goal>`
+#### `create(goal: unknown): Promise<Goal>`
 
 Creates a new goal.
 
 ```typescript
 const goal = await ctx.api.goals.create({
-  name: "Retirement Fund",
+  goalType: "retirement",
+  title: "Retirement Fund",
   targetAmount: 500000,
   targetDate: "2040-01-01",
-  // ... other goal data
 });
 ```
 
@@ -921,13 +924,18 @@ Gets funding rules for a goal.
 const allocations = await ctx.api.goals.getFunding("goal-123");
 ```
 
-#### `saveFunding(goalId: string, allocations: GoalAllocation[]): Promise<GoalAllocation[]>`
+#### `saveFunding(goalId: string, rules: GoalAllocation[]): Promise<GoalAllocation[]>`
 
 Saves funding rules for a goal.
 
 ```typescript
 await ctx.api.goals.saveFunding("goal-123", [
-  { goalId: "goal-123", accountId: "account-456", sharePercent: 50 },
+  {
+    id: "allocation-123",
+    goalId: "goal-123",
+    accountId: "account-456",
+    sharePercent: 50,
+  },
 ]);
 ```
 
@@ -939,7 +947,12 @@ Deprecated: use `saveFunding(goalId, allocations)` instead.
 
 ```typescript
 await ctx.api.goals.updateAllocations([
-  { goalId: "goal-123", accountId: "account-456", sharePercent: 50 },
+  {
+    id: "allocation-123",
+    goalId: "goal-123",
+    accountId: "account-456",
+    sharePercent: 50,
+  },
   // ... other allocations
 ]);
 ```
@@ -1007,7 +1020,7 @@ if (files) {
 }
 ```
 
-#### `openSaveDialog(fileContent: Uint8Array | Blob | string, fileName: string): Promise<any>`
+#### `openSaveDialog(fileContent: Uint8Array | Blob | string, fileName: string): Promise<unknown>`
 
 Opens a file save dialog.
 

--- a/docs/addons/addon-api-reference.md
+++ b/docs/addons/addon-api-reference.md
@@ -328,118 +328,125 @@ const enable: AddonEnableFunction = (ctx) => {
 
 ---
 
-## Error Handling
+## Activities API
 
-### API Error Types
+Create, update, search, and import activities. These methods require the
+corresponding functions in the `activities` permission.
 
-```typescript
-interface APIError {
-  code: string;
-  message: string;
-  details?: any;
-}
-```
+### Methods
 
-Common error codes:
+#### `getAll(accountId?: string): Promise<ActivityDetails[]>`
 
-- `PERMISSION_DENIED` - Insufficient permissions
-- `NOT_FOUND` - Resource not found
-- `VALIDATION_ERROR` - Invalid data provided
-- `NETWORK_ERROR` - Connection issues
-- `RATE_LIMITED` - Too many requests
-
-### Best Practices
+Gets all activities, optionally filtered to one account.
 
 ```typescript
-try {
-  const accounts = await ctx.api.accounts.getAll();
+const activities = await ctx.api.activities.getAll("account-123");
 ```
 
-#### `search(
+#### `search(page: number, pageSize: number, filters: ActivitySearchFilters, searchKeyword: string, sort?: ActivitySort): Promise<ActivitySearchResponse>`
 
-page: number, pageSize: number, filters: ActivitySearchFilters, searchKeyword:
-string, sort?: ActivitySort, ): Promise<ActivitySearchResponse>`
+Searches activities with pagination, filters, and one optional sort.
 
-Search activities with pagination, filters, and a single optional sort.
-
-- `page`: Zero-based page index. Use `0` for the first page (e.g., for exports
-  you can pass `0` with a large `pageSize` such as `1000`).
-- `pageSize`: Number of rows per page.
-- `filters`: Accepts single strings or arrays for `accountIds` and
-  `activityTypes`. Empty strings/arrays are ignored.
+- `page`: Zero-based page index. Use `0` for the first page.
+- `filters`: Accepts a string or array for `accountIds` and `activityTypes`.
+  Empty values are ignored.
 - `searchKeyword`: Free-form keyword search; pass an empty string when unused.
-- `sort`: Optional sort object (defaults to `{ id: "date", desc: true }`). Only
-  one sort is supported.
+- `sort`: Defaults to `{ id: "date", desc: true }` when omitted.
 
 ```typescript
 const { data, meta } = await ctx.api.activities.search(
   0,
   50,
   {
-    accountIds: "account-1", // single string or string[] both work
+    accountIds: "account-1",
     activityTypes: ["BUY", "DIVIDEND"],
-    symbol: "AAPL", // optional exact symbol filter
+    symbol: "AAPL",
   },
-  "", // optional search keyword
+  "",
   { id: "date", desc: true },
 );
 
 console.log(meta.totalRowCount);
 ```
 
-#### `update(activity: ActivityUpdate): Promise<Activity>`
+#### `create(activity: ActivityCreate): Promise<Activity>`
 
-Updates an existing activity with conflict detection.
+Creates an activity. Wealthfolio 3.8 adds the optional `status` and
+`needsReview` fields to `ActivityCreate`.
 
 ```typescript
-const updated = await ctx.api.activities.update({
-  ...existingActivity,
-  quantity: 150,
-  unitPrice: 145.75,
+const activity = await ctx.api.activities.create({
+  accountId: "account-123",
+  activityType: "BUY",
+  activityDate: "2026-09-04",
+  asset: { symbol: "AAPL" },
+  quantity: 100,
+  unitPrice: 150.5,
+  currency: "USD",
+  status: "POSTED",
+  needsReview: false,
 });
 ```
 
-#### `saveMany(activities: ActivityUpdate[]): Promise<Activity[]>`
+#### `update(activity: ActivityUpdate): Promise<Activity>`
 
-Efficiently creates multiple activities in a single transaction.
-
-```typescript
-const activities = await ctx.api.activities.saveMany([
-  { accountId: "account-123", activityType: "BUY" /* ... */ },
-  { accountId: "account-123", activityType: "DIVIDEND" /* ... */ },
-]);
-```
-
-#### `delete(activityId: string): Promise<void>`
-
-Deletes an activity and updates portfolio calculations.
+Updates an activity. Wealthfolio 3.8 adds the optional `status` and
+`needsReview` fields. Omit `asset` to preserve the current asset association;
+pass `asset: {}` to clear it.
 
 ```typescript
-await ctx.api.activities.delete("activity-456");
+const updated = await ctx.api.activities.update({
+  ...editableActivity, // ActivityUpdate
+  quantity: 150,
+  unitPrice: 145.75,
+  needsReview: false,
+});
 ```
 
-#### `import(activities: ActivityImport[]): Promise<ActivityImport[]>`
+Addons using the review fields or asset patch semantics must set
+`minWealthfolioVersion` to `3.8.0` or newer.
 
-Imports validated activities with duplicate detection.
+#### `saveMany(request: ActivityBulkMutationRequest): Promise<ActivityBulkMutationResult>`
+
+Creates, updates, and deletes activities in one request.
 
 ```typescript
-const imported = await ctx.api.activities.import(checkedActivities);
+const result = await ctx.api.activities.saveMany({
+  creates: [
+    {
+      accountId: "account-123",
+      activityType: "DIVIDEND",
+      activityDate: "2026-09-04",
+      amount: 25,
+      currency: "USD",
+    },
+  ],
+  updates: [],
+  deleteIds: [],
+});
 ```
 
-#### `checkImport(accountId: string, activities: ActivityImport[]): Promise<ActivityImport[]>`
+#### `import(activities: ActivityImport[]): Promise<ImportActivitiesResult>`
 
-Validates activities before import with error reporting.
+Imports validated activities with duplicate detection and returns the import
+run, imported activities, and summary.
 
 ```typescript
-const validated = await ctx.api.activities.checkImport(
-  "account-123",
-  activities,
-);
+const result = await ctx.api.activities.import(checkedActivities);
 ```
 
-#### `getImportMapping(accountId: string): Promise<ImportMappingData>`
+#### `checkImport(activities: ActivityImport[]): Promise<ActivityImport[]>`
 
-Get import mapping configuration for an account.
+Validates and normalizes activities without importing them.
+
+```typescript
+const validated = await ctx.api.activities.checkImport(activities);
+```
+
+#### `getImportMapping(accountId: string, contextKind?: string): Promise<ImportMappingData>`
+
+Gets import mapping configuration for an account. `contextKind` defaults to
+`"ACTIVITY"`.
 
 ```typescript
 const mapping = await ctx.api.activities.getImportMapping("account-123");
@@ -447,26 +454,26 @@ const mapping = await ctx.api.activities.getImportMapping("account-123");
 
 #### `saveImportMapping(mapping: ImportMappingData): Promise<ImportMappingData>`
 
-Save import mapping configuration.
+Saves import mapping configuration.
 
 ```typescript
 const savedMapping = await ctx.api.activities.saveImportMapping(mapping);
 ```
 
+---
+
+## Error Handling
+
+Host API failures reject their promise with an error. Handle failures at the
+user action boundary and show a useful message without exposing financial data.
+
 ```typescript
 try {
   const accounts = await ctx.api.accounts.getAll();
 } catch (error) {
-  if (error.code === "PERMISSION_DENIED") {
-    ctx.api.logger.error("Missing account permissions");
-    // Show user-friendly message
-  } else if (error.code === "NETWORK_ERROR") {
-    ctx.api.logger.warn("Network issue, retrying...");
-    // Implement retry logic
-  } else {
-    ctx.api.logger.error("Unexpected error:", error);
-    // General error handling
-  }
+  const message = error instanceof Error ? error.message : String(error);
+  ctx.api.logger.error(`Unable to load accounts: ${message}`);
+  ctx.api.toast.error("Unable to load accounts");
 }
 ```
 
@@ -504,23 +511,23 @@ const { data, meta } = await ctx.api.activities.search(
 console.log(meta.totalRowCount);
 
 // Batch create
-const newActivities = await ctx.api.activities.saveMany([
-  {
-    /* activity 1 */
-  },
-  {
-    /* activity 2 */
-  },
-  {
-    /* activity 3 */
-  },
-]);
+const result = await ctx.api.activities.saveMany({
+  creates: [
+    {
+      accountId: "account-1",
+      activityType: "DEPOSIT",
+      activityDate: "2026-09-04",
+      amount: 1000,
+      currency: "USD",
+    },
+  ],
+});
 ```
 
 ### Real-time Updates
 
 ```typescript
-export default function enable(ctx: AddonContext) {
+export default async function enable(ctx: AddonContext) {
   // Listen for multiple events
   const unsubscribers = [
     await ctx.api.events.portfolio.onUpdateComplete(() => refreshData()),
@@ -703,6 +710,9 @@ to come from an exact quote on the requested date.
 Results preserve the input order. A pair that cannot be resolved returns
 `rate: null` and an `error` without failing the rest of the batch.
 
+This method requires Wealthfolio 3.8 or newer. Addons using it must set
+`minWealthfolioVersion` to `3.8.0` or newer.
+
 ```typescript
 const results = await ctx.api.exchangeRates.getRatesForDates([
   { fromCurrency: "USD", toCurrency: "EUR", date: "2024-01-15" },
@@ -726,6 +736,10 @@ Classify activities (e.g. `WITHDRAWAL`s) into the user's existing spend-category
 taxonomy via Wealthfolio's categorization-rules engine, instead of a one-off
 per-activity tag. A rule is reusable — it keeps applying to future matching
 imports, not just the activities that exist when it's created.
+
+This API requires Wealthfolio 3.8 or newer and the medium-risk `spending`
+permission. Declare only the methods your addon calls from `isEnabled`,
+`getCategories`, `getRules`, `saveRule`, `deleteRule`, and `rerunRules`.
 
 `kind` selects which of Wealthfolio's three fixed activity-scope taxonomies a
 category or rule belongs to: `"expense"`, `"income"`, or `"saving"`. Asset
@@ -797,15 +811,15 @@ await ctx.api.spending.deleteRule("my-addon-rule-1");
 
 #### `rerunRules(onlyUncategorized?: boolean): Promise<number>`
 
-Re-runs all categorization rules. Defaults to `true`, which only fills in
-currently uncategorized activities — this preserves any existing manual or
-AI-assigned categories. Pass `false` to also overwrite existing rule/AI/import-
-assigned categories. Call this after an import so newly created activities pick
-up matching rules, since a rule only recategorizes existing activities at the
-moment it's created or updated.
+Re-runs all categorization rules and returns the number of activities matched by
+a rule. Defaults to `true`, which only fills in currently uncategorized
+activities. Pass `false` to also overwrite existing rule/AI/history/import-
+assigned categories. Manual assignments are always preserved. Call this after an
+import so newly created activities pick up matching rules, since a rule only
+recategorizes existing activities at the moment it's created or updated.
 
 ```typescript
-const touched = await ctx.api.spending.rerunRules();
+const matched = await ctx.api.spending.rerunRules();
 ```
 
 ---
@@ -956,19 +970,17 @@ Gets application settings.
 const settings = await ctx.api.settings.get();
 ```
 
-#### `update(settingsUpdate: Settings): Promise<Settings>`
+#### `update(settingsUpdate: Partial<Settings>): Promise<Settings>`
 
 Updates application settings.
 
 ```typescript
 const updatedSettings = await ctx.api.settings.update({
-  ...currentSettings,
   baseCurrency: "EUR",
-  // ... other settings
 });
 ```
 
-#### `backupDatabase(): Promise<{ filename: string; data: Uint8Array }>`
+#### `backupDatabase(): Promise<{ filename: string }>`
 
 Creates a database backup.
 

--- a/docs/addons/addon-architecture.md
+++ b/docs/addons/addon-architecture.md
@@ -139,23 +139,25 @@ The Rust backend scans for patterns like:
 
 Based on the actual code, these are the permission categories:
 
-| Category              | Functions                                   | Risk Level |
-| --------------------- | ------------------------------------------- | ---------- |
-| `accounts`            | getAll, create                              | High       |
-| `portfolio`           | getHoldings, update, recalculate            | High       |
-| `activities`          | getAll, search, create, update, import      | High       |
-| `market-data`         | searchTicker, sync, getProviders            | Low        |
-| `assets`              | getProfile, updateProfile, updateDataSource | Medium     |
-| `quotes`              | update, getHistory                          | Low        |
-| `performance`         | calculateHistory, calculateSummary          | Medium     |
-| `currency`            | getAll, update, add, getRatesForDates       | Low        |
-| `goals`               | getAll, create, update, updateAllocations   | Medium     |
-| `contribution-limits` | getAll, create, update, calculateDeposits   | Medium     |
-| `settings`            | get, update, backupDatabase                 | Medium     |
-| `files`               | openCsvDialog, openSaveDialog               | Medium     |
-| `events`              | onDrop, onUpdateComplete, onSyncStart       | Low        |
-| `network`             | request (brokered fetch to declared hosts)  | High       |
-| `secrets`             | set, get, delete                            | High       |
+| Category              | Risk Level | Common Functions                                                     |
+| --------------------- | ---------- | -------------------------------------------------------------------- |
+| `accounts`            | High       | getAll, create                                                       |
+| `portfolio`           | High       | getHoldings, getHolding, update, recalculate                         |
+| `activities`          | High       | getAll, search, create, update, saveMany, import                     |
+| `market-data`         | Low        | searchTicker, syncHistory, sync, getProviders, fetchDividends        |
+| `assets`              | Medium     | getProfile, updateProfile, updateQuoteMode                           |
+| `quotes`              | Low        | update, getHistory                                                   |
+| `performance`         | Medium     | calculateHistory, calculateSummary, calculateAccountsSimple          |
+| `currency`            | Low        | getAll, update, add, getRatesForDates                                |
+| `spending`            | Medium     | isEnabled, getCategories, getRules, saveRule, deleteRule, rerunRules |
+| `financial-planning`  | Medium     | getAll, create, update, getFunding, saveFunding                      |
+| `contribution-limits` | Medium     | getAll, create, update, calculateDeposits                            |
+| `settings`            | Medium     | get, update, backupDatabase                                          |
+| `files`               | Medium     | openCsvDialog, openSaveDialog                                        |
+| `snapshots`           | High       | getAll, getByDate, save, checkImport, importSnapshots                |
+| `events`              | Low        | onDrop, onUpdateComplete, onSyncComplete                             |
+| `network`             | High       | request                                                              |
+| `secrets`             | High       | set, get, use, delete                                                |
 
 > **Baseline capabilities are not permissions.** `ui`, packaged `assets`,
 > `query`, `toast`, `logger`, and `storage` are granted to every addon and are
@@ -254,12 +256,16 @@ interface HostAPI {
   quotes: QuotesAPI;
   performance: PerformanceAPI;
   exchangeRates: ExchangeRatesAPI;
+  spending: SpendingAPI;
   goals: GoalsAPI;
   contributionLimits: ContributionLimitsAPI;
   settings: SettingsAPI;
   files: FilesAPI;
+  snapshots: SnapshotsAPI;
   events: EventsAPI;
   secrets: SecretsAPI;
+  network: NetworkAPI;
+  navigation: NavigationAPI;
 }
 ```
 
@@ -572,8 +578,8 @@ Each addon includes a manifest.json file:
   "version": "1.0.0",
   "description": "Does something useful",
   "main": "dist/addon.js",
-  "sdkVersion": "3.7.0",
-  "minWealthfolioVersion": "3.7.0",
+  "sdkVersion": "3.8.0",
+  "minWealthfolioVersion": "3.8.0",
   "contributes": {
     "routes": [{ "id": "my-addon" }],
     "links": {
@@ -618,7 +624,7 @@ Optional fields:
   render before booting the addon
 - `permissions`: Declared data access (array of
   `{ category, functions, purpose }`)
-- `sdkVersion`: SDK version the addon targets (`"3.7.0"`)
+- `sdkVersion`: SDK version the addon targets (`"3.8.0"`)
 - `minWealthfolioVersion`: Minimum host version required to load the addon
 
 The host mounts every contributed route below `/addons/<manifest.id>`. Omit

--- a/docs/addons/addon-architecture.md
+++ b/docs/addons/addon-architecture.md
@@ -159,10 +159,10 @@ Based on the actual code, these are the permission categories:
 | `network`             | High       | request                                                              |
 | `secrets`             | High       | set, get, use, delete                                                |
 
-> **Baseline capabilities are not permissions.** `ui`, packaged `assets`,
-> `query`, `toast`, `logger`, and `storage` are granted to every addon and are
-> **not** declared in `manifest.json`. Only data categories plus `files`,
-> `network`, `secrets`, `events`, `snapshots`, and `settings` require
+> **Baseline capabilities are not permissions.** `ui`, `navigation`, packaged
+> `assets`, `query`, `toast`, `logger`, and `storage` are granted to every addon
+> and are **not** declared in `manifest.json`. Only data categories plus
+> `files`, `network`, `secrets`, `events`, `snapshots`, and `settings` require
 > declaration and consent.
 
 ### Permission Enforcement
@@ -247,11 +247,12 @@ interface HostAPI {
   storage: StorageAPI;
   toast: ToastAPI;
   logger: LoggerAPI;
+  navigation: NavigationAPI;
   // Domain data APIs — gated by manifest permissions
   accounts: AccountsAPI;
   portfolio: PortfolioAPI;
   activities: ActivitiesAPI;
-  market: MarketAPI;
+  market: MarketDataAPI;
   assets: AssetsAPI;
   quotes: QuotesAPI;
   performance: PerformanceAPI;
@@ -265,7 +266,6 @@ interface HostAPI {
   events: EventsAPI;
   secrets: SecretsAPI;
   network: NetworkAPI;
-  navigation: NavigationAPI;
 }
 ```
 

--- a/docs/addons/addon-getting-started.md
+++ b/docs/addons/addon-getting-started.md
@@ -93,8 +93,8 @@ permissions it needs:
   "description": "My first Wealthfolio addon",
   "author": "Your Name",
   "main": "dist/addon.js",
-  "sdkVersion": "3.7.0",
-  "minWealthfolioVersion": "3.7.0",
+  "sdkVersion": "3.8.0",
+  "minWealthfolioVersion": "3.8.0",
   "enabled": true,
   "contributes": {
     "routes": [{ "id": "hello-world" }],
@@ -300,7 +300,7 @@ function HelloWorldPage({ ctx }: { ctx: AddonContext }) {
     queryKey: ['accounts'],
     queryFn: () => ctx.api.accounts.getAll(),
     onError: (error) => {
-      ctx.api.logger.error('Failed to load accounts:', error);
+      ctx.api.logger.error(`Failed to load accounts: ${String(error)}`);
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: false,
@@ -417,8 +417,8 @@ declaring a data `category`, the `functions` you call, and a human-readable
   "description": "My first Wealthfolio addon",
   "author": "Your Name",
   "main": "dist/addon.js",
-  "sdkVersion": "3.7.0",
-  "minWealthfolioVersion": "3.7.0",
+  "sdkVersion": "3.8.0",
+  "minWealthfolioVersion": "3.8.0",
   "enabled": true,
   "contributes": {
     "routes": [{ "id": "hello-world" }],

--- a/docs/addons/addon-getting-started.md
+++ b/docs/addons/addon-getting-started.md
@@ -126,11 +126,11 @@ The host derives the route URL from the manifest `id`, so this root page is
 mounted at `/addons/hello-world-addon`. Omit `path` for the root; nested pages
 use a relative suffix such as `"path": "reports/:year"`.
 
-> **Permissions:** `ui`, `query`, `toast`, `logger`, and `storage` are implicit
-> **baseline capabilities** — you do not declare them. Only data categories
-> (`accounts`, `portfolio`, `activities`, …) plus `files`, `network`, `secrets`,
-> `events`, `snapshots`, and `settings` require a permission entry and user
-> consent.
+> **Permissions:** `ui`, `navigation`, `query`, `toast`, `logger`, and `storage`
+> are implicit **baseline capabilities** — you do not declare them. Only data
+> categories (`accounts`, `portfolio`, `activities`, …) plus `files`, `network`,
+> `secrets`, `events`, `snapshots`, and `settings` require a permission entry
+> and user consent.
 
 ## Main Addon File
 
@@ -283,6 +283,7 @@ import {
   QueryClientProvider,
   useQuery,
 } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import type {
   Account,
   AddonContext,
@@ -299,12 +300,15 @@ function HelloWorldPage({ ctx }: { ctx: AddonContext }) {
   } = useQuery<Account[]>({
     queryKey: ['accounts'],
     queryFn: () => ctx.api.accounts.getAll(),
-    onError: (error) => {
-      ctx.api.logger.error(`Failed to load accounts: ${String(error)}`);
-    },
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    if (isError) {
+      ctx.api.logger.error(`Failed to load accounts: ${String(error)}`);
+    }
+  }, [ctx, error, isError]);
 
   return (
     <div className="p-6 max-w-4xl mx-auto">
@@ -356,9 +360,9 @@ function HelloWorldPage({ ctx }: { ctx: AddonContext }) {
                       </div>
                       <div className="text-right">
                         <div className="text-lg font-semibold">
-                          {account.totalValue?.toLocaleString() || 'N/A'}
+                          {account.balance.toLocaleString()}
                         </div>
-                        <div className="text-sm text-muted-foreground">Total Value</div>
+                        <div className="text-sm text-muted-foreground">Balance</div>
                       </div>
                     </div>
                   </div>

--- a/docs/addons/addon-localization.md
+++ b/docs/addons/addon-localization.md
@@ -8,6 +8,10 @@ localization: **formatting** (numbers, currencies, dates — region-driven) and
 Both follow the user's settings automatically and update live when the user
 changes them — no reload, no listeners to wire up.
 
+The sandbox localization runtime described here ships with Wealthfolio 3.8.
+Addons that use these APIs must set both `sdkVersion` and
+`minWealthfolioVersion` to `3.8.0` or newer.
+
 ## Region formatting (numbers, currencies, dates)
 
 The host separates the UI **language** from the **formatting region**: a user
@@ -100,6 +104,10 @@ Behavior and rules:
   separately from `zh`. A missing `zh-Hant` string falls back to your `en`
   bundle, never to `zh`: Simplified glyphs in a Traditional UI read as broken
   rather than untranslated.
+
+  Regional aliases normalize to the host's supported language. For example,
+  `fr-CA` becomes `fr`, while `zh-TW`, `zh-HK`, and `zh-MO` become `zh-Hant`.
+  Invalid language keys are ignored with a warning.
 
 - **Fallback is your `en` bundle.** If the current language is missing a key (or
   the whole bundle), lookup falls back to your `en` resources; if that is

--- a/docs/addons/addon-migration-guide-v2-to-v3.md
+++ b/docs/addons/addon-migration-guide-v2-to-v3.md
@@ -282,7 +282,7 @@ const ActivityType = {
   SPLIT: "SPLIT",
 };
 
-// v3 - 15 types (added CREDIT, ADJUSTMENT, UNKNOWN)
+// v3 - 14 types (removed ADD_HOLDING/REMOVE_HOLDING; added CREDIT/ADJUSTMENT/UNKNOWN)
 const ActivityType = {
   BUY: "BUY",
   SELL: "SELL",
@@ -327,7 +327,7 @@ interface Activity {
   accountId: string;
   assetId?: string; // NOW OPTIONAL for pure cash events
 
-  activityType: string; // Canonical type (closed set of 15)
+  activityType: string; // Canonical type (closed set of 14)
   activityTypeOverride?: string; // User override
   sourceType?: string; // Raw provider label
   subtype?: string; // Semantic variation (DRIP, STAKING_REWARD, etc.)

--- a/docs/addons/addon-packages.md
+++ b/docs/addons/addon-packages.md
@@ -172,7 +172,10 @@ import { Input, Label, Checkbox, Select } from "@wealthfolio/ui";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui";
 
 // Feedback
-import { Alert, AlertDescription, Toast } from "@wealthfolio/ui";
+import { Alert, AlertDescription } from "@wealthfolio/ui";
+
+// User notifications are exposed by the addon context
+ctx.api.toast.success("Saved");
 ```
 
 ### Icons
@@ -215,7 +218,7 @@ export default function PerformanceChart({ data }) {
 
 ### React Query
 
-Available through `@wealthfolio/ui`:
+Available as a host-provided dependency:
 
 ```typescript
 import { useQuery } from '@tanstack/react-query';
@@ -277,7 +280,7 @@ export default function Card({ className, children }) {
 
 ### date-fns
 
-Available through `@wealthfolio/ui`:
+Available as a host-provided dependency:
 
 ```typescript
 import { format, parseISO, isAfter } from 'date-fns';
@@ -287,8 +290,8 @@ export default function ActivityList({ activities }) {
     <div>
       {activities.map(activity => (
         <div key={activity.id}>
-          <span>{format(parseISO(activity.date), 'MMM dd, yyyy')}</span>
-          <span>{activity.type}</span>
+          <span>{format(parseISO(activity.activityDate), 'MMM dd, yyyy')}</span>
+          <span>{activity.activityType}</span>
         </div>
       ))}
     </div>

--- a/docs/addons/addon-packages.md
+++ b/docs/addons/addon-packages.md
@@ -36,7 +36,7 @@ import type {
 } from "@wealthfolio/addon-sdk";
 ```
 
-**Version:** 3.7.0 **Peer Dependencies:** React ^19.2.4
+**Version:** 3.8.0 **Peer Dependencies:** React ^19.2.4
 
 ### @wealthfolio/ui
 
@@ -305,8 +305,8 @@ You can add other npm packages to your addon:
 ```json
 {
   "dependencies": {
-    "@wealthfolio/addon-sdk": "^3.7.0",
-    "@wealthfolio/ui": "^3.7.0",
+    "@wealthfolio/addon-sdk": "^3.8.0",
+    "@wealthfolio/ui": "^3.8.0",
     "react": "^19.2.4"
   }
 }
@@ -340,13 +340,13 @@ Template for addon package.json:
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@wealthfolio/addon-sdk": "^3.7.0",
-    "@wealthfolio/ui": "^3.7.0",
+    "@wealthfolio/addon-sdk": "^3.8.0",
+    "@wealthfolio/ui": "^3.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@wealthfolio/addon-dev-tools": "^3.7.0",
+    "@wealthfolio/addon-dev-tools": "^3.8.0",
     "@types/node": "^22.14.0",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
@@ -408,6 +408,7 @@ Always use compatible versions:
 
 | SDK Version | Wealthfolio Version | React Version |
 | ----------- | ------------------- | ------------- |
+| 3.8.x       | 3.8.0+              | ^19.2.4       |
 | 3.7.x       | 3.7.0+              | ^19.2.4       |
 | 3.6.x       | 3.6.0+              | ^19.2.4       |
 

--- a/docs/addons/addons-overview.md
+++ b/docs/addons/addons-overview.md
@@ -129,11 +129,11 @@ const accounts = await ctx.api.accounts.getAll();
 | `network`             | High       | request                                                              |
 | `secrets`             | High       | set, get, use, delete                                                |
 
-> **Baseline capabilities are not permissions.** `ui`, packaged `assets`,
-> `query`, `toast`, `logger`, and `storage` are granted to every addon and must
-> **not** appear in `manifest.json` `permissions`. Only data categories plus
-> `files`, `network`, `secrets`, `events`, `snapshots`, and `settings` require
-> declaration and consent.
+> **Baseline capabilities are not permissions.** `ui`, `navigation`, packaged
+> `assets`, `query`, `toast`, `logger`, and `storage` are granted to every addon
+> and must **not** appear in `manifest.json` `permissions`. Only data categories
+> plus `files`, `network`, `secrets`, `events`, `snapshots`, and `settings`
+> require declaration and consent.
 
 #### 3. User Approval
 
@@ -143,27 +143,29 @@ approve or reject the addon installation.
 ## Available APIs
 
 The addon context provides access to domain-specific data APIs plus a set of
-**baseline capabilities** (`ui`, packaged `assets`, `query`, `storage`, `toast`,
-`logger`) that every addon gets without declaring a permission:
+**baseline capabilities** (`ui`, `navigation`, packaged `assets`, `query`,
+`storage`, `toast`, `logger`) that every addon gets without declaring a
+permission:
 
 ```typescript
 interface AddonContext {
   ui: { root: HTMLElement };
-  sidebar: SidebarAPI;
-  router: RouterAPI;
+  sidebar: SidebarManager;
+  router: RouterManager;
   assets: AddonAssets;
-  onDisable: (callback: () => void) => void;
+  onDisable(callback: () => void): void;
   api: {
     // Baseline capabilities — no permission declaration required
     query: QueryAPI; // addon-local QueryClient with host invalidation bridge
     storage: StorageAPI; // durable, per-addon key/value store
     toast: ToastAPI; // user-facing notifications
     logger: LoggerAPI; // scoped logging
+    navigation: NavigationAPI; // application route navigation
     // Domain data APIs — declared in manifest `permissions`
     accounts: AccountsAPI;
     portfolio: PortfolioAPI;
     activities: ActivitiesAPI;
-    market: MarketAPI;
+    market: MarketDataAPI;
     assets: AssetsAPI;
     quotes: QuotesAPI;
     performance: PerformanceAPI;
@@ -177,7 +179,6 @@ interface AddonContext {
     events: EventsAPI;
     secrets: SecretsAPI;
     network: NetworkAPI;
-    navigation: NavigationAPI;
   };
 }
 ```

--- a/docs/addons/addons-overview.md
+++ b/docs/addons/addons-overview.md
@@ -109,22 +109,25 @@ const accounts = await ctx.api.accounts.getAll();
 
 #### 2. Permission Categories
 
-| Category      | Risk Level | Functions                                   |
-| ------------- | ---------- | ------------------------------------------- |
-| `accounts`    | High       | getAll, create                              |
-| `portfolio`   | High       | getHoldings, update, recalculate            |
-| `activities`  | High       | getAll, search, create, update, import      |
-| `market-data` | Low        | searchTicker, sync, getProviders            |
-| `assets`      | Medium     | getProfile, updateProfile, updateDataSource |
-| `quotes`      | Low        | update, getHistory                          |
-| `performance` | Medium     | calculateHistory, calculateSummary          |
-| `currency`    | Low        | getAll, update, add, getRatesForDates       |
-| `goals`       | Medium     | getAll, create, update, updateAllocations   |
-| `settings`    | Medium     | get, update, backupDatabase                 |
-| `files`       | Medium     | openCsvDialog, openSaveDialog               |
-| `events`      | Low        | onDrop, onUpdateComplete, onSyncStart       |
-| `secrets`     | High       | set, get, delete                            |
-| `network`     | High       | request (brokered fetch to declared hosts)  |
+| Category              | Risk Level | Common Functions                                                     |
+| --------------------- | ---------- | -------------------------------------------------------------------- |
+| `accounts`            | High       | getAll, create                                                       |
+| `portfolio`           | High       | getHoldings, getHolding, update, recalculate                         |
+| `activities`          | High       | getAll, search, create, update, saveMany, import                     |
+| `market-data`         | Low        | searchTicker, syncHistory, sync, getProviders, fetchDividends        |
+| `assets`              | Medium     | getProfile, updateProfile, updateQuoteMode                           |
+| `quotes`              | Low        | update, getHistory                                                   |
+| `performance`         | Medium     | calculateHistory, calculateSummary, calculateAccountsSimple          |
+| `currency`            | Low        | getAll, update, add, getRatesForDates                                |
+| `spending`            | Medium     | isEnabled, getCategories, getRules, saveRule, deleteRule, rerunRules |
+| `financial-planning`  | Medium     | getAll, create, update, getFunding, saveFunding                      |
+| `contribution-limits` | Medium     | getAll, create, update, calculateDeposits                            |
+| `settings`            | Medium     | get, update, backupDatabase                                          |
+| `files`               | Medium     | openCsvDialog, openSaveDialog                                        |
+| `snapshots`           | High       | getAll, getByDate, save, checkImport, importSnapshots                |
+| `events`              | Low        | onDrop, onUpdateComplete, onSyncComplete                             |
+| `network`             | High       | request                                                              |
+| `secrets`             | High       | set, get, use, delete                                                |
 
 > **Baseline capabilities are not permissions.** `ui`, packaged `assets`,
 > `query`, `toast`, `logger`, and `storage` are granted to every addon and must
@@ -165,12 +168,16 @@ interface AddonContext {
     quotes: QuotesAPI;
     performance: PerformanceAPI;
     exchangeRates: ExchangeRatesAPI;
+    spending: SpendingAPI;
     goals: GoalsAPI;
     contributionLimits: ContributionLimitsAPI;
     settings: SettingsAPI;
     files: FilesAPI;
+    snapshots: SnapshotsAPI;
     events: EventsAPI;
     secrets: SecretsAPI;
+    network: NetworkAPI;
+    navigation: NavigationAPI;
   };
 }
 ```
@@ -252,8 +259,8 @@ automatically. Addons using this API must set `minWealthfolioVersion` to
   "main": "dist/addon.js",
   "description": "Addon description",
   "author": "Your Name",
-  "sdkVersion": "3.7.0",
-  "minWealthfolioVersion": "3.7.0",
+  "sdkVersion": "3.8.0",
+  "minWealthfolioVersion": "3.8.0",
   "enabled": true,
   "contributes": {
     "routes": [{ "id": "my-addon" }],

--- a/docs/addons/shared-query-client-design.md
+++ b/docs/addons/shared-query-client-design.md
@@ -7,7 +7,9 @@ across that addon's route renders, then cleared when the sandbox stops. It is
 not the main application's client and does not share the host's in-memory cache.
 
 ```tsx
-const addonQueryClient = ctx.api.query.getClient();
+import type { QueryClient } from "@wealthfolio/addon-sdk";
+
+const addonQueryClient = ctx.api.query.getClient() as QueryClient;
 
 function AddonRoot() {
   return (

--- a/packages/addon-sdk/CHANGELOG.md
+++ b/packages/addon-sdk/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to
   setting. Requires a Wealthfolio release that ships this sandbox runtime
   (unreleased at the time of writing). See the
   [Addon Localization guide](../../docs/addons/addon-localization.md).
+- Optional `status` and `needsReview` fields on `ActivityCreate` and
+  `ActivityUpdate`.
+
+### Changed
+
+- `ActivityUpdate.asset` now has explicit patch semantics: omit it to preserve
+  the current asset, or pass an empty object to clear the asset association.
+- Host-provided `@wealthfolio/addon-sdk` and `@wealthfolio/ui` dependency ranges
+  are now `^3.8.0`.
 
 ## [3.7.0] - 2026-08-10
 

--- a/packages/addon-sdk/README.md
+++ b/packages/addon-sdk/README.md
@@ -42,6 +42,8 @@ integrations, and visualizations.
 - **ESM Support**: Modern ECMAScript modules with tree-shaking support
 - **Comprehensive Logging**: Built-in logging system with multiple levels
 - **Event System**: Subscribe to application events and state changes
+- **Spend Categorization**: Manage reusable expense, income, and savings rules
+- **Localization**: Follow the host locale with scoped addon translations
 - **Performance Optimized**: Lightweight bundle with minimal overhead
 - **Developer Tools**: Built-in debugging and development utilities
 - **Backwards Compatible**: Stable API with semantic versioning
@@ -130,7 +132,7 @@ pnpm add @wealthfolio/addon-sdk @tanstack/react-query
 ### Package Information
 
 - **Package Name**: `@wealthfolio/addon-sdk`
-- **Current Version**: 3.7.0
+- **Current Version**: 3.8.0
 - **Bundle Format**: ESM (ECMAScript Modules)
 - **Type Definitions**: Included (TypeScript ready)
 - **License**: MIT
@@ -233,8 +235,8 @@ Create a `manifest.json` file in your addon root:
   "homepage": "https://github.com/yourname/investment-fees-tracker",
   "license": "MIT",
   "main": "dist/addon.js",
-  "sdkVersion": "3.7.0",
-  "minWealthfolioVersion": "3.7.0",
+  "sdkVersion": "3.8.0",
+  "minWealthfolioVersion": "3.8.0",
   "keywords": ["portfolio", "fees", "tracking", "analytics"],
   "icon": "data:image/svg+xml;base64,...",
   "permissions": [
@@ -426,12 +428,9 @@ export function FeesPage({ ctx }: FeesPageProps) {
 
   useEffect(() => {
     if (!isLoading) {
-      ctx.api.logger.info('Fees data loaded successfully', {
-        accountsCount: accounts?.length,
-        holdingsCount: holdings?.length,
-        activitiesCount: activities?.data?.length,
-        totalFees
-      });
+      ctx.api.logger.info(
+        `Fees data loaded successfully (${accounts?.length ?? 0} accounts, ${holdings?.length ?? 0} holdings, ${activities?.data?.length ?? 0} activities, ${totalFees} in fees)`,
+      );
     }
   }, [isLoading, accounts, holdings, activities, totalFees, ctx.api.logger]);
 
@@ -560,11 +559,10 @@ export function usePortfolioData(accountId?: string) {
         setHoldings(holdingsData);
 
         if (accountId) {
-          const performanceData =
-            await ctx.api.portfolio.calculatePerformanceSummary({
-              itemType: 'account',
-              itemId: accountId,
-            });
+          const performanceData = await ctx.api.performance.calculateSummary({
+            itemType: 'account',
+            itemId: accountId,
+          });
           console.log(
             performanceData.returns.twr,
             performanceData.returns.irr,
@@ -594,18 +592,28 @@ cash flows.
 
 ### Permission Categories
 
-| Category             | Risk Level | Description                     |
-| -------------------- | ---------- | ------------------------------- |
-| `ui`                 | Low        | Add navigation items and routes |
-| `market-data`        | Low        | Access market prices and quotes |
-| `events`             | Low        | Listen to application events    |
-| `currency`           | Low        | Access exchange rates           |
-| `portfolio`          | Medium     | Access holdings and valuations  |
-| `files`              | Medium     | File dialog operations          |
-| `financial-planning` | Medium     | Goals and contribution limits   |
-| `activities`         | High       | Transaction history access      |
-| `accounts`           | High       | Account management              |
-| `settings`           | High       | Application configuration       |
+| Category              | Risk Level | Description                                  |
+| --------------------- | ---------- | -------------------------------------------- |
+| `market-data`         | Low        | Search and synchronize market data           |
+| `quotes`              | Low        | Read and update quotes                       |
+| `events`              | Low        | Listen to application events                 |
+| `currency`            | Low        | Access exchange rates                        |
+| `assets`              | Medium     | Read and update financial asset profiles     |
+| `performance`         | Medium     | Calculate portfolio performance              |
+| `spending`            | Medium     | View categories and manage spending rules    |
+| `financial-planning`  | Medium     | Manage goals and allocations                 |
+| `contribution-limits` | Medium     | Manage contribution limits                   |
+| `files`               | Medium     | Open host file dialogs                       |
+| `settings`            | Medium     | Access application configuration             |
+| `portfolio`           | High       | Access holdings and valuations               |
+| `activities`          | High       | Access and modify transaction history        |
+| `accounts`            | High       | Access and create accounts                   |
+| `snapshots`           | High       | Access and modify holdings snapshots         |
+| `network`             | High       | Request declared external HTTPS hosts        |
+| `secrets`             | High       | Store and use secrets through the OS keyring |
+
+`ui`, `query`, `toast`, `logger`, and `storage` are baseline capabilities and
+must not be declared as permissions.
 
 ### Declaring Permissions
 
@@ -614,7 +622,7 @@ cash flows.
   "permissions": [
     {
       "category": "portfolio",
-      "functions": ["getHoldings", "getHolding", "calculatePerformanceSummary"],
+      "functions": ["getHoldings", "getHolding"],
       "purpose": "Display detailed portfolio analytics and performance metrics"
     },
     {
@@ -624,8 +632,13 @@ cash flows.
     },
     {
       "category": "market-data",
-      "functions": ["searchTicker", "getQuoteHistory"],
+      "functions": ["searchTicker"],
       "purpose": "Show price charts and enable ticker search functionality"
+    },
+    {
+      "category": "spending",
+      "functions": ["getCategories", "saveRule"],
+      "purpose": "Save categorization rules selected by the user"
     }
   ]
 }
@@ -794,7 +807,6 @@ Add an item to the application sidebar.
   `chart-bar`, or `calendar-dots`
 - `config.route` (string): Navigation route
 - `config.order` (number): Display order (optional)
-- `config.onClick` (function): Click handler (optional)
 
 **Returns:** `SidebarItemHandle` with `remove()` method
 
@@ -805,8 +817,10 @@ Register a new route in the application.
 **Parameters:**
 
 - `route.path` (string): Route path pattern
-- `route.render` (function): `({ root, location }) => void` — mount your React
-  root into the provided `root` element
+- `route.component` (component): Preferred; the host mounts the React component
+  and passes the current `location`
+- `route.render` (function): Legacy imperative alternative receiving
+  `{ root, location }`
 
 #### `onDisable(callback)`
 
@@ -828,42 +842,65 @@ const holdings = await ctx.api.portfolio.getHoldings(accountId);
 const accounts = await ctx.api.accounts.getAll();
 
 // Market data
-const quotes = await ctx.api.marketData.getQuoteHistory(symbol);
-const profile = await ctx.api.marketData.getAssetProfile(assetId);
+const symbols = await ctx.api.market.searchTicker('AAPL');
+const quotes = await ctx.api.quotes.getHistory(assetId);
+const profile = await ctx.api.assets.getProfile(assetId);
 
 // Financial planning
 const goals = await ctx.api.goals.getAll();
-const limits = await ctx.api.financialPlanning.getContributionLimit();
+const limits = await ctx.api.contributionLimits.getAll();
+
+// Historical exchange rates and spend categorization (Wealthfolio 3.8+)
+const rates = await ctx.api.exchangeRates.getRatesForDates([
+  { fromCurrency: 'USD', toCurrency: 'EUR', date: '2026-09-04' },
+]);
+const spendCategories = await ctx.api.spending.getCategories('expense');
 
 // Settings
-const settings = await ctx.api.getSettings();
+const settings = await ctx.api.settings.get();
 
 // Logging and debugging
 ctx.api.logger.info('Operation completed successfully');
-ctx.api.logger.error('Error occurred:', error);
-ctx.api.logger.debug('Debug info:', debugData);
+ctx.api.logger.error(`Error occurred: ${String(error)}`);
+ctx.api.logger.debug(`Debug info: ${JSON.stringify(debugData)}`);
 ```
 
 ### Available API Methods
 
-| Method                                          | Description                                               | Permission Required  |
-| ----------------------------------------------- | --------------------------------------------------------- | -------------------- |
-| `portfolio.getHoldings(accountId)`              | Get portfolio holdings for account                        | `portfolio`          |
-| `portfolio.getHolding(accountId, assetId)`      | Get specific holding                                      | `portfolio`          |
-| `portfolio.calculatePerformanceSummary(params)` | Calculate performance metrics                             | `portfolio`          |
-| `portfolio.getIncomeSummary()`                  | Get income summary data                                   | `portfolio`          |
-| `accounts.getAll()`                             | Get all account information                               | `accounts`           |
-| `accounts.create(account)`                      | Create new account                                        | `accounts`           |
-| `activities.getAll(accountId?)`                 | Get activity history (optionally filtered to one account) | `activities`         |
-| `activities.create(activity)`                   | Create new activity                                       | `activities`         |
-| `marketData.getQuoteHistory(symbol)`            | Get historical quotes                                     | `market-data`        |
-| `marketData.getAssetProfile(assetId)`           | Get asset profile                                         | `market-data`        |
-| `marketData.searchTicker(query)`                | Search for tickers                                        | `market-data`        |
-| `goals.getAll()`                                | Get financial goals                                       | `financial-planning` |
-| `goals.getFunding(goalId)`                      | Get funding rules for a goal                              | `financial-planning` |
-| `goals.saveFunding(goalId, rules)`              | Save funding rules for a goal                             | `financial-planning` |
-| `settings.get()`                                | Get app settings                                          | `settings`           |
-| `query.getClient()`                             | Get this addon's QueryClient                              | None                 |
+| Method                                     | Description                                 | Permission Required   |
+| ------------------------------------------ | ------------------------------------------- | --------------------- |
+| `portfolio.getHoldings(accountId)`         | Get portfolio holdings for an account       | `portfolio`           |
+| `portfolio.getHolding(accountId, assetId)` | Get a specific holding                      | `portfolio`           |
+| `performance.calculateSummary(params)`     | Calculate performance metrics               | `performance`         |
+| `accounts.getAll()`                        | Get all account information                 | `accounts`            |
+| `accounts.create(account)`                 | Create an account                           | `accounts`            |
+| `activities.getAll(accountId?)`            | Get activity history                        | `activities`          |
+| `activities.create(activity)`              | Create an activity                          | `activities`          |
+| `market.searchTicker(query)`               | Search for tickers                          | `market-data`         |
+| `assets.getProfile(assetId)`               | Get a financial asset profile               | `assets`              |
+| `quotes.getHistory(assetId)`               | Get historical quotes                       | `quotes`              |
+| `exchangeRates.getRatesForDates(pairs)`    | Resolve dated exchange rates                | `currency`            |
+| `spending.isEnabled()`                     | Check whether Spending is enabled           | `spending`            |
+| `spending.getCategories(kind?)`            | List expense, income, or savings categories | `spending`            |
+| `spending.getRules()`                      | List this addon's categorization rules      | `spending`            |
+| `spending.saveRule(rule)`                  | Create or update an addon-owned rule        | `spending`            |
+| `spending.deleteRule(ruleKey)`             | Delete an addon-owned rule                  | `spending`            |
+| `spending.rerunRules(onlyUncategorized?)`  | Re-run categorization rules                 | `spending`            |
+| `goals.getAll()`                           | Get financial goals                         | `financial-planning`  |
+| `contributionLimits.getAll()`              | Get contribution limits                     | `contribution-limits` |
+| `settings.get()`                           | Get application settings                    | `settings`            |
+| `query.getClient()`                        | Get this addon's QueryClient                | None                  |
+
+The Spending and dated exchange-rate APIs require Wealthfolio 3.8 or newer. See
+the [complete API reference](../../docs/addons/addon-api-reference.md).
+
+### Localization
+
+Wealthfolio 3.8 addons can register private translation bundles with
+`registerTranslations()` and read them from React components with
+`useAddonTranslation()`. Addons using these exports must set
+`minWealthfolioVersion` to `3.8.0` or newer. See the
+[localization guide](../../docs/addons/addon-localization.md).
 
 > Tip: `activities.getAll` accepts an optional account ID string to scope
 > results to a single account. The SDK normalizes this for both desktop (Tauri)
@@ -902,19 +939,12 @@ The SDK provides a comprehensive logging system:
 ```typescript
 const ctx = getAddonContext();
 
-// Log levels: 'error', 'warn', 'info', 'debug'
-ctx.api.logger.error('Critical error occurred', { error, context });
-ctx.api.logger.warn('Warning message', additionalData);
+// Each method accepts one string message.
+ctx.api.logger.error(`Critical error occurred: ${String(error)}`);
+ctx.api.logger.warn(`Warning message: ${String(additionalData)}`);
 ctx.api.logger.info('Information message');
-ctx.api.logger.debug('Debug information', debugObject);
-
-// Set log level (for development)
-ctx.api.logger.setLevel('debug');
-
-// Check if logging level is enabled
-if (ctx.api.logger.isLevelEnabled('debug')) {
-  ctx.api.logger.debug('Expensive debug operation', expensiveData);
-}
+ctx.api.logger.debug(`Debug information: ${JSON.stringify(debugObject)}`);
+ctx.api.logger.trace('Detailed trace message');
 ```
 
 ### Addon QueryClient Integration
@@ -1209,8 +1239,7 @@ npm publish --tag beta
 ```typescript
 // In your addon
 const ctx = getAddonContext();
-ctx.api.logger.setLevel('debug');
-ctx.api.logger.debug('Debug information:', data);
+ctx.api.logger.debug(`Debug information: ${JSON.stringify(data)}`);
 ```
 
 #### 2. Development Console
@@ -1254,14 +1283,8 @@ async function fetchPortfolioData() {
     ).then((results) => results.flat());
     return holdings;
   } catch (error) {
-    ctx.api.logger.error('Failed to fetch holdings:', error);
-
-    // Handle different error types
-    if (error.code === 'PERMISSION_DENIED') {
-      // Show permission error to user
-    } else if (error.code === 'NETWORK_ERROR') {
-      // Handle network issues
-    }
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.api.logger.error(`Failed to fetch holdings: ${message}`);
 
     throw error;
   }
@@ -1438,6 +1461,7 @@ We follow [Semantic Versioning](https://semver.org/) (SemVer):
 
 | SDK Version | Wealthfolio Version | Node.js   | React   |
 | ----------- | ------------------- | --------- | ------- |
+| 3.8.x       | >= 3.8.0            | >= 20.0.0 | ^19.2.4 |
 | 3.7.x       | >= 3.7.0            | >= 20.0.0 | ^19.2.4 |
 | 0.9.x       | >= 0.9.0            | >= 16.0.0 | ^17.0.0 |
 
@@ -1450,10 +1474,10 @@ We follow [Semantic Versioning](https://semver.org/) (SemVer):
 npm install @wealthfolio/addon-sdk
 
 # Specific version
-npm install @wealthfolio/addon-sdk@3.7.0
+npm install @wealthfolio/addon-sdk@3.8.0
 
 # Version range
-npm install @wealthfolio/addon-sdk@^3.7.0
+npm install @wealthfolio/addon-sdk@^3.8.0
 ```
 
 #### Beta/Preview Releases
@@ -1779,13 +1803,10 @@ ls -la dist/  # Should update when you save files
 try {
   const accounts = await ctx.api.accounts.getAll();
   const data = await ctx.api.portfolio.getHoldings(accounts[0]?.id);
-  ctx.api.logger.info('Data loaded successfully', { count: data.length });
+  ctx.api.logger.info(`Data loaded successfully (${data.length} holdings)`);
 } catch (error) {
-  ctx.api.logger.error('API call failed', {
-    error: error.message,
-    stack: error.stack,
-    timestamp: new Date().toISOString(),
-  });
+  const message = error instanceof Error ? error.message : String(error);
+  ctx.api.logger.error(`API call failed: ${message}`);
 }
 ```
 

--- a/packages/addon-sdk/README.md
+++ b/packages/addon-sdk/README.md
@@ -446,11 +446,9 @@ export function FeesPage({ ctx }: FeesPageProps) {
 
   useEffect(() => {
     if (!isLoading) {
-      ctx.api.logger.info(
-        `Fees data loaded successfully (${accounts?.length ?? 0} accounts, ${holdings?.length ?? 0} holdings, ${activities?.length ?? 0} activities, ${totalFees} in fees)`,
-      );
+      ctx.api.logger.info("Fees data loaded successfully");
     }
-  }, [isLoading, accounts, holdings, activities, totalFees, ctx.api.logger]);
+  }, [isLoading, ctx.api.logger]);
 
   if (isLoading) {
     return (

--- a/packages/addon-sdk/README.md
+++ b/packages/addon-sdk/README.md
@@ -127,7 +127,7 @@ pnpm add @wealthfolio/addon-sdk @tanstack/react-query
 - **Node.js**: >= 20.0.0
 - **React**: ^19.2.4 (peer dependency and host-provided version)
 - **TypeScript**: ^5.0.0 (recommended for development)
-- **React Query**: ^4.0.0 or ^5.0.0 (for data fetching)
+- **React Query**: ^5.90.0 (for data fetching)
 
 ### Package Information
 
@@ -142,22 +142,27 @@ pnpm add @wealthfolio/addon-sdk @tanstack/react-query
 
 ### Import Methods
 
-The SDK supports multiple import patterns:
+The SDK supports a public entry point plus focused subpath imports:
 
 ```typescript
-// Default import (recommended)
-import { getAddonContext } from '@wealthfolio/addon-sdk';
+// Public entry point (recommended)
+import type {
+  AddonContext,
+  AddonManifest,
+  Holding,
+  Permission,
+  RiskLevel,
+} from '@wealthfolio/addon-sdk';
+import { PERMISSION_CATEGORIES } from '@wealthfolio/addon-sdk';
 
-// Named imports
-import { AddonContext, PermissionLevel } from '@wealthfolio/addon-sdk';
-
-// Type-only imports
-import type { AddonManifest, Permission } from '@wealthfolio/addon-sdk';
-
-// Subpath imports
-import type { PortfolioHolding } from '@wealthfolio/addon-sdk/types';
-import { PERMISSION_CATEGORIES } from '@wealthfolio/addon-sdk/permissions';
+// Optional module-specific subpath imports
+import type { AddonManifest as Manifest } from '@wealthfolio/addon-sdk/manifest';
+import type { Permission as AddonPermission } from '@wealthfolio/addon-sdk/permissions';
 ```
+
+The `/types` subpath contains core context, routing, sidebar, and event types.
+Financial data types such as `Account`, `Activity`, and `Holding` are exported
+from the package root.
 
 ## 🏗️ Project Structure
 
@@ -241,6 +246,11 @@ Create a `manifest.json` file in your addon root:
   "icon": "data:image/svg+xml;base64,...",
   "permissions": [
     {
+      "category": "accounts",
+      "functions": ["getAll"],
+      "purpose": "List accounts whose holdings will be analyzed"
+    },
+    {
       "category": "portfolio",
       "functions": ["getHoldings"],
       "purpose": "Access portfolio data to calculate fee analytics"
@@ -249,6 +259,11 @@ Create a `manifest.json` file in your addon root:
       "category": "activities",
       "functions": ["getAll"],
       "purpose": "Analyze transaction history for fee calculations"
+    },
+    {
+      "category": "performance",
+      "functions": ["calculateSummary"],
+      "purpose": "Calculate account performance alongside fee totals"
     }
   ]
 }
@@ -287,7 +302,11 @@ example:
 ```typescript
 // src/addon.tsx
 import { QueryClientProvider } from '@tanstack/react-query';
-import type { AddonContext, AddonEnableFunction } from '@wealthfolio/addon-sdk';
+import type {
+  AddonContext,
+  AddonEnableFunction,
+  QueryClient,
+} from '@wealthfolio/addon-sdk';
 import FeesPage from './pages/fees-page';
 
 // Main addon component
@@ -321,7 +340,7 @@ const enable: AddonEnableFunction = (context) => {
 
     // Create wrapper component with this addon's QueryClient
     const InvestmentFeesTrackerWrapper = () => {
-      const addonQueryClient = context.api.query.getClient();
+      const addonQueryClient = context.api.query.getClient() as QueryClient;
       return (
         <QueryClientProvider client={addonQueryClient}>
           <InvestmentFeesTrackerAddon ctx={context} />
@@ -369,7 +388,7 @@ export default enable;
 
 1. **Addon Query Client**: Uses `context.api.query.getClient()` for local data
    fetching with host invalidation bridging
-2. **UI Icons**: Leverages `@wealthfolio/ui` for consistent iconography
+2. **UI Icons**: Uses a host-supported icon token for consistent navigation
 3. **Error Handling**: Comprehensive error handling with logging
 4. **Resource Management**: Proper cleanup of sidebar items and event listeners
 5. **TypeScript**: Full type safety with proper imports
@@ -379,10 +398,9 @@ export default enable;
 
 ```typescript
 // components/FeesPage.tsx
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { AddonContext } from '@wealthfolio/addon-sdk';
-import type { Holding, Account, Activity } from '@wealthfolio/addon-sdk/types';
 
 interface FeesPageProps {
   ctx: AddonContext;
@@ -417,11 +435,11 @@ export function FeesPage({ ctx }: FeesPageProps) {
 
   // Calculate total fees from activities
   const totalFees = React.useMemo(() => {
-    if (!activities?.data) return 0;
+    if (!activities) return 0;
 
-    return activities.data.reduce((total, activity) => {
+    return activities.reduce((total, activity) => {
       // Look for fee-related activities or transaction costs
-      const fee = activity.fee || 0;
+      const fee = Number(activity.fee ?? 0);
       return total + fee;
     }, 0);
   }, [activities]);
@@ -429,7 +447,7 @@ export function FeesPage({ ctx }: FeesPageProps) {
   useEffect(() => {
     if (!isLoading) {
       ctx.api.logger.info(
-        `Fees data loaded successfully (${accounts?.length ?? 0} accounts, ${holdings?.length ?? 0} holdings, ${activities?.data?.length ?? 0} activities, ${totalFees} in fees)`,
+        `Fees data loaded successfully (${accounts?.length ?? 0} accounts, ${holdings?.length ?? 0} holdings, ${activities?.length ?? 0} activities, ${totalFees} in fees)`,
       );
     }
   }, [isLoading, accounts, holdings, activities, totalFees, ctx.api.logger]);
@@ -475,14 +493,16 @@ export function FeesPage({ ctx }: FeesPageProps) {
         <div className="bg-white p-6 rounded-lg shadow border">
           <h2 className="text-xl font-semibold mb-4">Recent Fee Activities</h2>
           <div className="space-y-3">
-            {activities?.data?.slice(0, 5).map((activity) => (
+            {activities?.slice(0, 5).map((activity) => (
               <div key={activity.id} className="flex justify-between items-center py-2 border-b">
                 <div>
                   <p className="font-medium">{activity.activityType}</p>
-                  <p className="text-sm text-gray-600">{activity.date}</p>
+                  <p className="text-sm text-gray-600">
+                    {activity.date.toLocaleDateString()}
+                  </p>
                 </div>
                 <span className="text-red-600 font-medium">
-                  ${(activity.fee || 0).toFixed(2)}
+                  ${Number(activity.fee ?? 0).toFixed(2)}
                 </span>
               </div>
             ))}
@@ -534,10 +554,13 @@ export default AnalyticsDashboard;
 ```typescript
 // hooks/usePortfolioData.ts
 import { useState, useEffect } from 'react';
-import { getAddonContext } from '@wealthfolio/addon-sdk';
-import type { Holding, PerformanceResult } from '@wealthfolio/addon-sdk/types';
+import type {
+  AddonContext,
+  Holding,
+  PerformanceResult,
+} from '@wealthfolio/addon-sdk';
 
-export function usePortfolioData(accountId?: string) {
+export function usePortfolioData(ctx: AddonContext, accountId?: string) {
   const [holdings, setHoldings] = useState<Holding[]>([]);
   const [performance, setPerformance] = useState<PerformanceResult | null>(
     null,
@@ -551,25 +574,25 @@ export function usePortfolioData(accountId?: string) {
         setLoading(true);
         setError(null);
 
-        const ctx = getAddonContext();
+        if (!accountId) {
+          setHoldings([]);
+          setPerformance(null);
+          return;
+        }
 
-        const holdingsData = await ctx.api.portfolio.getHoldings(
-          accountId || '',
-        );
+        const holdingsData = await ctx.api.portfolio.getHoldings(accountId);
         setHoldings(holdingsData);
 
-        if (accountId) {
-          const performanceData = await ctx.api.performance.calculateSummary({
-            itemType: 'account',
-            itemId: accountId,
-          });
-          console.log(
-            performanceData.returns.twr,
-            performanceData.returns.irr,
-            performanceData.risk.maxDrawdown,
-          );
-          setPerformance(performanceData);
-        }
+        const performanceData = await ctx.api.performance.calculateSummary({
+          itemType: 'account',
+          itemId: accountId,
+        });
+        console.log(
+          performanceData.returns.twr,
+          performanceData.returns.irr,
+          performanceData.risk.maxDrawdown,
+        );
+        setPerformance(performanceData);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
       } finally {
@@ -578,7 +601,7 @@ export function usePortfolioData(accountId?: string) {
     }
 
     fetchData();
-  }, [accountId]);
+  }, [accountId, ctx]);
 
   return { holdings, performance, loading, error };
 }
@@ -612,8 +635,8 @@ cash flows.
 | `network`             | High       | Request declared external HTTPS hosts        |
 | `secrets`             | High       | Store and use secrets through the OS keyring |
 
-`ui`, `query`, `toast`, `logger`, and `storage` are baseline capabilities and
-must not be declared as permissions.
+`ui`, `navigation`, `query`, `toast`, `logger`, and `storage` are baseline
+capabilities and must not be declared as permissions.
 
 ### Declaring Permissions
 
@@ -835,7 +858,7 @@ Register cleanup callback for addon disable.
 All data access is performed through the context's `api` property:
 
 ```typescript
-const ctx = getAddonContext();
+// Use the ctx parameter supplied to enable(ctx), or pass it to this helper.
 
 // Portfolio data
 const holdings = await ctx.api.portfolio.getHoldings(accountId);
@@ -937,7 +960,7 @@ const response = await ctx.api.activities.search(
 The SDK provides a comprehensive logging system:
 
 ```typescript
-const ctx = getAddonContext();
+// Use the ctx parameter supplied to enable(ctx), or pass it to this helper.
 
 // Each method accepts one string message.
 ctx.api.logger.error(`Critical error occurred: ${String(error)}`);
@@ -954,28 +977,34 @@ across that addon's route renders, not shared with the host or other addons.
 Invalidate/refetch operations are mirrored to the host:
 
 ```typescript
-// Access this addon's QueryClient instance
-const addonQueryClient = context.api.query.getClient();
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import type { AddonContext, QueryClient } from '@wealthfolio/addon-sdk';
 
 // Wrap your components with QueryClientProvider
-const MyAddonWrapper = () => {
+const MyAddonWrapper = ({ ctx }: { ctx: AddonContext }) => {
+  const addonQueryClient = ctx.api.query.getClient() as QueryClient;
+
   return (
     <QueryClientProvider client={addonQueryClient}>
-      <MyAddonComponent />
+      <MyAddonComponent ctx={ctx} />
     </QueryClientProvider>
   );
 };
 
 // Use React Query hooks in your components
-function MyAddonComponent() {
+function MyAddonComponent({ ctx }: { ctx: AddonContext }) {
   const { data: accounts, isLoading } = useQuery({
     queryKey: ['accounts'],
     queryFn: () => ctx.api.accounts.getAll()
   });
 
+  const selectedAccountId = accounts?.[0]?.id;
   const { data: holdings } = useQuery({
     queryKey: ['holdings', selectedAccountId],
-    queryFn: () => ctx.api.portfolio.getHoldings(selectedAccountId),
+    queryFn: () =>
+      selectedAccountId
+        ? ctx.api.portfolio.getHoldings(selectedAccountId)
+        : Promise.resolve([]),
     enabled: !!selectedAccountId
   });
 
@@ -1009,9 +1038,14 @@ the required development-tools upgrade.
 // Before
 import ctx from '@wealthfolio/addon-sdk';
 
-// After (recommended)
-import { getAddonContext } from '@wealthfolio/addon-sdk';
-const ctx = getAddonContext();
+// Current SDK
+import type { AddonEnableFunction } from '@wealthfolio/addon-sdk';
+
+const enable: AddonEnableFunction = (ctx) => {
+  // Pass ctx to components, hooks, and helper functions that need host APIs.
+};
+
+export default enable;
 ```
 
 #### Type Imports
@@ -1238,8 +1272,9 @@ npm publish --tag beta
 
 ```typescript
 // In your addon
-const ctx = getAddonContext();
-ctx.api.logger.debug(`Debug information: ${JSON.stringify(data)}`);
+function logDebug(ctx: AddonContext, data: unknown) {
+  ctx.api.logger.debug(`Debug information: ${JSON.stringify(data)}`);
+}
 ```
 
 #### 2. Development Console
@@ -1270,11 +1305,9 @@ if (process.env.NODE_ENV === 'development') {
 #### 1. Error Handling
 
 ```typescript
-import { getAddonContext } from '@wealthfolio/addon-sdk';
+import type { AddonContext } from '@wealthfolio/addon-sdk';
 
-async function fetchPortfolioData() {
-  const ctx = getAddonContext();
-
+async function fetchPortfolioData(ctx: AddonContext) {
   try {
     // Get all accounts first, then holdings for each
     const accounts = await ctx.api.accounts.getAll();
@@ -1348,17 +1381,15 @@ const HeavyChart = lazy(() => import('./components/HeavyChart'));
 
 ```typescript
 // Use React Query or SWR for caching
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 function usePortfolioData(accountId: string) {
-  return useQuery(
-    ['portfolio', accountId],
-    () => ctx.api.portfolio.getHoldings(accountId),
-    {
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      cacheTime: 10 * 60 * 1000, // 10 minutes
-    },
-  );
+  return useQuery({
+    queryKey: ['portfolio', accountId],
+    queryFn: () => ctx.api.portfolio.getHoldings(accountId),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+  });
 }
 ```
 
@@ -1733,31 +1764,29 @@ export default defineConfig({
   "permissions": [
     {
       "category": "portfolio",
-      "functions": ["holdings"],
+      "functions": ["getHoldings"],
       "purpose": "Access portfolio data for analytics"
     }
   ]
 }
 ```
 
-#### 6. Context Not Available
+#### 6. Context Not Available in a Component or Helper
 
-**Error**: `getAddonContext() returns undefined`
+**Error**: A component or helper cannot access the addon context.
 
 **Solutions**:
 
 ```typescript
-// Ensure you're calling it within addon context
-function MyComponent() {
-  useEffect(() => {
-    // Call context inside useEffect or event handlers
-    const ctx = getAddonContext();
-    // ... use context
-  }, []);
+import type { AddonContext, AddonEnableFunction } from '@wealthfolio/addon-sdk';
+
+function MyComponent({ ctx }: { ctx: AddonContext }) {
+  return <button onClick={() => ctx.api.toast.success('Ready')}>Test API</button>;
 }
 
-// Don't call at module level
-// const ctx = getAddonContext(); // ❌ Wrong
+const enable: AddonEnableFunction = (ctx) => {
+  // Capture ctx for a route wrapper, or pass it directly to helpers/components.
+};
 ```
 
 ### Development Environment Issues

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -179,7 +179,7 @@ export interface Activity {
   assetId?: string; // NOW OPTIONAL for pure cash events
 
   // Classification
-  activityType: string; // Canonical type (closed set of 15)
+  activityType: string; // Canonical type (closed set of 14)
   activityTypeOverride?: string; // User override (never touched by sync)
   sourceType?: string; // Raw provider label (REI, DIV, etc.)
   subtype?: string; // Semantic variation (DRIP, STAKING_REWARD, etc.)

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -445,11 +445,11 @@ export interface SpendingAPI {
 
   /**
    * Re-run all categorization rules. Pass false to overwrite existing
-   * rule/AI/import-assigned categories too — the default only fills in
-   * currently uncategorized activities, preserving any existing manual or
-   * AI-assigned categories.
+   * rule/AI/history/import-assigned categories too — the default only fills in
+   * currently uncategorized activities. Manual assignments are always
+   * preserved.
    * @param onlyUncategorized Defaults to true
-   * @returns Promise resolving to the number of activities touched
+   * @returns Promise resolving to the number of activities matched by a rule
    */
   rerunRules(onlyUncategorized?: boolean): Promise<number>;
 }

--- a/packages/addon-sdk/src/i18n.ts
+++ b/packages/addon-sdk/src/i18n.ts
@@ -17,10 +17,11 @@ export interface AddonTranslationBundle {
 }
 
 /**
- * Translations keyed by base language code (`en`, `fr`, `de`, ...).
- * Regional codes (`fr-CA`) are normalized to their base language; keys that
- * are not plain language codes are ignored with a warning.
- * Languages the host does not support are stored but never resolved.
+ * Translations keyed by language code (`en`, `fr`, `de`, `zh-Hant`, ...).
+ * Regional aliases are normalized to the host's canonical language: for
+ * example, `fr-CA` becomes `fr` and Traditional Chinese aliases such as
+ * `zh-TW` become `zh-Hant`. Invalid codes are ignored with a warning.
+ * Valid languages the host does not support are stored but never resolved.
  */
 export type AddonTranslationResources = Record<string, AddonTranslationBundle>;
 

--- a/packages/addon-sdk/src/i18n.ts
+++ b/packages/addon-sdk/src/i18n.ts
@@ -34,7 +34,7 @@ export interface AddonTranslationApi {
    * literally, and `$t()` nesting inside translation values is disabled.
    */
   t: (key: string, options?: Record<string, unknown>) => string;
-  /** Current UI language as a base code (`en`, `fr`, ...). Follows the host setting. */
+  /** Current UI language as a canonical host code (`en`, `fr`, `zh-Hant`, ...). */
   language: string;
 }
 


### PR DESCRIPTION
## Summary

- document the SDK 3.8 spending, dated FX, activity review, and localization APIs
- align addon setup, permissions, imports, and TanStack Query examples with the current public contracts
- correct API reference models, payloads, opaque asset IDs, and compatibility guidance

## Validation

- `pnpm exec prettier --check packages/addon-sdk/README.md packages/addon-sdk/src/data-types.ts packages/addon-sdk/src/host-api.ts packages/addon-sdk/src/i18n.ts docs/addons/*.md`
- `pnpm --filter @wealthfolio/addon-sdk type-check`
- `pnpm --filter @wealthfolio/addon-sdk build:types`
- `pnpm --filter @wealthfolio/addon-sdk lint`
- verified documented SDK/UI imports against the source export tables
- verified Markdown code fences are balanced