### PR TITLE
Require schema-compatible snapshot reuse

### DIFF
--- a/apps/server/src/api/device_sync_engine.rs
+++ b/apps/server/src/api/device_sync_engine.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 
 use crate::main_lib::AppState;
 use wealthfolio_core::events::DomainEvent;
-use wealthfolio_core::sync::{APP_SYNC_TABLES, SNAPSHOT_SCHEMA_VERSION};
+use wealthfolio_core::sync::{
+    snapshot_covers_cursor_and_schema, APP_SYNC_TABLES, SNAPSHOT_SCHEMA_VERSION,
+};
 use wealthfolio_device_sync::engine::{
     self, CredentialStore, OutboxStore, ReadyReconcileStore, ReplayEvent, ReplayStore,
     SyncIdentity, SyncTransport, TransportError,
@@ -1397,7 +1399,12 @@ pub async fn generate_snapshot_now(
             .get_latest_snapshot_with_cursor_fallback(&token, &device_id)
             .await
         {
-            if latest_snapshot.oplog_seq >= cursor {
+            if snapshot_covers_cursor_and_schema(
+                latest_snapshot.oplog_seq,
+                latest_snapshot.schema_version,
+                cursor,
+                SNAPSHOT_SCHEMA_VERSION,
+            ) {
                 return Ok(SyncSnapshotUploadResult {
                     status: "uploaded".to_string(),
                     snapshot_id: Some(latest_snapshot.snapshot_id),
@@ -1492,7 +1499,12 @@ pub async fn generate_snapshot_now(
                     .ok()
                     .flatten();
                 if let (Some(cursor), Some(snapshot)) = (local_cursor, latest) {
-                    if snapshot.oplog_seq >= cursor {
+                    if snapshot_covers_cursor_and_schema(
+                        snapshot.oplog_seq,
+                        snapshot.schema_version,
+                        cursor,
+                        SNAPSHOT_SCHEMA_VERSION,
+                    ) {
                         tracing::info!(
                             "[DeviceSync] Snapshot conflict resolved by existing remote snapshot id={} oplog_seq={} cursor={}",
                             snapshot.snapshot_id,

--- a/apps/tauri/src/commands/device_sync/snapshot.rs
+++ b/apps/tauri/src/commands/device_sync/snapshot.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 use crate::context::ServiceContext;
 use crate::events::{emit_portfolio_trigger_recalculate, PortfolioRequestPayload};
 use wealthfolio_core::quotes::MarketSyncMode;
-use wealthfolio_core::sync::{APP_SYNC_TABLES, SNAPSHOT_SCHEMA_VERSION};
+use wealthfolio_core::sync::{
+    snapshot_covers_cursor_and_schema, APP_SYNC_TABLES, SNAPSHOT_SCHEMA_VERSION,
+};
 use wealthfolio_device_sync::SyncState;
 
 use super::{
@@ -634,7 +636,12 @@ pub async fn generate_snapshot_now_internal(
             .get_latest_snapshot_with_cursor_fallback(&token, &device_id)
             .await
         {
-            if latest_snapshot.oplog_seq >= cursor {
+            if snapshot_covers_cursor_and_schema(
+                latest_snapshot.oplog_seq,
+                latest_snapshot.schema_version,
+                cursor,
+                SNAPSHOT_SCHEMA_VERSION,
+            ) {
                 info!(
                     "[DeviceSync] Reusing latest remote snapshot id={} oplog_seq={} for cursor={}",
                     latest_snapshot.snapshot_id, latest_snapshot.oplog_seq, cursor
@@ -765,7 +772,12 @@ pub async fn generate_snapshot_now_internal(
                     Err(_) => None,
                 };
                 if let (Some(cursor), Some(snapshot)) = (local_cursor, latest) {
-                    if snapshot.oplog_seq >= cursor {
+                    if snapshot_covers_cursor_and_schema(
+                        snapshot.oplog_seq,
+                        snapshot.schema_version,
+                        cursor,
+                        SNAPSHOT_SCHEMA_VERSION,
+                    ) {
                         info!(
                             "[DeviceSync] Snapshot conflict resolved by existing remote snapshot id={} oplog_seq={} cursor={}",
                             snapshot.snapshot_id, snapshot.oplog_seq, cursor

--- a/crates/core/src/sync/app_sync_model.rs
+++ b/crates/core/src/sync/app_sync_model.rs
@@ -85,6 +85,17 @@ pub const APP_SYNC_TABLES: &[&str] = &[
 /// bootstraps from a snapshot missing a table it expects.
 pub const SNAPSHOT_SCHEMA_VERSION: i32 = 2;
 
+/// A remote snapshot is reusable only when it covers the required event cursor
+/// and contains at least the schema required by the local client.
+pub fn snapshot_covers_cursor_and_schema(
+    snapshot_seq: i64,
+    snapshot_schema_version: i32,
+    required_seq: i64,
+    required_schema_version: i32,
+) -> bool {
+    snapshot_seq >= required_seq && snapshot_schema_version >= required_schema_version
+}
+
 /// Entity names used by incremental sync events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -303,7 +314,16 @@ pub trait EntitySyncAdapter: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_apply_lww, SyncEntity};
+    use super::{should_apply_lww, snapshot_covers_cursor_and_schema, SyncEntity};
+
+    #[test]
+    fn snapshot_reuse_requires_current_cursor_and_schema() {
+        assert!(snapshot_covers_cursor_and_schema(10, 2, 10, 2));
+        assert!(snapshot_covers_cursor_and_schema(11, 2, 10, 2));
+        assert!(snapshot_covers_cursor_and_schema(11, 3, 10, 2));
+        assert!(!snapshot_covers_cursor_and_schema(9, 2, 10, 2));
+        assert!(!snapshot_covers_cursor_and_schema(11, 1, 10, 2));
+    }
 
     #[test]
     fn lww_newer_timestamp_wins() {


### PR DESCRIPTION
## Summary

- reuse a remote pairing snapshot only when it covers both the local cursor and the local snapshot schema
- apply the same rule to upload-conflict recovery
- share the compatibility predicate between desktop and web implementations
- add focused coverage for equal, newer, older, and behind snapshots

## Safety

- this changes only pairing-time snapshot generation and conflict recovery
- snapshot bootstrap and restore behavior are unchanged
- schema compatibility is monotonic: a producer accepts the required schema or a newer schema, but never an older one
- an incompatible remote snapshot causes a fresh upload or an explicit pairing failure rather than silent reuse

## Deployment dependency

Deploy cloud PR #111 before releasing this client change:
https://github.com/afadil/wealthfolio-cloud/pull/111

The cloud change supports safe same-sequence schema replacement and rejects old-schema snapshots that claim to cover asset_logo events.

## Validation

- cargo fmt --all --check
- cargo test -p wealthfolio-core snapshot_reuse_requires_current_cursor_and_schema
- cargo check -p wealthfolio-app -p wealthfolio-server