### PR TITLE
fix(spending): truncate long notes in the transaction list

### DIFF
--- a/apps/frontend/src/components/truncated-text.test.tsx
+++ b/apps/frontend/src/components/truncated-text.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { TooltipProvider } from "@wealthfolio/ui";
+
+import { TRUNCATED_TEXT_TOOLTIP_MAX_CHARS, TruncatedText } from "./truncated-text";
+
+/** jsdom does no layout, so overflow is whatever the test says it is. */
+function setOverflow(el: HTMLElement, overflowing: boolean) {
+  Object.defineProperty(el, "clientWidth", { value: 100, configurable: true });
+  Object.defineProperty(el, "scrollWidth", { value: overflowing ? 500 : 100, configurable: true });
+}
+
+function renderText(text: string) {
+  render(
+    <TooltipProvider delayDuration={0}>
+      <TruncatedText text={text} data-testid="text" />
+    </TooltipProvider>,
+  );
+  return screen.getByTestId("text");
+}
+
+describe("TruncatedText", () => {
+  it("shows the full text in a tooltip only when the text overflows", async () => {
+    const user = userEvent.setup();
+    const el = renderText("a long note");
+    setOverflow(el, true);
+
+    await user.hover(el);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("a long note");
+  });
+
+  it("stays quiet when the text fits", async () => {
+    const user = userEvent.setup();
+    const el = renderText("short");
+    setOverflow(el, false);
+
+    await user.hover(el);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("caps the tooltip itself", async () => {
+    const user = userEvent.setup();
+    const text = "x".repeat(TRUNCATED_TEXT_TOOLTIP_MAX_CHARS + 50);
+    const el = renderText(text);
+    setOverflow(el, true);
+
+    await user.hover(el);
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toHaveLength(TRUNCATED_TEXT_TOOLTIP_MAX_CHARS + 1);
+    expect(tooltip.textContent?.endsWith("…")).toBe(true);
+  });
+});

--- a/apps/frontend/src/components/truncated-text.tsx
+++ b/apps/frontend/src/components/truncated-text.tsx
@@ -1,0 +1,46 @@
+import { useRef, useState, type ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui";
+
+/** Longest text the tooltip shows before it too is cut off. */
+export const TRUNCATED_TEXT_TOOLTIP_MAX_CHARS = 300;
+
+interface TruncatedTextProps extends Omit<ComponentProps<"span">, "children"> {
+  text: string;
+}
+
+/**
+ * Single-line text that truncates to its container. Only when it actually
+ * overflows does hovering show the full text in a tooltip, itself capped so a
+ * pathological note cannot fill the viewport.
+ */
+export function TruncatedText({ text, className, ...props }: TruncatedTextProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Tooltip
+      open={open}
+      onOpenChange={(next) => {
+        const el = ref.current;
+        setOpen(next && el !== null && el.scrollWidth > el.clientWidth);
+      }}
+    >
+      <TooltipTrigger asChild>
+        <span ref={ref} className={cn("block min-w-0 truncate", className)} {...props}>
+          {text}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        className="max-w-md whitespace-pre-wrap break-words"
+      >
+        {text.length > TRUNCATED_TEXT_TOOLTIP_MAX_CHARS
+          ? `${text.slice(0, TRUNCATED_TEXT_TOOLTIP_MAX_CHARS)}…`
+          : text}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/frontend/src/features/spending/components/reports/category-transactions-sheet.tsx
+++ b/apps/frontend/src/features/spending/components/reports/category-transactions-sheet.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
+import { TruncatedText } from "@/components/truncated-text";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import type { Account, TaxonomyCategory } from "@/lib/types";
@@ -406,8 +407,10 @@ export function CategoryTransactionsSheet({
                       className="hover:bg-muted/30 flex items-center gap-2.5 px-1 py-2 transition-colors"
                     >
                       <div className="min-w-0 flex-1">
-                        <div className="text-foreground truncate text-[13px] font-medium leading-tight">
-                          {it.notes ?? (
+                        <div className="text-foreground text-[13px] font-medium leading-tight">
+                          {it.notes != null ? (
+                            <TruncatedText text={it.notes} />
+                          ) : (
                             <span className="text-muted-foreground italic">
                               {it.activityType.toLowerCase()}
                             </span>

--- a/apps/frontend/src/features/spending/components/transaction-review-state.test.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-review-state.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@/test/render";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Table, TableBody } from "@wealthfolio/ui";
+import { Table, TableBody, TooltipProvider } from "@wealthfolio/ui";
 import type { ReactNode } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -84,7 +84,11 @@ function withProviders({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{children}</TooltipProvider>
+    </QueryClientProvider>
+  );
 }
 
 function renderRow(needsReview: boolean) {

--- a/apps/frontend/src/features/spending/components/transaction-row.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-row.tsx
@@ -2,6 +2,7 @@ import { memo, type Ref } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { Account } from "@/lib/types";
+import { TruncatedText } from "@/components/truncated-text";
 import { HOVER_SLOT } from "@/lib/hover-slot";
 import { cn } from "@/lib/utils";
 import {
@@ -123,7 +124,12 @@ function TransactionRowImpl({
       <TableCell className="text-muted-foreground hidden w-20 whitespace-nowrap px-3 py-2 text-xs tabular-nums md:table-cell">
         {time}
       </TableCell>
-      <TableCell className="px-3 py-2">
+      {/* `max-w-0` hands this column whatever width the fixed-width columns
+          leave over, instead of letting a long note stretch the table. It has
+          to be `!important`: globals.css sets `max-width: 100vw` on every
+          element at or below 1024px from outside any layer, which beats a
+          plain utility and would let the note run to the viewport edge. */}
+      <TableCell className="max-w-0! px-3 py-2">
         <div className="flex items-center gap-2">
           {/* The stripe beside the checkbox carries this too, but colour alone
               cannot be the only signal — it says nothing to a screen reader and
@@ -135,9 +141,11 @@ function TransactionRowImpl({
               <span className="sr-only">{t("spending:transactions.review")}</span>
             </span>
           )}
-          <span className="min-w-0 truncate text-sm">
-            {a.notes ?? <span className="text-muted-foreground italic">—</span>}
-          </span>
+          {a.notes != null ? (
+            <TruncatedText text={a.notes} className="text-sm" />
+          ) : (
+            <span className="text-muted-foreground text-sm italic">—</span>
+          )}
           {showAccount && (
             <span className="text-muted-foreground max-w-[8rem] shrink-0 truncate text-xs">
               {accountName}


### PR DESCRIPTION
Fixes #1644 .
### Summary

Long notes in the spending transaction list stretched the Name / Notes column past the viewport and pushed the Category, Amount, and row-actions columns out of view. Two things combined to cause it.

- The compact list rework (#1627) dropped the `max-w-[260px]` cap from the notes cell. The table is auto-layout, so with no cap the column grows to fit the longest note at any viewport width.
- `globals.css` applies `max-width: 100vw` to every element at viewports of 1024px and below, from outside any cascade layer. Unlayered rules beat Tailwind utilities, so at those sizes any `max-w-*` on the cell is replaced with the viewport width. This is why the old 260px cap never worked on narrow viewports either.

### Changes

- `transaction-row.tsx`: the notes cell gets `max-w-0!`. The zero cap lets the column absorb whatever width the fixed-width columns leave over. The important modifier is required to beat the global rule below 1024px; a comment explains why.
- New `TruncatedText` component in `apps/frontend/src/components/truncated-text.tsx`. Single-line truncation, and a tooltip with the full text that opens only when the text actually overflows its container. Tooltip content is capped at 300 characters with an ellipsis and a max width.
- `category-transactions-sheet.tsx`: notes were already truncated but gave no way to read the rest. Same component.
- Existing row test wrapper gains a `TooltipProvider`. Three new tests cover the component: tooltip on overflow, no tooltip when the text fits, and the cap.

### Verification

Standalone page built from the real production CSS bundle and the exact table, row, and day-header markup, measured in Chromium and WebKit at 640, 900, 1024, 1200, and 1600px.

| Cell classes | ≤ 1024px | > 1024px |
|---|---|---|
| none (main) | overflow | overflow |
| `w-full max-w-0` | overflow, cap computed as 100vw | ok |
| `max-w-0!` | ok, fixed columns keep declared widths | ok |

### Follow-up

The global `* { max-width: 100vw }` rule under 1024px silently defeats every `max-w-*` utility in the app at those sizes, for example the 220px cap in the activity table. Moving it into `@layer base` would let explicit utilities win while keeping the mobile safety net, but that deserves its own visual pass across mobile screens.
## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
