### PR TITLE
fix(settings): respect menu_bar_visible setting on startup

### DIFF
--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -116,16 +116,20 @@ mod desktop {
     use super::*;
 
     /// Sets up the application menu and its event handler.
-    pub fn setup_menu(handle: &AppHandle) {
-        match menu::create_menu(handle) {
-            Ok(menu) => {
-                if let Err(e) = handle.set_menu(menu) {
-                    error!("Failed to set menu: {}", e);
+    pub fn setup_menu(handle: &AppHandle, menu_bar_visible: bool) {
+        if menu_bar_visible {
+            match menu::create_menu(handle) {
+                Ok(menu) => {
+                    if let Err(e) = handle.set_menu(menu) {
+                        error!("Failed to set menu: {}", e);
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to create menu: {}", e);
                 }
             }
-            Err(e) => {
-                error!("Failed to create menu: {}", e);
-            }
+        } else if let Err(e) = handle.remove_menu() {
+            error!("Failed to remove menu: {}", e);
         }
 
         handle.on_menu_event(move |app, event| {
@@ -178,7 +182,12 @@ mod desktop {
         });
 
         // Menu setup is synchronous (no I/O)
-        setup_menu(&handle);
+        let menu_bar_visible = context
+            .settings_service()
+            .get_settings()
+            .map(|s| s.menu_bar_visible)
+            .unwrap_or(true);
+        setup_menu(&handle, menu_bar_visible);
 
         // Notify frontend that app is ready
         // The frontend will trigger the initial portfolio update and update check after it's mounted


### PR DESCRIPTION
## Summary

Menu bar visibility setting is not respected after restart ([#1628](https://github.com/wealthfolio/wealthfolio/issues/1628)).

`desktop::setup()` called `setup_menu(&handle)` unconditionally on every startup, ignoring the saved `menu_bar_visible` preference. Two problems compounded:

1. The custom menu was always created and set, overriding the saved preference.
2. Even skipping the custom menu wasn't enough — Tauri/the OS creates a **default** menu automatically, so it still appeared.

## Changes

- `setup_menu` now takes a `menu_bar_visible: bool` parameter
- In `desktop::setup()`, the setting is read from the initialized context before calling `setup_menu`
- When `false`: `handle.remove_menu()` is called explicitly to suppress the default menu
- When `true`: existing behaviour unchanged

This mirrors the logic already in `commands/settings.rs` for the runtime toggle.

## Test plan

- [X] Disable "Show menu bar" → restart → menu bar stays hidden
- [X] Re-enable "Show menu bar" → restart → menu bar reappears
- [X] Toggle at runtime (no restart) still works as before

## Checklist

- [X] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
