### PR TITLE
fix: keep same-account FX conversions contribution-neutral

### DIFF
--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -10640,6 +10640,113 @@ mod tests {
         assert_eq!(performance.attribution.residual, Decimal::ZERO);
     }
 
+    #[tokio::test]
+    async fn imported_same_account_cash_fx_has_no_external_flow_or_twr_cash_flow() {
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+        let fx_metadata = json!({
+            "flow": { "is_external": false },
+            "fx": {
+                "sourceCurrency": "EUR",
+                "destinationCurrency": "USD",
+                "sourceAmount": "106.03",
+                "destinationAmount": "124.9743801",
+                "impliedRate": "1.1786646232198434405356974441",
+                "rateSource": "implied_from_import"
+            }
+        });
+
+        let mut transfer_out = create_stored_activity("fx-out", "acc-eur", None);
+        transfer_out.activity_type = "TRANSFER_OUT".to_string();
+        transfer_out.activity_date = parse_test_activity_datetime("2026-04-14");
+        transfer_out.amount = Some(dec!(106.03));
+        transfer_out.currency = "EUR".to_string();
+        transfer_out.source_group_id = Some("ibkr-fx-execution".to_string());
+        transfer_out.metadata = Some(fx_metadata.clone());
+
+        let mut transfer_in = create_stored_activity("fx-in", "acc-eur", None);
+        transfer_in.activity_type = "TRANSFER_IN".to_string();
+        transfer_in.activity_date = parse_test_activity_datetime("2026-04-14");
+        transfer_in.amount = Some(dec!(124.9743801));
+        transfer_in.currency = "USD".to_string();
+        transfer_in.source_group_id = Some("ibkr-fx-execution".to_string());
+        transfer_in.metadata = Some(fx_metadata);
+
+        activity_repository.add_activity(transfer_out);
+        activity_repository.add_activity(transfer_in);
+
+        let mut start = create_daily_valuation(
+            "acc-eur",
+            "2026-04-13",
+            dec!(1000),
+            Decimal::ZERO,
+            dec!(1000),
+            dec!(1000),
+        );
+        let mut end = create_daily_valuation(
+            "acc-eur",
+            "2026-04-14",
+            dec!(1003.42),
+            Decimal::ZERO,
+            dec!(1003.42),
+            dec!(1000),
+        );
+        for valuation in [&mut start, &mut end] {
+            valuation.account_currency = "EUR".to_string();
+            valuation.base_currency = "EUR".to_string();
+        }
+
+        let valuation_repository = Arc::new(MockValuationRepository::new(vec![start, end]));
+        let quote_service = Arc::new(MockQuoteService);
+        let valuation_service = Arc::new(
+            ValuationService::new(
+                Arc::new(RwLock::new("EUR".to_string())),
+                valuation_repository,
+                Arc::new(MockSnapshotService),
+                quote_service.clone(),
+                fx_service.clone(),
+            )
+            .with_activity_repository(
+                activity_repository.clone(),
+                Arc::new(RwLock::new("UTC".to_string())),
+            ),
+        );
+        let account_ids = vec!["acc-eur".to_string()];
+        let start_date = NaiveDate::parse_from_str("2026-04-13", "%Y-%m-%d").unwrap();
+        let end_date = NaiveDate::parse_from_str("2026-04-14", "%Y-%m-%d").unwrap();
+
+        let scoped_valuations = valuation_service
+            .get_historical_valuations_for_accounts(
+                "scope:same-account-fx",
+                &account_ids,
+                "EUR",
+                Some(start_date),
+                Some(end_date),
+            )
+            .expect("same-account FX valuations should load");
+        assert_eq!(scoped_valuations[1].external_inflow_base, Decimal::ZERO);
+        assert_eq!(scoped_valuations[1].external_outflow_base, Decimal::ZERO);
+
+        let performance_service = PerformanceService::new(valuation_service, quote_service)
+            .with_activity_repository(activity_repository, fx_service);
+        let performance = performance_service
+            .calculate_performance_history_for_accounts(
+                "scope:same-account-fx",
+                &account_ids,
+                "EUR",
+                &HashMap::new(),
+                &HashMap::new(),
+                Some(start_date),
+                Some(end_date),
+            )
+            .await
+            .expect("same-account FX performance should calculate");
+
+        assert_eq!(performance.attribution.contributions, Decimal::ZERO);
+        assert_eq!(performance.attribution.distributions, Decimal::ZERO);
+        assert_eq!(performance.returns.twr, Some(dec!(0.00342)));
+    }
+
     #[test]
     fn scoped_flow_pipeline_uses_removed_lot_basis_for_unquoted_cross_scope_outbound_pair() {
         let activity_repository = Arc::new(MockActivityRepository::new());

--- a/crates/core/src/activities/mod.rs
+++ b/crates/core/src/activities/mod.rs
@@ -52,5 +52,6 @@ pub use import_run_model::{
     ImportRunType, ReviewMode,
 };
 pub use transfer_pairs::{
-    is_same_account_cash_fx_conversion, InvalidTransferGroup, TransferPair, TransferPairResolution,
+    is_contribution_neutral_same_account_cash_fx_conversion, is_same_account_cash_fx_conversion,
+    InvalidTransferGroup, TransferPair, TransferPairResolution,
 };

--- a/crates/core/src/activities/transfer_pairs.rs
+++ b/crates/core/src/activities/transfer_pairs.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 
 use rust_decimal::Decimal;
 
@@ -176,6 +177,96 @@ pub fn is_same_account_cash_fx_conversion(transfer_in: &Activity, transfer_out: 
             .eq_ignore_ascii_case(transfer_out.currency.trim())
 }
 
+fn has_imported_fx_pair_metadata(
+    activity: &Activity,
+    source_currency: &str,
+    destination_currency: &str,
+    source_amount: Decimal,
+    destination_amount: Decimal,
+) -> bool {
+    let Some(metadata) = activity.metadata.as_ref() else {
+        return false;
+    };
+    if metadata
+        .pointer("/flow/is_external")
+        .and_then(serde_json::Value::as_bool)
+        != Some(false)
+    {
+        return false;
+    }
+
+    let Some(fx) = metadata.get("fx") else {
+        return false;
+    };
+    let metadata_amount_matches = |key: &str, expected: Decimal| {
+        fx.get(key)
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| Decimal::from_str(value).ok())
+            .is_some_and(|value| value == expected)
+    };
+
+    fx.get("rateSource").and_then(serde_json::Value::as_str) == Some("implied_from_import")
+        && fx
+            .get("sourceCurrency")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|currency| currency.eq_ignore_ascii_case(source_currency))
+        && fx
+            .get("destinationCurrency")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|currency| currency.eq_ignore_ascii_case(destination_currency))
+        && metadata_amount_matches("sourceAmount", source_amount)
+        && metadata_amount_matches("destinationAmount", destination_amount)
+}
+
+/// Returns true only for a complete same-account cash FX pair carrying the
+/// internal-flow metadata written by the import linker. Structural pairing
+/// alone is deliberately insufficient for contribution-neutral accounting.
+pub fn is_contribution_neutral_same_account_cash_fx_conversion(
+    transfer_in: &Activity,
+    transfer_out: &Activity,
+) -> bool {
+    if !is_same_account_cash_fx_conversion(transfer_in, transfer_out) {
+        return false;
+    }
+
+    let Some(in_group_id) = transfer_in
+        .source_group_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|group_id| !group_id.is_empty())
+    else {
+        return false;
+    };
+    let Some(out_group_id) = transfer_out
+        .source_group_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|group_id| !group_id.is_empty())
+    else {
+        return false;
+    };
+    if in_group_id != out_group_id {
+        return false;
+    }
+
+    let Some(source_amount) = transfer_out.amount.map(|amount| amount.abs()) else {
+        return false;
+    };
+    let Some(destination_amount) = transfer_in.amount.map(|amount| amount.abs()) else {
+        return false;
+    };
+
+    [transfer_in, transfer_out].iter().all(|activity| {
+        has_imported_fx_pair_metadata(
+            activity,
+            &transfer_out.currency,
+            &transfer_in.currency,
+            source_amount,
+            destination_amount,
+        )
+    })
+}
+
 fn build_transfer_pair(group_id: &str, activities: &[Activity]) -> Result<TransferPair, String> {
     if activities.len() != 2 {
         return Err(format!(
@@ -319,6 +410,47 @@ mod tests {
                 .and_then(|pair| pair.counterparty_account_id("out")),
             Some("a1")
         );
+    }
+
+    #[test]
+    fn imported_same_account_cash_fx_pair_is_contribution_neutral() {
+        let mut transfer_out = activity("out", ACTIVITY_TYPE_TRANSFER_OUT, "a1", Some("g1"), "USD");
+        transfer_out.amount = Some(Decimal::new(2433, 2));
+        let mut transfer_in = activity("in", ACTIVITY_TYPE_TRANSFER_IN, "a1", Some("g1"), "CAD");
+        transfer_in.amount = Some(Decimal::new(3293, 2));
+        let metadata = serde_json::json!({
+            "flow": { "is_external": false },
+            "fx": {
+                "sourceCurrency": "USD",
+                "destinationCurrency": "CAD",
+                "sourceAmount": "24.33",
+                "destinationAmount": "32.93",
+                "impliedRate": "1.3534730785039046444718454583",
+                "rateSource": "implied_from_import"
+            }
+        });
+        transfer_out.metadata = Some(metadata.clone());
+        transfer_in.metadata = Some(metadata);
+
+        assert!(is_contribution_neutral_same_account_cash_fx_conversion(
+            &transfer_in,
+            &transfer_out
+        ));
+    }
+
+    #[test]
+    fn structural_same_account_cash_fx_pair_without_import_metadata_is_not_neutral() {
+        let transfer_out = activity("out", ACTIVITY_TYPE_TRANSFER_OUT, "a1", Some("g1"), "USD");
+        let transfer_in = activity("in", ACTIVITY_TYPE_TRANSFER_IN, "a1", Some("g1"), "CAD");
+
+        assert!(is_same_account_cash_fx_conversion(
+            &transfer_in,
+            &transfer_out
+        ));
+        assert!(!is_contribution_neutral_same_account_cash_fx_conversion(
+            &transfer_in,
+            &transfer_out
+        ));
     }
 
     #[test]

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
@@ -77,7 +77,10 @@ fn split_lots_by_cover_quantity(lots: &[Lot], cover_qty_abs: Decimal) -> (Vec<Lo
 impl HoldingsCalculator {
     /// Handle TRANSFER_IN activity.
     /// Books cash/asset inflow in ACTIVITY currency.
-    /// Transfers always affect account-level net_contribution; portfolio boundary is handled by aggregation.
+    /// Ordinary transfers increase account-level net_contribution and
+    /// net_contribution_base; a cash leg in a qualified same-account internal FX
+    /// pair still books cash but is contribution-neutral. Portfolio boundary is
+    /// handled by aggregation.
     pub(crate) fn handle_transfer_in(
         &self,
         activity: &Activity,
@@ -399,7 +402,10 @@ impl HoldingsCalculator {
 
     /// Handle TRANSFER_OUT activity.
     /// Books cash/asset outflow in ACTIVITY currency.
-    /// Transfers always affect account-level net_contribution; portfolio boundary is handled by aggregation.
+    /// Ordinary transfers decrease account-level net_contribution and
+    /// net_contribution_base; a cash leg in a qualified same-account internal FX
+    /// pair still books cash but is contribution-neutral. Portfolio boundary is
+    /// handled by aggregation.
     pub(crate) fn handle_transfer_out(
         &self,
         activity: &Activity,

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
@@ -98,32 +98,34 @@ impl HoldingsCalculator {
             let (cash_currency, cash_effect) = cash_booking(activity, cash_effect);
             add_cash(state, &cash_currency, cash_effect);
 
-            let amount_acct = self.convert_to_account_currency(
-                gross_effect,
-                activity,
-                account_currency,
-                "TransferIn Cash",
-            );
+            if !run.is_contribution_neutral_transfer(&activity.id) {
+                let amount_acct = self.convert_to_account_currency(
+                    gross_effect,
+                    activity,
+                    account_currency,
+                    "TransferIn Cash",
+                );
 
-            let base_ccy = self.base_currency.read().unwrap();
-            let amount_base = match self.fx_service.convert_currency_for_date(
-                gross_effect,
-                activity_currency,
-                &base_ccy,
-                activity_date,
-            ) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(
-                        "Holdings Calc (NetContrib TransferIn Cash {}): Failed conversion {}: {}.",
-                        activity.id, activity_currency, e
-                    );
-                    Decimal::ZERO
-                }
-            };
+                let base_ccy = self.base_currency.read().unwrap();
+                let amount_base = match self.fx_service.convert_currency_for_date(
+                    gross_effect,
+                    activity_currency,
+                    &base_ccy,
+                    activity_date,
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!(
+                            "Holdings Calc (NetContrib TransferIn Cash {}): Failed conversion {}: {}.",
+                            activity.id, activity_currency, e
+                        );
+                        Decimal::ZERO
+                    }
+                };
 
-            state.net_contribution += amount_acct;
-            state.net_contribution_base += amount_base;
+                state.net_contribution += amount_acct;
+                state.net_contribution_base += amount_base;
+            }
         } else {
             // Asset transfer
             let activity_date = self.activity_local_date(activity);
@@ -418,32 +420,34 @@ impl HoldingsCalculator {
             let (cash_currency, cash_effect) = cash_booking(activity, cash_effect);
             add_cash(state, &cash_currency, cash_effect);
 
-            let amount_acct = self.convert_to_account_currency(
-                gross_effect,
-                activity,
-                account_currency,
-                "TransferOut Cash",
-            );
+            if !run.is_contribution_neutral_transfer(&activity.id) {
+                let amount_acct = self.convert_to_account_currency(
+                    gross_effect,
+                    activity,
+                    account_currency,
+                    "TransferOut Cash",
+                );
 
-            let base_ccy = self.base_currency.read().unwrap();
-            let amount_base = match self.fx_service.convert_currency_for_date(
-                gross_effect,
-                activity_currency,
-                &base_ccy,
-                activity_date,
-            ) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(
-                        "Holdings Calc (NetContrib TransferOut Cash {}): Failed conversion {}: {}.",
-                        activity.id, activity_currency, e
-                    );
-                    Decimal::ZERO
-                }
-            };
+                let base_ccy = self.base_currency.read().unwrap();
+                let amount_base = match self.fx_service.convert_currency_for_date(
+                    gross_effect,
+                    activity_currency,
+                    &base_ccy,
+                    activity_date,
+                ) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!(
+                            "Holdings Calc (NetContrib TransferOut Cash {}): Failed conversion {}: {}.",
+                            activity.id, activity_currency, e
+                        );
+                        Decimal::ZERO
+                    }
+                };
 
-            state.net_contribution += amount_acct;
-            state.net_contribution_base += amount_base;
+                state.net_contribution += amount_acct;
+                state.net_contribution_base += amount_base;
+            }
         } else {
             // Asset transfer
             if !cash_effect.is_zero() {

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/mod.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/mod.rs
@@ -1,5 +1,8 @@
 use crate::accounts::account_types;
-use crate::activities::{Activity, ActivityType};
+use crate::activities::{
+    is_contribution_neutral_same_account_cash_fx_conversion, Activity, ActivityType, TransferPair,
+    TransferPairResolution,
+};
 use crate::assets::AssetRepositoryTrait;
 use crate::errors::{CalculatorError, Result};
 use crate::fx::FxServiceTrait;
@@ -12,7 +15,7 @@ use crate::utils::time_utils::{activity_date_in_tz, parse_user_timezone_or_defau
 use chrono::{DateTime, NaiveDate, Utc};
 use log::{debug, warn};
 use rust_decimal::Decimal;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
@@ -62,6 +65,9 @@ pub struct ProjectionRun {
     lot_disposals: HashMap<String, Vec<LotDisposal>>,
     /// Cost-basis method selected for each account during the run.
     cost_basis_methods: HashMap<String, String>,
+    /// Imported same-account cash FX legs in the current activity batch whose
+    /// contribution effect is neutral.
+    contribution_neutral_transfer_ids: HashSet<String>,
 }
 
 impl ProjectionRun {
@@ -86,6 +92,21 @@ impl ProjectionRun {
             .get(account_id)
             .cloned()
             .unwrap_or_else(|| "FIFO".to_string())
+    }
+
+    fn register_contribution_neutral_transfer_pair(&mut self, transfer_pair: &TransferPair) {
+        self.contribution_neutral_transfer_ids
+            .insert(transfer_pair.transfer_in.id.clone());
+        self.contribution_neutral_transfer_ids
+            .insert(transfer_pair.transfer_out.id.clone());
+    }
+
+    fn reset_contribution_neutral_transfers(&mut self) {
+        self.contribution_neutral_transfer_ids.clear();
+    }
+
+    fn is_contribution_neutral_transfer(&self, activity_id: &str) -> bool {
+        self.contribution_neutral_transfer_ids.contains(activity_id)
     }
 
     /// Returns and removes all accumulated lot closures for the given account,
@@ -315,6 +336,16 @@ impl HoldingsCalculator {
 
         let account_currency = next_state.currency.clone();
         let mut warnings: Vec<HoldingsCalculationWarning> = Vec::new();
+        run.reset_contribution_neutral_transfers();
+        let transfer_resolution = TransferPairResolution::from_activities(activities_today);
+        for pair in transfer_resolution.pairs().iter().filter(|pair| {
+            is_contribution_neutral_same_account_cash_fx_conversion(
+                &pair.transfer_in,
+                &pair.transfer_out,
+            )
+        }) {
+            run.register_contribution_neutral_transfer_pair(pair);
+        }
 
         // Session-wide asset info cache to avoid DB lookups per unique asset.
         let mut asset_cache: AssetCache = HashMap::new();

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -3301,6 +3301,125 @@ mod tests {
     }
 
     #[test]
+    fn imported_same_account_cash_fx_pair_is_contribution_neutral() {
+        let target_date_str = "2026-04-14";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let valuation_rate = dec!(0.88);
+        let mut mock_fx_service = MockFxService::new();
+        mock_fx_service.add_bidirectional_rate("USD", "EUR", target_date, valuation_rate);
+
+        let base_currency = Arc::new(RwLock::new("EUR".to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+        let mut previous_snapshot = create_initial_snapshot("acc_fx", "EUR", "2026-04-13");
+        previous_snapshot
+            .cash_balances
+            .insert("EUR".to_string(), dec!(48.30));
+        previous_snapshot
+            .cash_balances
+            .insert("USD".to_string(), dec!(19839.79));
+        previous_snapshot.net_contribution = dec!(1234.56);
+        previous_snapshot.net_contribution_base = dec!(7890.12);
+
+        let mut transfer_out = create_cash_activity(
+            "fx-out",
+            ActivityType::TransferOut,
+            dec!(106.03),
+            Decimal::ZERO,
+            "EUR",
+            target_date_str,
+        );
+        let mut transfer_in = create_cash_activity(
+            "fx-in",
+            ActivityType::TransferIn,
+            dec!(124.9743801),
+            Decimal::ZERO,
+            "USD",
+            target_date_str,
+        );
+        for activity in [&mut transfer_out, &mut transfer_in] {
+            activity.account_id = "acc_fx".to_string();
+            activity.source_group_id = Some("ibkr-fx-execution".to_string());
+            activity.metadata = Some(json!({
+                "flow": { "is_external": false },
+                "fx": {
+                    "sourceCurrency": "EUR",
+                    "destinationCurrency": "USD",
+                    "sourceAmount": "106.03",
+                    "destinationAmount": "124.9743801",
+                    "impliedRate": "1.1786646232198434405356974441",
+                    "rateSource": "implied_from_import"
+                }
+            }));
+        }
+
+        let result = calculator
+            .calculate_next_holdings(
+                &previous_snapshot,
+                &[transfer_out, transfer_in],
+                target_date,
+            )
+            .expect("same-account FX conversion should calculate");
+        let state = result.snapshot;
+
+        assert_eq!(state.cash_balances.get("EUR"), Some(&dec!(-57.73)));
+        assert_eq!(state.cash_balances.get("USD"), Some(&dec!(19964.7643801)));
+        assert_eq!(state.net_contribution, previous_snapshot.net_contribution);
+        assert_eq!(
+            state.net_contribution_base,
+            previous_snapshot.net_contribution_base
+        );
+
+        let value_before = dec!(48.30) + dec!(19839.79) * valuation_rate;
+        assert_ne!(state.cash_total_account_currency, value_before);
+    }
+
+    #[test]
+    fn grouped_same_account_cash_fx_without_import_metadata_keeps_transfer_semantics() {
+        let target_date_str = "2026-04-14";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let mut mock_fx_service = MockFxService::new();
+        mock_fx_service.add_bidirectional_rate("USD", "EUR", target_date, dec!(0.88));
+
+        let base_currency = Arc::new(RwLock::new("EUR".to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+        let previous_snapshot = create_initial_snapshot("acc_fx", "EUR", "2026-04-13");
+
+        let mut transfer_out = create_cash_activity(
+            "ordinary-out",
+            ActivityType::TransferOut,
+            dec!(100),
+            Decimal::ZERO,
+            "EUR",
+            target_date_str,
+        );
+        let mut transfer_in = create_cash_activity(
+            "ordinary-in",
+            ActivityType::TransferIn,
+            dec!(120),
+            Decimal::ZERO,
+            "USD",
+            target_date_str,
+        );
+        for activity in [&mut transfer_out, &mut transfer_in] {
+            activity.account_id = "acc_fx".to_string();
+            activity.source_group_id = Some("ordinary-group".to_string());
+            activity.metadata = Some(json!({ "flow": { "is_external": false } }));
+        }
+
+        let state = calculator
+            .calculate_next_holdings(
+                &previous_snapshot,
+                &[transfer_out, transfer_in],
+                target_date,
+            )
+            .expect("ordinary grouped transfers should calculate")
+            .snapshot;
+
+        assert_eq!(state.net_contribution, dec!(5.6));
+        assert_eq!(state.net_contribution_base, dec!(5.6));
+    }
+
+    #[test]
     fn test_multiple_activities_on_same_day_with_fx() {
         let mut mock_fx_service = MockFxService::new();
         let target_date_str = "2023-01-12";

--- a/docs/activities/activity-types.md
+++ b/docs/activities/activity-types.md
@@ -19,22 +19,22 @@ Wealthfolio uses a closed set of **14 canonical activity types**. Each activity
 
 ## Summary Table
 
-| Type             | Category | Cash Impact          | Holdings Impact   | Cost Basis         | Net Contribution        | Required Asset |
-| ---------------- | -------- | -------------------- | ----------------- | ------------------ | ----------------------- | -------------- |
-| **BUY**          | Trading  | -(qty × price + fee) | +quantity         | +cost              | No change               | Yes            |
-| **SELL**         | Trading  | +(qty × price - fee) | -quantity         | -cost (FIFO)       | No change               | Yes            |
-| **SPLIT**        | Trading  | No change            | Adjusted          | Per-share adjusted | No change               | Yes            |
-| **DEPOSIT**      | Cash     | +(amount - fee)      | N/A               | N/A                | +amount                 | No             |
-| **WITHDRAWAL**   | Cash     | -(amount + fee)      | N/A               | N/A                | -amount                 | No             |
-| **TRANSFER_IN**  | Transfer | +amount or +quantity | +quantity (asset) | Preserved/set      | +amount (account scope) | Optional       |
-| **TRANSFER_OUT** | Transfer | -amount or -quantity | -quantity (asset) | Removed (FIFO)     | -amount (account scope) | Optional       |
-| **DIVIDEND**     | Income   | +(amount - fee)      | No change         | No change          | No change               | Yes            |
-| **INTEREST**     | Income   | +(amount - fee)      | No change         | No change          | No change               | Optional       |
-| **CREDIT**       | Income   | +(amount - fee)      | No change         | No change          | Depends on subtype      | No             |
-| **FEE**          | Charge   | -amount              | No change         | No change          | No change               | Optional       |
-| **TAX**          | Charge   | -amount              | No change         | No change          | No change               | Optional       |
-| **ADJUSTMENT**   | Other    | Varies               | Varies            | Varies             | No change               | Yes (required) |
-| **UNKNOWN**      | Other    | No auto impact       | No auto impact    | No auto impact     | No change               | Optional       |
+| Type             | Category | Cash Impact          | Holdings Impact   | Cost Basis         | Net Contribution                 | Required Asset |
+| ---------------- | -------- | -------------------- | ----------------- | ------------------ | -------------------------------- | -------------- |
+| **BUY**          | Trading  | -(qty × price + fee) | +quantity         | +cost              | No change                        | Yes            |
+| **SELL**         | Trading  | +(qty × price - fee) | -quantity         | -cost (FIFO)       | No change                        | Yes            |
+| **SPLIT**        | Trading  | No change            | Adjusted          | Per-share adjusted | No change                        | Yes            |
+| **DEPOSIT**      | Cash     | +(amount - fee)      | N/A               | N/A                | +amount                          | No             |
+| **WITHDRAWAL**   | Cash     | -(amount + fee)      | N/A               | N/A                | -amount                          | No             |
+| **TRANSFER_IN**  | Transfer | +amount or +quantity | +quantity (asset) | Preserved/set      | +amount (ordinary account scope) | Optional       |
+| **TRANSFER_OUT** | Transfer | -amount or -quantity | -quantity (asset) | Removed (FIFO)     | -amount (ordinary account scope) | Optional       |
+| **DIVIDEND**     | Income   | +(amount - fee)      | No change         | No change          | No change                        | Yes            |
+| **INTEREST**     | Income   | +(amount - fee)      | No change         | No change          | No change                        | Optional       |
+| **CREDIT**       | Income   | +(amount - fee)      | No change         | No change          | Depends on subtype               | No             |
+| **FEE**          | Charge   | -amount              | No change         | No change          | No change                        | Optional       |
+| **TAX**          | Charge   | -amount              | No change         | No change          | No change                        | Optional       |
+| **ADJUSTMENT**   | Other    | Varies               | Varies            | Varies             | No change                        | Yes (required) |
+| **UNKNOWN**      | Other    | No auto impact       | No auto impact    | No auto impact     | No change                        | Optional       |
 
 ---
 
@@ -144,14 +144,28 @@ calculation.
 
 ### Transfer Activities
 
+Ordinary cash transfers update account-level net contribution: `TRANSFER_IN`
+increases it and `TRANSFER_OUT` decreases it. A complete, recognized internal
+cash FX conversion within the same account is a narrow exception:
+
+- Source-currency cash decreases by the transferred amount.
+- Destination-currency cash increases by the transferred amount.
+- Account-level `net_contribution` and `net_contribution_base` do not change.
+- No external portfolio flow or TWR cash-flow event is created.
+
+This exception uses Wealthfolio's qualified FX-pair recognition. Same-account
+transfers or transfers that merely share a group identifier are not
+automatically contribution-neutral.
+
 #### TRANSFER_IN
 
 **Purpose**: Move cash or assets into this account.
 
-| Scenario           | Cash Impact | Holdings Impact     | Net Contribution            |
-| ------------------ | ----------- | ------------------- | --------------------------- |
-| **Cash transfer**  | +amount     | N/A                 | +amount (account scope)     |
-| **Asset transfer** | -fee only   | +quantity (new lot) | +cost_basis (account scope) |
+| Scenario                            | Cash Impact         | Holdings Impact     | Net Contribution            |
+| ----------------------------------- | ------------------- | ------------------- | --------------------------- |
+| **Ordinary cash transfer**          | +amount             | N/A                 | +amount (account scope)     |
+| **Recognized same-account FX pair** | +destination amount | N/A                 | No change                   |
+| **Asset transfer**                  | -fee only           | +quantity (new lot) | +cost_basis (account scope) |
 
 **Required Fields**:
 
@@ -162,10 +176,10 @@ calculation.
 
 **Flow Behavior**:
 
-| Scope         | `is_external = false` (default)            | `is_external = true` |
-| ------------- | ------------------------------------------ | -------------------- |
-| **Account**   | +net_contribution                          | +net_contribution    |
-| **Portfolio** | No change (nets to zero with TRANSFER_OUT) | +net_contribution    |
+| Scope         | Ordinary internal transfer (`is_external = false`) | `is_external = true` |
+| ------------- | -------------------------------------------------- | -------------------- |
+| **Account**   | +net_contribution                                  | +net_contribution    |
+| **Portfolio** | No external flow when paired                       | +net_contribution    |
 
 **Use Cases**:
 
@@ -179,10 +193,11 @@ calculation.
 
 **Purpose**: Move cash or assets out of this account.
 
-| Scenario           | Cash Impact     | Holdings Impact  | Net Contribution            |
-| ------------------ | --------------- | ---------------- | --------------------------- |
-| **Cash transfer**  | -(amount + fee) | N/A              | -amount (account scope)     |
-| **Asset transfer** | -fee only       | -quantity (FIFO) | -cost_basis (account scope) |
+| Scenario                            | Cash Impact     | Holdings Impact  | Net Contribution            |
+| ----------------------------------- | --------------- | ---------------- | --------------------------- |
+| **Ordinary cash transfer**          | -(amount + fee) | N/A              | -amount (account scope)     |
+| **Recognized same-account FX pair** | -source amount  | N/A              | No change                   |
+| **Asset transfer**                  | -fee only       | -quantity (FIFO) | -cost_basis (account scope) |
 
 **Required Fields**:
 
@@ -191,7 +206,9 @@ calculation.
 
 **Optional Fields**: `fee`, `metadata.flow.is_external`
 
-**Flow Behavior**: Same as TRANSFER_IN but with opposite sign.
+**Flow Behavior**: Ordinary transfers use the opposite sign from TRANSFER_IN.
+Recognized same-account cash FX pairs use the contribution-neutral behavior
+described above.
 
 **Use Cases**:
 


### PR DESCRIPTION
## Summary

Fixes an accounting issue where a same-account cash FX conversion could incorrectly change account-level net contribution and severely distort TWR.

Wealthfolio already recognizes imported same-account FX conversions as paired internal `TRANSFER_OUT` / `TRANSFER_IN` activities with shared `source_group_id` and FX metadata.

However, during holdings calculation, each cash transfer leg independently updated:

- `net_contribution`
- `net_contribution_base`

Because the two currencies were valued independently, the contribution effects did not necessarily cancel at the broker's actual execution rate.

This PR makes only recognized same-account internal FX conversion pairs contribution-neutral while preserving their exact cash movements.

Related to #590.

## Example

A real reproduction used:

- `TRANSFER_OUT`: €106.03 EUR
- `TRANSFER_IN`: $124.9743801 USD
- same account
- same date
- internal FX conversion

Before this fix:

- EUR cash moved correctly
- USD cash moved correctly
- Net Contribution changed from €0.00 to €3.42
- TWR became pathological

After this fix:

- EUR cash still decreases by exactly €106.03
- USD cash still increases by exactly $124.9743801
- Net Contribution remains €0.00
- no external inflow/outflow is generated
- the remaining account-value change is treated as FX valuation/performance rather than a contribution

## Implementation

The fix is intentionally narrow and fail-closed.

A transfer pair is contribution-neutral only when it is a complete same-account cash FX conversion with:

- one `TRANSFER_OUT`
- one `TRANSFER_IN`
- same account
- different currencies
- matching non-empty `source_group_id`
- internal flow metadata (`flow.is_external = false`)
- matching FX metadata for source/destination currencies and amounts
- `rateSource = "implied_from_import"`

Structural pairing alone is not sufficient.

Qualified FX transfer IDs are registered for the projection run, and their cash movement is processed normally while their contribution updates are skipped.

Ordinary transfers retain their existing semantics.

## Behavior preserved

This does not change the accounting behavior of:

- transfers between different accounts
- external transfers
- securities transfers
- unpaired transfers
- ordinary grouped transfers
- transfer fees

It also does not force account value to remain constant during a conversion. Differences between the execution rate and Wealthfolio's valuation rate can still appear as legitimate FX performance.

## Tests

Added regression coverage for:

- contribution-neutral same-account FX conversion
- exact source/destination cash movement
- zero `net_contribution` change
- zero `net_contribution_base` change
- zero external inflow/outflow
- TWR behavior
- reverse currency direction
- grouped transfers without qualifying FX metadata
- ordinary transfer behavior remaining unchanged

Validation completed successfully:

- 1,963 core tests passed
- Clippy passed with warnings denied
- `cargo fmt --all -- --check`
- `git diff --check`

The same FX conversion was also validated against a local Wealthfolio runtime using the addon import path. Cash movement, contribution neutrality, and idempotency all behaved as expected.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
