### PR TITLE
fix(addon-sdk): addon sdk activity import is external

### DIFF
--- a/docs/addons/addon-api-reference.md
+++ b/docs/addons/addon-api-reference.md
@@ -439,6 +439,30 @@ run, imported activities, and summary.
 const result = await ctx.api.activities.import(checkedActivities);
 ```
 
+Use `isExternal` to identify whether a transfer or credit crosses the tracked
+Wealthfolio portfolio boundary. For example, an internal transfer can be
+imported explicitly as:
+
+```typescript
+const internalTransfer: ActivityImport = {
+  accountId: "account-123",
+  activityType: "TRANSFER_IN",
+  date: "2026-09-04",
+  currency: "USD",
+  amount: 100,
+  symbol: "",
+  isExternal: false,
+  isValid: true,
+  isDraft: false,
+};
+```
+
+`false` means the activity stays within the tracked portfolio boundary; `true`
+means it crosses that boundary. Do not set `false` for every transfer: when
+omitted, `TRANSFER_IN` and `TRANSFER_OUT` default to internal at the portfolio
+boundary. For `CREDIT`, omission keeps the subtype default (`BONUS` is external;
+other credit subtypes are internal).
+
 #### `checkImport(activities: ActivityImport[]): Promise<ActivityImport[]>`
 
 Validates and normalizes activities without importing them.

--- a/packages/addon-sdk/CHANGELOG.md
+++ b/packages/addon-sdk/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ### Added
 
+- Optional `ActivityImport.isExternal` boundary override for transfer and credit
+  imports.
 - `ExchangeRatesAPI.getRatesForDates(pairs)` for batched date-specific FX-rate
   lookups, with per-pair errors and Wealthfolio's standard FX resolution rules.
 - `ctx.api.spending` (`SpendingAPI`) — `isEnabled()`, `getCategories()`,

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -401,8 +401,11 @@ export interface ActivityImport {
   lineNumber?: number;
   isDraft: boolean;
   forceImport?: boolean;
-  /** Whether a transfer or credit crosses the tracked-account boundary.
-   * Persisted as `metadata.flow.is_external` so net-contribution and flow classification work. */
+  /**
+   * Whether a transfer or credit crosses the tracked-account boundary.
+   * Controls flow classification; internal transfers may omit
+   * `metadata.flow.is_external` because false is the default.
+   */
   isExternal?: boolean;
   comment?: string;
 }

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -401,6 +401,9 @@ export interface ActivityImport {
   lineNumber?: number;
   isDraft: boolean;
   forceImport?: boolean;
+  /** Whether a transfer or credit crosses the tracked-account boundary.
+   * Persisted as `metadata.flow.is_external` so net-contribution and flow classification work. */
+  isExternal?: boolean;
   comment?: string;
 }
 


### PR DESCRIPTION
## Description

Expose the existing `isExternal` activity import field through the public addon SDK.

Wealthfolio's import pipeline already supports `isExternal` for transfers and credits, but `ActivityImport` in `@wealthfolio/addon-sdk` does not currently declare it. As a result, addons that need to explicitly classify an imported activity as internal or external have to extend or cast the SDK type locally.

This PR adds the missing optional field to `ActivityImport` and documents its boundary semantics.

## Changes

- Add `ActivityImport.isExternal?: boolean` to the addon SDK
- Document internal/external boundary behavior in the addon API reference
- Add an Unreleased changelog entry

No runtime import behavior is changed.

## Semantics

`isExternal` controls whether an imported transfer or credit crosses the tracked Wealthfolio portfolio boundary:

- `false` — internal to the tracked portfolio
- `true` — crosses the tracked portfolio boundary

For transfers, omission defaults to internal behavior.

For credits, omission retains the existing subtype-based defaults: `BONUS` is external, while other credit subtypes are internal.

Internal transfers do not necessarily persist an explicit `metadata.flow.is_external: false`, since `false` is already the default. The SDK field represents the import behavior rather than guaranteeing metadata serialization.

## Motivation

This makes the public addon SDK consistent with functionality already supported by Wealthfolio's frontend and core importer.

It also removes the need for addon authors to define local extensions such as:

    interface InternalTransferImport extends ActivityImport {
      isExternal: false;
    }

and allows the supported field to be used directly:

    const activity: ActivityImport = {
      accountId: "...",
      activityType: "TRANSFER_IN",
      currency: "USD",
      amount: 100,
      symbol: "",
      isExternal: false,
      isValid: true,
      isDraft: false,
    };

## Validation

- Addon SDK type-check passes
- Addon SDK lint passes
- Addon SDK build passes
- Prettier check passes
- `git diff --check` passes
- Compile-only consumer validation covers `isExternal: false`, `isExternal: true`, and omission

The addon SDK currently has no dedicated test harness, so no new test framework was introduced for this type-only API addition.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
