### PR TITLE
fix(dashboard/insights/activities): Hide every amount the privacy toggle promises to hide

### DIFF
--- a/apps/frontend/src/pages/activity/components/activity-detail-sheet.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-detail-sheet.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Icons,
   PriceDisplay,
+  QuantityDisplay,
   Separator,
   Sheet,
   SheetContent,
@@ -17,15 +18,22 @@ import {
 } from "@wealthfolio/ui";
 import { AmountDisplay } from "@wealthfolio/ui/components/financial/amount-display";
 import { useTranslation } from "react-i18next";
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { getProviderMappingReasons } from "./activity-data-grid/types";
 
 /** An activity with no stored amount booked no cash; rendering `Number(null)`
  * would claim it moved exactly zero. */
-function StoredAmount({ activity }: { activity: ActivityDetails }) {
+function StoredAmount({ activity, isHidden }: { activity: ActivityDetails; isHidden: boolean }) {
   if (activity.amount === null || activity.amount.trim() === "") {
     return <span className="text-muted-foreground">—</span>;
   }
-  return <AmountDisplay value={Number(activity.amount)} currency={activity.currency} />;
+  return (
+    <AmountDisplay
+      value={Number(activity.amount)}
+      currency={activity.currency}
+      isHidden={isHidden}
+    />
+  );
 }
 
 interface ActivityDetailSheetProps {
@@ -111,6 +119,7 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
   const { t } = useTranslation();
   const numberFormatting = useNumberFormatting();
   const dateFormatting = useDateFormatting();
+  const { isBalanceHidden } = useBalancePrivacy();
 
   if (!activity) return null;
 
@@ -211,7 +220,7 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
               <div className="text-right">
                 <div className="text-muted-foreground text-xs">{t("activity:field_amount")}</div>
                 <div className="text-lg font-bold">
-                  <StoredAmount activity={activity} />
+                  <StoredAmount activity={activity} isHidden={isBalanceHidden} />
                 </div>
               </div>
             </div>
@@ -269,7 +278,9 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
             {Number(activity.quantity) !== 0 && (
               <DetailRow
                 label={isOption ? t("activity:detail.contracts") : t("activity:activity_quantity")}
-                value={numberFormatting.formatQuantity(Number(activity.quantity))}
+                value={
+                  <QuantityDisplay value={Number(activity.quantity)} isHidden={isBalanceHidden} />
+                }
               />
             )}
             {Number(activity.unitPrice) !== 0 && (
@@ -278,18 +289,28 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
                   isOption ? t("activity:detail.premium_share") : t("activity:activity_unit_price")
                 }
                 value={
-                  <PriceDisplay value={Number(activity.unitPrice)} currency={activity.currency} />
+                  <PriceDisplay
+                    value={Number(activity.unitPrice)}
+                    currency={activity.currency}
+                    isHidden={isBalanceHidden}
+                  />
                 }
               />
             )}
             <DetailRow
               label={isOption ? t("activity:detail.total_premium") : t("activity:field_amount")}
-              value={<StoredAmount activity={activity} />}
+              value={<StoredAmount activity={activity} isHidden={isBalanceHidden} />}
             />
             {Number(activity.fee) !== 0 && (
               <DetailRow
                 label={t("activity:field_fee")}
-                value={<AmountDisplay value={Number(activity.fee)} currency={activity.currency} />}
+                value={
+                  <AmountDisplay
+                    value={Number(activity.fee)}
+                    currency={activity.currency}
+                    isHidden={isBalanceHidden}
+                  />
+                }
               />
             )}
             {Number(activity.tax ?? 0) !== 0 && (
@@ -300,7 +321,11 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
                     : t("activity:type_tax")
                 }
                 value={
-                  <AmountDisplay value={Number(activity.tax ?? 0)} currency={activity.currency} />
+                  <AmountDisplay
+                    value={Number(activity.tax ?? 0)}
+                    currency={activity.currency}
+                    isHidden={isBalanceHidden}
+                  />
                 }
               />
             )}

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -19,11 +19,12 @@ import { useSettingsContext } from "@/lib/settings-provider";
 import { ActivityDetails } from "@/lib/types";
 import { formatDateTime } from "@/lib/utils";
 import {
+  AmountDisplay,
   Button,
   EmptyPlaceholder,
   Icons,
+  PriceDisplay,
   Separator,
-  useAmountFormatting,
   useNumberFormatting,
   useDateFormatting,
 } from "@wealthfolio/ui";
@@ -32,6 +33,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { useVirtualScrollContainer } from "@/hooks/use-virtual-scroll-container";
 import { ActivityOperations } from "../activity-operations";
 import { ActivityTypeBadge } from "../activity-type-badge";
@@ -85,9 +87,9 @@ export const ActivityTableMobile = ({
   isFetchingNextPage = false,
   hasLoadMoreError = false,
 }: ActivityTableMobileProps) => {
-  const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
   const dateFormatting = useDateFormatting();
+  const { isBalanceHidden } = useBalancePrivacy();
   const { t } = useTranslation();
   const { settings } = useSettingsContext();
   const appTimezone = settings?.timezone?.trim() || undefined;
@@ -203,9 +205,12 @@ export const ActivityTableMobile = ({
                     <div className="flex items-baseline justify-between gap-2">
                       <p className="truncate font-semibold">{displaySymbol}</p>
                       {activity.activityType !== "SPLIT" && (
-                        <span className="shrink-0 text-sm font-semibold">
-                          {formatting.formatAmount(displayValue, activity.currency)}
-                        </span>
+                        <AmountDisplay
+                          value={displayValue}
+                          currency={activity.currency}
+                          isHidden={isBalanceHidden}
+                          className="shrink-0 text-sm font-semibold"
+                        />
                       )}
                     </div>
                     <p className="text-muted-foreground text-xs">
@@ -223,7 +228,7 @@ export const ActivityTableMobile = ({
                           <>
                             <span>•</span>
                             <span>
-                              {activity.quantity}{" "}
+                              {isBalanceHidden ? "••••" : activity.quantity}{" "}
                               {isOptionActivity
                                 ? t("activity:date_list.contracts")
                                 : t("activity:date_list.shares")}
@@ -337,7 +342,9 @@ export const ActivityTableMobile = ({
                   <span className="text-muted-foreground">
                     {isOptionActivity ? t("activity:detail.contracts") : t("activity:field_shares")}
                   </span>
-                  <span className="font-medium">{activity.quantity}</span>
+                  <span className="font-medium">
+                    {isBalanceHidden ? "••••" : activity.quantity}
+                  </span>
                 </div>
               )}
 
@@ -357,17 +364,27 @@ export const ActivityTableMobile = ({
                       : t("activity:field_price")}
               </span>
               <span className="font-medium">
-                {activity.activityType === "FEE"
-                  ? "-"
-                  : activity.activityType === "SPLIT"
-                    ? formatSplitRatio(Number(activity.amount))
-                    : (isCashActivity(activity.activityType) &&
-                          !isAssetBackedIncome &&
-                          !isSecuritiesTransfer(activity.activityType, symbol, activity.assetId)) ||
-                        isCashTransfer(activity.activityType, symbol, activity.assetId) ||
-                        (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
-                      ? formatting.formatAmount(Number(activity.amount), activity.currency)
-                      : formatting.formatPrice(Number(activity.unitPrice), activity.currency)}
+                {activity.activityType === "FEE" ? (
+                  "-"
+                ) : activity.activityType === "SPLIT" ? (
+                  formatSplitRatio(Number(activity.amount))
+                ) : (isCashActivity(activity.activityType) &&
+                    !isAssetBackedIncome &&
+                    !isSecuritiesTransfer(activity.activityType, symbol, activity.assetId)) ||
+                  isCashTransfer(activity.activityType, symbol, activity.assetId) ||
+                  (isIncomeActivity(activity.activityType) && !isAssetBackedIncome) ? (
+                  <AmountDisplay
+                    value={Number(activity.amount)}
+                    currency={activity.currency}
+                    isHidden={isBalanceHidden}
+                  />
+                ) : (
+                  <PriceDisplay
+                    value={Number(activity.unitPrice)}
+                    currency={activity.currency}
+                    isHidden={isBalanceHidden}
+                  />
+                )}
               </span>
             </div>
 
@@ -375,17 +392,23 @@ export const ActivityTableMobile = ({
             {Number(activity.fee) > 0 && activity.activityType !== "SPLIT" && (
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">{t("activity:table_fee")}</span>
-                <span className="font-medium">
-                  {formatting.formatAmount(Number(activity.fee), activity.currency)}
-                </span>
+                <AmountDisplay
+                  value={Number(activity.fee)}
+                  currency={activity.currency}
+                  isHidden={isBalanceHidden}
+                  className="font-medium"
+                />
               </div>
             )}
             {Number(activity.tax) > 0 && activity.activityType !== "SPLIT" && (
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">{t("activity:table.tax")}</span>
-                <span className="font-medium">
-                  {formatting.formatAmount(Number(activity.tax), activity.currency)}
-                </span>
+                <AmountDisplay
+                  value={Number(activity.tax)}
+                  currency={activity.currency}
+                  isHidden={isBalanceHidden}
+                  className="font-medium"
+                />
               </div>
             )}
 
@@ -395,9 +418,12 @@ export const ActivityTableMobile = ({
                 <span className="text-muted-foreground font-medium">
                   {t("activity:table.total_value")}
                 </span>
-                <span className="font-semibold">
-                  {formatting.formatAmount(displayValue, activity.currency)}
-                </span>
+                <AmountDisplay
+                  value={displayValue}
+                  currency={activity.currency}
+                  isHidden={isBalanceHidden}
+                  className="font-semibold"
+                />
               </div>
             )}
 

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -30,9 +30,10 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  AmountDisplay,
   Button,
   EmptyPlaceholder,
-  useAmountFormatting,
+  PriceDisplay,
   useNumberFormatting,
   useDateFormatting,
 } from "@wealthfolio/ui";
@@ -55,6 +56,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { useVirtualScrollContainer } from "@/hooks/use-virtual-scroll-container";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { ActivityOperations } from "../activity-operations";
@@ -106,9 +108,9 @@ export const ActivityTable = ({
   isFetchingNextPage = false,
   hasLoadMoreError = false,
 }: ActivityTableProps) => {
-  const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
   const dateFormatting = useDateFormatting();
+  const { isBalanceHidden } = useBalancePrivacy();
   const { t } = useTranslation();
   const { duplicateActivityMutation } = useActivityMutations();
   const { settings } = useSettingsContext();
@@ -344,7 +346,11 @@ export const ActivityTable = ({
 
           return (
             <div className="pr-4 text-right">
-              {typeof quantity === "number" ? quantity : String(quantity)}
+              {isBalanceHidden
+                ? "••••"
+                : typeof quantity === "number"
+                  ? quantity
+                  : String(quantity)}
             </div>
           );
         },
@@ -394,11 +400,21 @@ export const ActivityTable = ({
             (isIncomeActivity(activityType) && !isAssetBackedIncome)
           ) {
             return (
-              <div className="text-right">{formatting.formatAmount(Number(amount), currency)}</div>
+              <div className="text-right">
+                <AmountDisplay
+                  value={Number(amount)}
+                  currency={currency}
+                  isHidden={isBalanceHidden}
+                />
+              </div>
             );
           }
 
-          return <div className="text-right">{formatting.formatPrice(unitPrice, currency)}</div>;
+          return (
+            <div className="text-right">
+              <PriceDisplay value={unitPrice} currency={currency} isHidden={isBalanceHidden} />
+            </div>
+          );
         },
       },
       {
@@ -427,7 +443,11 @@ export const ActivityTable = ({
 
           return (
             <div className="text-right">
-              {activityType === "SPLIT" ? "-" : formatting.formatAmount(fee, currency)}
+              {activityType === "SPLIT" ? (
+                "-"
+              ) : (
+                <AmountDisplay value={fee} currency={currency} isHidden={isBalanceHidden} />
+              )}
             </div>
           );
         },
@@ -458,7 +478,11 @@ export const ActivityTable = ({
 
           return (
             <div className="text-right">
-              {activityType === "SPLIT" ? "-" : formatting.formatAmount(tax, currency)}
+              {activityType === "SPLIT" ? (
+                "-"
+              ) : (
+                <AmountDisplay value={tax} currency={currency} isHidden={isBalanceHidden} />
+              )}
             </div>
           );
         },
@@ -489,7 +513,9 @@ export const ActivityTable = ({
 
           const displayValue = calculateActivityValue(activity);
           return (
-            <div className="pr-4 text-right">{formatting.formatAmount(displayValue, currency)}</div>
+            <div className="pr-4 text-right">
+              <AmountDisplay value={displayValue} currency={currency} isHidden={isBalanceHidden} />
+            </div>
           );
         },
       },
@@ -608,7 +634,7 @@ export const ActivityTable = ({
     [
       appTimezone,
       dateFormatting,
-      formatting,
+      isBalanceHidden,
       handleEdit,
       handleDelete,
       handleDuplicate,

--- a/apps/frontend/src/pages/dashboard/top-holdings.test.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@/test/render";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HoldingType } from "@/lib/constants";
 import type { Holding } from "@/lib/types";
 import { TopHoldings } from "./top-holdings";
@@ -20,8 +20,10 @@ vi.mock("@/components/ticker-avatar", () => ({
   TickerAvatar: ({ symbol }: { symbol: string }) => <span>{symbol}</span>,
 }));
 
+const privacy = vi.hoisted(() => ({ isBalanceHidden: false }));
+
 vi.mock("@/hooks/use-balance-privacy", () => ({
-  useBalancePrivacy: () => ({ isBalanceHidden: false }),
+  useBalancePrivacy: () => ({ isBalanceHidden: privacy.isBalanceHidden }),
 }));
 
 vi.mock("@wealthfolio/ui", async (importOriginal) => ({
@@ -57,6 +59,10 @@ const longQuantityHolding = {
 } satisfies Holding;
 
 describe("TopHoldings", () => {
+  beforeEach(() => {
+    privacy.isBalanceHidden = false;
+  });
+
   it("truncates a long quantity within the shrinkable holding details column", () => {
     render(
       <MemoryRouter>
@@ -65,5 +71,18 @@ describe("TopHoldings", () => {
     );
 
     expect(screen.getByText("123,456,789 shares")).toHaveClass("truncate");
+  });
+
+  it("hides the share count when balances are hidden", () => {
+    privacy.isBalanceHidden = true;
+
+    render(
+      <MemoryRouter>
+        <TopHoldings holdings={[longQuantityHolding]} isLoading={false} baseCurrency="CNY" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("123,456,789 shares")).not.toBeInTheDocument();
+    expect(screen.getByText("•••• shares")).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -62,10 +62,13 @@ function HoldingRow({
   const subtitle = parsedOption
     ? formatOptionSubtitle(parsedOption, { ...numberFormatting, ...dateFormatting })
     : t("dashboard:holdings.shares", {
-        count: holding.quantity ?? 0,
-        formatted: formatting.formatDecimal(holding.quantity ?? 0, {
-          maximumFractionDigits: 3,
-        }),
+        // Force the plural form when hidden so the label does not leak a quantity of exactly 1.
+        count: isHidden ? 0 : (holding.quantity ?? 0),
+        formatted: isHidden
+          ? "••••"
+          : formatting.formatDecimal(holding.quantity ?? 0, {
+              maximumFractionDigits: 3,
+            }),
       });
   const avatarSymbol = parsedOption ? parsedOption.underlying : symbol;
   const marketValue = holding.marketValue?.base ?? 0;

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -17,6 +17,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getHoldingsByAllocation } from "@/adapters";
 import { namedChild, namedChildren } from "@/lib/allocation-children";
 import { TickerAvatar } from "@/components/ticker-avatar";
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
 import type {
   AccountScope,
@@ -49,6 +50,7 @@ export function AllocationDetailSheet({
 }: AllocationDetailSheetProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { isBalanceHidden } = useBalancePrivacy();
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
   const [selectedCategoryName, setSelectedCategoryName] = useState<string | null>(null);
   const [selectedColor, setSelectedColor] = useState<string | null>(null);
@@ -271,6 +273,7 @@ export function AllocationDetailSheet({
                       <AmountDisplay
                         value={category.value}
                         currency={baseCurrency}
+                        isHidden={isBalanceHidden}
                         className="shrink-0 text-sm"
                       />
                       <span className="text-muted-foreground w-12 shrink-0 text-right text-xs tabular-nums">
@@ -313,6 +316,7 @@ export function AllocationDetailSheet({
                                   <AmountDisplay
                                     value={child.value}
                                     currency={baseCurrency}
+                                    isHidden={isBalanceHidden}
                                     className="text-muted-foreground shrink-0 text-xs"
                                   />
                                   <span className="text-muted-foreground w-12 shrink-0 text-right text-xs tabular-nums">
@@ -430,6 +434,7 @@ export function AllocationDetailSheet({
                           <AmountDisplay
                             value={holding.marketValue}
                             currency={baseCurrency}
+                            isHidden={isBalanceHidden}
                             className="text-sm font-medium"
                           />
                           <p className="text-muted-foreground text-xs">

--- a/apps/frontend/src/pages/holdings/components/composition-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/composition-chart.tsx
@@ -1,12 +1,13 @@
 import { RenderableChartContainer } from "@/components/renderable-chart-container";
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { usePersistentState } from "@/hooks/use-persistent-state";
 import { getBaseHoldingPerformancePercentForMode } from "@/lib/holding-performance";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
+  AmountDisplay,
   AnimatedToggleGroup,
-  useAmountFormatting,
   useDateFormatting,
   useNumberFormatting,
 } from "@wealthfolio/ui";
@@ -252,9 +253,9 @@ interface TooltipProps {
 }
 
 const CompositionTooltip = ({ active, payload, settings }: TooltipProps) => {
-  const amountFormatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
   const dateFormatting = useDateFormatting();
+  const { isBalanceHidden } = useBalancePrivacy();
 
   const { t } = useTranslation();
   if (active && payload?.length) {
@@ -286,9 +287,12 @@ const CompositionTooltip = ({ active, payload, settings }: TooltipProps) => {
               <span className="text-muted-foreground pr-6 text-sm">
                 {t("holdings:market_value_label")}
               </span>
-              <span className="text-sm font-semibold">
-                {amountFormatting.formatAmount(value, settings?.baseCurrency ?? "USD")}
-              </span>
+              <AmountDisplay
+                value={value}
+                currency={settings?.baseCurrency ?? "USD"}
+                isHidden={isBalanceHidden}
+                className="text-sm font-semibold"
+              />
             </div>
 
             {/* Gain/Loss */}


### PR DESCRIPTION
Fixes #1663.

With **Hide amounts** on, several surfaces still rendered real values. Each one had the same root cause: `AmountDisplay`, `PriceDisplay` and `QuantityDisplay` take `isHidden` as a prop rather than reading the privacy setting themselves, and these call sites never passed it — or formatted the value directly and bypassed the components entirely.

### What was leaking

| Where | What |
| --- | --- |
| Dashboard → Investments → Holdings | Share count in each row's subtitle (market value was already masked) |
| Dashboard → Net Worth → Breakdown → **Investments** | Every amount in the drawer: asset class, sub-class, per-holding market value |
| Insights → Composition | Market Value in the treemap hover tooltip |
| Activities table (desktop + mobile) | Quantity, price/amount, fee, tax, total |
| Activities row drawer | Header amount and the whole Financial Details block |

The Net Worth **Cash** row was already correct — it opens a different sheet that uses the privacy-aware `CompactAmount`. That inconsistency is what the issue reports.

### Approach

Every fix follows the pattern already used by the files next to each of these: call `useBalancePrivacy()` and thread `isHidden={isBalanceHidden}` into the shared display components, which mask with the usual `••••`. Where a raw `formatAmount`/`formatPrice` call was rendering a string, it now goes through `AmountDisplay`/`PriceDisplay` — the visible output is byte-identical, since those components call the same formatters with the same defaults. No new abstraction, no change to the privacy mechanism itself.

Two details worth a reviewer's eye:

- The activities table builds its columns in a `useMemo`, so `isBalanceHidden` had to join the dependency array or toggling the setting wouldn't re-render the cells.
- The Holdings share count is interpolated into an i18n string. When hidden it forces the plural form, so the label can't leak a quantity of exactly 1 via "1 share".

### What deliberately stays visible

Percentages, split ratios, FX rates, currency codes, and an option contract's strike and expiry. Those describe the instrument or the corporate action rather than the size of the position, and percentages have never been masked anywhere in the app.

Also unchanged: the editable activities data grid. Its number cells are inputs — masking them would break editing.

### Testing

`pnpm format:check`, `pnpm lint`, `pnpm type-check`, `pnpm test` (1986 passing) and `pnpm build` all green.

Added a regression test in `top-holdings.test.tsx` covering the issue's first bullet: with balances hidden, the row subtitle renders `•••• shares` and the real count is absent.

Manually verified each surface with the toggle both on and off, confirming values return to their previous formatting when shown.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
