### PR TITLE
fix(valuation): exact flow mixtures are no longer reported as degraded provenance

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1057,7 +1057,8 @@ export interface AccountValuation {
     | "ACTIVITY_DERIVED"
     | "STORED_GROSS"
     | "NET_CONTRIBUTION_FALLBACK"
-    | "MIXED";
+    | "MIXED"
+    | "MIXED_EXACT";
   performanceEligibleValueBase: number;
   valueStatus: ValuationStatus;
   basisStatus: BasisStatus;

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -10973,6 +10973,12 @@ mod tests {
         );
         assert_eq!(scoped[2].external_inflow_base, Decimal::ZERO);
         assert_eq!(scoped[2].external_outflow_base, Decimal::ZERO);
+        // Netting the internal legs must not relabel the day: it keeps the
+        // per-account provenance instead of a stamped CashAmount mixture.
+        assert_eq!(
+            scoped[2].external_flow_source,
+            ExternalFlowSource::ActivityDerived
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -10981,6 +10981,96 @@ mod tests {
         );
     }
 
+    // Issue #1609 through the scoped pipeline: a cash deposit and an external
+    // in-kind transfer-in land on the same day in one account. The mock quote
+    // service has no quote, so the transfer degrades to its cost basis and the
+    // day must be the degraded mixture, not the exact one.
+    #[test]
+    fn scoped_flow_pipeline_marks_same_day_cash_and_cost_basis_flows_as_mixed() {
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let mut deposit = create_stored_activity("deposit", "acc-a", None);
+        deposit.activity_type = "DEPOSIT".to_string();
+        deposit.activity_date = parse_test_activity_datetime("2026-05-02");
+        deposit.quantity = None;
+        deposit.unit_price = None;
+        deposit.amount = Some(dec!(50));
+        deposit.metadata = None;
+        activity_repository.add_activity(deposit);
+
+        let mut transfer_in = create_stored_activity("transfer-in", "acc-a", Some("AAPL"));
+        transfer_in.activity_type = "TRANSFER_IN".to_string();
+        transfer_in.activity_date = parse_test_activity_datetime("2026-05-02");
+        transfer_in.quantity = Some(dec!(10));
+        transfer_in.unit_price = Some(dec!(8));
+        transfer_in.amount = None;
+        transfer_in.metadata = Some(json!({ "flow": { "is_external": true } }));
+        activity_repository.add_activity(transfer_in);
+
+        let valuation_repository = Arc::new(MockValuationRepository::new(vec![
+            create_daily_valuation(
+                "acc-a",
+                "2026-05-01",
+                dec!(100),
+                Decimal::ZERO,
+                dec!(100),
+                dec!(100),
+            ),
+            create_daily_valuation(
+                "acc-a",
+                "2026-05-02",
+                dec!(150),
+                dec!(80),
+                dec!(230),
+                dec!(230),
+            ),
+            create_daily_valuation(
+                "acc-b",
+                "2026-05-01",
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            create_daily_valuation(
+                "acc-b",
+                "2026-05-02",
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ]));
+        let account_ids = vec!["acc-a".to_string(), "acc-b".to_string()];
+        let valuation_service = ValuationService::new(
+            Arc::new(RwLock::new("USD".to_string())),
+            valuation_repository,
+            Arc::new(MockSnapshotService),
+            Arc::new(MockQuoteService),
+            Arc::new(MockFxService::new()),
+        )
+        .with_activity_repository(
+            activity_repository,
+            Arc::new(RwLock::new("UTC".to_string())),
+        );
+
+        let scoped = valuation_service
+            .get_historical_valuations_for_accounts(
+                "scope:mixed-day",
+                &account_ids,
+                "USD",
+                Some(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap()),
+                Some(NaiveDate::from_ymd_opt(2026, 5, 2).unwrap()),
+            )
+            .expect("scoped flow calculation should fold same-day activities");
+
+        assert_eq!(scoped[1].external_inflow_base, dec!(130));
+        assert_eq!(scoped[1].external_outflow_base, Decimal::ZERO);
+        assert_eq!(scoped[1].external_flow_source, ExternalFlowSource::Mixed);
+        assert!(scoped[1].external_flow_source.is_degraded());
+        assert!(!scoped[1].external_flow_source.is_unavailable_for_returns());
+    }
+
     #[tokio::test]
     async fn test_import_accepts_manual_equity_without_exchange_mic() {
         let account_service = Arc::new(MockAccountService::new());

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -10268,6 +10268,127 @@ mod tests {
         assert!(result.data_quality.not_applicable_reasons.is_empty());
     }
 
+    // Issue #1609: the exact mixture is complete provenance. Same fixture as
+    // the degraded mixture above; its returns and data quality must match a
+    // plain cash flow exactly, with no provenance warning.
+    #[test]
+    fn mixed_exact_flow_source_is_clean_and_computable() {
+        let compute = |source: ExternalFlowSource| {
+            let mut history = vec![
+                valuation("2026-04-01", dec!(1000), dec!(1000), dec!(1000), dec!(1000)),
+                valuation("2026-04-02", dec!(1110), dec!(1100), dec!(1110), dec!(1000)),
+            ];
+            history[1].external_inflow_base = dec!(100);
+            history[1].external_flow_source = source;
+            PerformanceService::compute_account_performance(
+                &history,
+                Some(TrackingMode::Transactions),
+                None,
+                false,
+            )
+            .expect("known-source flow should compute")
+        };
+
+        let exact = compute(ExternalFlowSource::MixedExact);
+        let control = compute(ExternalFlowSource::CashAmount);
+        let degraded = compute(ExternalFlowSource::Mixed);
+
+        assert_eq!(exact.returns.twr.unwrap().round_dp(4), dec!(0.0091));
+        assert_eq!(exact.returns.twr, control.returns.twr);
+        assert_eq!(exact.returns.irr, control.returns.irr);
+        assert_eq!(exact.data_quality.status, control.data_quality.status);
+        assert_eq!(exact.data_quality.warnings, control.data_quality.warnings);
+        assert_eq!(
+            exact.data_quality.not_applicable_reasons,
+            control.data_quality.not_applicable_reasons
+        );
+        assert!(exact
+            .data_quality
+            .warnings
+            .iter()
+            .all(|warning| !warning.starts_with("External cash flow")));
+
+        // The degraded mixture differs from the exact one by exactly the
+        // provenance warning.
+        let provenance: Vec<_> = degraded
+            .data_quality
+            .warnings
+            .iter()
+            .filter(|warning| !exact.data_quality.warnings.contains(warning))
+            .collect();
+        assert_eq!(provenance.len(), 1);
+        assert!(provenance[0].contains("External cash flow provenance is incomplete"));
+        assert_eq!(degraded.data_quality.status, DataQualityStatus::Partial);
+    }
+
+    // The exact mixture is explicit gross: the stored amounts are used as-is,
+    // never re-derived from the net-contribution delta.
+    #[test]
+    fn daily_external_flows_read_stored_gross_for_mixed_exact() {
+        let prev = valuation("2026-04-01", dec!(1000), dec!(1000), dec!(1000), dec!(1000));
+        let mut curr = valuation("2026-04-02", dec!(1200), dec!(1200), dec!(1200), dec!(1200));
+        curr.external_inflow_base = dec!(150);
+        curr.external_outflow_base = dec!(30);
+        curr.external_flow_source = ExternalFlowSource::MixedExact;
+
+        let flow =
+            PerformanceService::daily_external_flows(&prev, &curr, ExternalFlowBasis::BaseCurrency);
+
+        assert_eq!(flow.inflow, dec!(150));
+        assert_eq!(flow.outflow, dec!(30));
+        assert_eq!(flow.source, ExternalFlowSource::MixedExact);
+        assert!(!flow.source.is_degraded());
+    }
+
+    #[test]
+    fn external_flow_quality_warnings_ignore_mixed_exact() {
+        let flow = |source: ExternalFlowSource| DailyExternalFlow {
+            date: NaiveDate::from_ymd_opt(2026, 4, 2).unwrap(),
+            inflow: dec!(100),
+            outflow: Decimal::ZERO,
+            source,
+        };
+
+        assert!(PerformanceService::external_flow_quality_warnings(&[flow(
+            ExternalFlowSource::MixedExact
+        )])
+        .is_empty());
+        let degraded =
+            PerformanceService::external_flow_quality_warnings(&[flow(ExternalFlowSource::Mixed)]);
+        assert_eq!(degraded.len(), 1);
+        assert!(degraded[0].contains("External cash flow provenance is incomplete"));
+    }
+
+    // HOLDINGS-mode helpers key off `is_explicit_gross`, so the exact mixture
+    // is netted like any other gross flow and the fallback row is ignored.
+    #[test]
+    fn holdings_flow_helpers_treat_mixed_exact_as_explicit_gross() {
+        let date = NaiveDate::from_ymd_opt(2026, 4, 2).unwrap();
+        let flows = [
+            DailyExternalFlow {
+                date,
+                inflow: dec!(100),
+                outflow: dec!(30),
+                source: ExternalFlowSource::MixedExact,
+            },
+            DailyExternalFlow {
+                date,
+                inflow: dec!(999),
+                outflow: Decimal::ZERO,
+                source: ExternalFlowSource::NetContributionFallback,
+            },
+        ];
+
+        assert_eq!(
+            PerformanceService::net_explicit_gross_flow(&flows),
+            dec!(70)
+        );
+        assert!(PerformanceService::has_estimated_holdings_flows(&flows));
+        assert!(!PerformanceService::has_estimated_holdings_flows(
+            &flows[1..]
+        ));
+    }
+
     #[test]
     fn partial_unpriced_valuation_warns_but_still_computes_priced_subset() {
         let mut history = vec![

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -10243,6 +10243,31 @@ mod tests {
         );
     }
 
+    // Issue #1609: a scope-internal in-kind transfer nets to zero flow but keeps
+    // its quote-derived provenance. That day is exact, so it must not raise the
+    // provenance warning or downgrade data quality.
+    #[test]
+    fn netted_in_kind_transfer_day_is_clean() {
+        let mut history = vec![
+            valuation("2026-04-01", dec!(1000), dec!(1000), dec!(1000), dec!(1000)),
+            valuation("2026-04-02", dec!(1010), dec!(1000), dec!(1010), dec!(1000)),
+        ];
+        history[1].external_flow_source = ExternalFlowSource::QuoteDerivedMarketValue;
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            false,
+        )
+        .expect("netted in-kind transfer day should compute");
+
+        assert_eq!(result.returns.twr.unwrap().round_dp(4), dec!(0.0100));
+        assert_eq!(result.data_quality.status, DataQualityStatus::Ok);
+        assert!(result.data_quality.warnings.is_empty());
+        assert!(result.data_quality.not_applicable_reasons.is_empty());
+    }
+
     #[test]
     fn partial_unpriced_valuation_warns_but_still_computes_priced_subset() {
         let mut history = vec![

--- a/crates/core/src/portfolio/valuation/valuation_model.rs
+++ b/crates/core/src/portfolio/valuation/valuation_model.rs
@@ -35,8 +35,14 @@ pub enum ExternalFlowSource {
     /// Compatibility-only value for persisted rows that already have gross flow columns.
     StoredGross,
     NetContributionFallback,
-    /// Aggregate valuation rows can contain multiple compiler flow sources on the same day.
+    /// Two or more distinct flow sources on the same day, at least one of them
+    /// degraded. Aggregate rows and per-account days with several activities
+    /// produce this; it stays degraded because a constituent is.
     Mixed,
+    /// Two or more distinct flow sources on the same day, every one of them
+    /// exact (e.g. a cash movement and a quote-priced in-kind transfer).
+    /// Provenance is complete, only heterogeneous, so it is not degraded.
+    MixedExact,
 }
 
 #[cfg(test)]
@@ -62,25 +68,41 @@ mod tests {
 
     #[test]
     fn known_external_flow_source_codes_roundtrip() {
-        let sources = [
-            ExternalFlowSource::NoFlow,
-            ExternalFlowSource::Unknown,
-            ExternalFlowSource::CashAmount,
-            ExternalFlowSource::QuoteDerivedMarketValue,
-            ExternalFlowSource::CostBasisFallback,
-            ExternalFlowSource::RemovedLotBasisFallback,
-            ExternalFlowSource::LegacyActivityAmountFallback,
-            ExternalFlowSource::UnknownBoundaryTransfer,
-            ExternalFlowSource::UnpricedHoldingsTransition,
-            ExternalFlowSource::ActivityDerived,
-            ExternalFlowSource::StoredGross,
-            ExternalFlowSource::NetContributionFallback,
-            ExternalFlowSource::Mixed,
-        ];
+        // `ALL` is the exhaustive list; a variant added without updating it
+        // would silently escape every property test that iterates it.
+        assert_eq!(ExternalFlowSource::ALL.len(), 14);
 
-        for source in sources {
+        for source in ExternalFlowSource::ALL {
             assert_eq!(ExternalFlowSource::from_code(source.as_str()), source);
         }
+        assert_eq!(
+            ExternalFlowSource::from_code("MIXED_EXACT"),
+            ExternalFlowSource::MixedExact
+        );
+        assert_eq!(ExternalFlowSource::MixedExact.as_str(), "MIXED_EXACT");
+    }
+
+    #[test]
+    fn serde_codes_match_storage_codes() {
+        for source in ExternalFlowSource::ALL {
+            let json = serde_json::to_string(&source).expect("serialize flow source");
+            assert_eq!(json, format!("\"{}\"", source.as_str()));
+            let parsed: ExternalFlowSource =
+                serde_json::from_str(&json).expect("deserialize flow source");
+            assert_eq!(parsed, source);
+        }
+    }
+
+    #[test]
+    fn from_code_is_case_and_whitespace_tolerant() {
+        assert_eq!(
+            ExternalFlowSource::from_code(" mixed_exact "),
+            ExternalFlowSource::MixedExact
+        );
+        assert_eq!(
+            ExternalFlowSource::from_code("mixed"),
+            ExternalFlowSource::Mixed
+        );
     }
 
     #[test]
@@ -110,7 +132,16 @@ mod tests {
         assert!(ExternalFlowSource::CostBasisFallback.is_degraded());
         assert!(ExternalFlowSource::RemovedLotBasisFallback.is_degraded());
         assert!(ExternalFlowSource::LegacyActivityAmountFallback.is_degraded());
+
+        // Mixed carries a degraded constituent; MixedExact carries only exact
+        // ones. Both are gross flows, neither blocks returns.
+        assert!(ExternalFlowSource::Mixed.is_explicit_gross());
         assert!(ExternalFlowSource::Mixed.is_degraded());
+        assert!(!ExternalFlowSource::Mixed.is_unavailable_for_returns());
+
+        assert!(ExternalFlowSource::MixedExact.is_explicit_gross());
+        assert!(!ExternalFlowSource::MixedExact.is_degraded());
+        assert!(!ExternalFlowSource::MixedExact.is_unavailable_for_returns());
 
         assert!(ExternalFlowSource::Unknown.is_unavailable_for_returns());
         assert!(ExternalFlowSource::UnknownBoundaryTransfer.is_unavailable_for_returns());
@@ -144,10 +175,130 @@ mod tests {
             ExternalFlowSource::RemovedLotBasisFallback.combine(ExternalFlowSource::CashAmount),
             ExternalFlowSource::RemovedLotBasisFallback
         );
+        // Two exact sources merge into the exact mixture, in either order, and
+        // the exact mixture absorbs further exact sources.
         assert_eq!(
             ExternalFlowSource::CashAmount.combine(ExternalFlowSource::QuoteDerivedMarketValue),
+            ExternalFlowSource::MixedExact
+        );
+        assert_eq!(
+            ExternalFlowSource::QuoteDerivedMarketValue.combine(ExternalFlowSource::CashAmount),
+            ExternalFlowSource::MixedExact
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::CashAmount),
+            ExternalFlowSource::MixedExact
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::QuoteDerivedMarketValue),
+            ExternalFlowSource::MixedExact
+        );
+
+        // Any degraded constituent turns the mixture into the degraded one.
+        assert_eq!(
+            ExternalFlowSource::CashAmount.combine(ExternalFlowSource::StoredGross),
             ExternalFlowSource::Mixed
         );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::StoredGross),
+            ExternalFlowSource::Mixed
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::CostBasisFallback),
+            ExternalFlowSource::Mixed
+        );
+        assert_eq!(
+            ExternalFlowSource::Mixed.combine(ExternalFlowSource::MixedExact),
+            ExternalFlowSource::Mixed
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::Mixed),
+            ExternalFlowSource::Mixed
+        );
+
+        // Absorbing markers still win over the exact mixture.
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::Unknown),
+            ExternalFlowSource::Unknown
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::UnknownBoundaryTransfer),
+            ExternalFlowSource::UnknownBoundaryTransfer
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::UnpricedHoldingsTransition),
+            ExternalFlowSource::UnpricedHoldingsTransition
+        );
+        assert_eq!(
+            ExternalFlowSource::MixedExact.combine(ExternalFlowSource::RemovedLotBasisFallback),
+            ExternalFlowSource::RemovedLotBasisFallback
+        );
+    }
+
+    // Issue #1609: merging exact provenance must never invent degradation.
+    // The exact sources form a closed set under `combine`.
+    #[test]
+    fn exact_sources_are_closed_under_combine() {
+        const EXACT: [ExternalFlowSource; 4] = [
+            ExternalFlowSource::NoFlow,
+            ExternalFlowSource::CashAmount,
+            ExternalFlowSource::QuoteDerivedMarketValue,
+            ExternalFlowSource::MixedExact,
+        ];
+        for source in ExternalFlowSource::ALL {
+            assert_eq!(
+                EXACT.contains(&source),
+                !source.is_degraded(),
+                "{source:?} must be exact iff it is not degraded",
+            );
+        }
+        for left in EXACT {
+            for right in EXACT {
+                let combined = left.combine(right);
+                assert!(
+                    EXACT.contains(&combined),
+                    "combine({left:?}, {right:?}) = {combined:?} left the exact set",
+                );
+                assert!(!combined.is_degraded());
+                assert!(!combined.is_unavailable_for_returns());
+            }
+        }
+    }
+
+    // The two mixture variants partition the "distinct, non-absorbing" merges:
+    // `Mixed` always has a degraded input, `MixedExact` never does.
+    #[test]
+    fn mixture_variants_reflect_their_inputs() {
+        for left in ExternalFlowSource::ALL {
+            for right in ExternalFlowSource::ALL {
+                let either_degraded = left.is_degraded() || right.is_degraded();
+                match left.combine(right) {
+                    ExternalFlowSource::Mixed => assert!(
+                        either_degraded,
+                        "combine({left:?}, {right:?}) is Mixed without a degraded input",
+                    ),
+                    ExternalFlowSource::MixedExact => {
+                        assert!(
+                            !either_degraded,
+                            "combine({left:?}, {right:?}) is MixedExact with a degraded input",
+                        );
+                        // Unless an input already was the exact mixture, it
+                        // takes two distinct real sources to produce one.
+                        if left != ExternalFlowSource::MixedExact
+                            && right != ExternalFlowSource::MixedExact
+                        {
+                            assert_ne!(
+                                left, right,
+                                "a single exact source must not merge into MixedExact",
+                            );
+                            assert_ne!(left, ExternalFlowSource::NoFlow);
+                            assert_ne!(right, ExternalFlowSource::NoFlow);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
     }
 
     #[test]
@@ -176,7 +327,7 @@ mod tests {
 }
 
 impl ExternalFlowSource {
-    pub const ALL: [ExternalFlowSource; 13] = [
+    pub const ALL: [ExternalFlowSource; 14] = [
         ExternalFlowSource::NoFlow,
         ExternalFlowSource::Unknown,
         ExternalFlowSource::CashAmount,
@@ -190,6 +341,7 @@ impl ExternalFlowSource {
         ExternalFlowSource::StoredGross,
         ExternalFlowSource::NetContributionFallback,
         ExternalFlowSource::Mixed,
+        ExternalFlowSource::MixedExact,
     ];
 
     pub fn as_str(self) -> &'static str {
@@ -207,6 +359,7 @@ impl ExternalFlowSource {
             Self::StoredGross => "STORED_GROSS",
             Self::NetContributionFallback => "NET_CONTRIBUTION_FALLBACK",
             Self::Mixed => "MIXED",
+            Self::MixedExact => "MIXED_EXACT",
         }
     }
 
@@ -226,6 +379,7 @@ impl ExternalFlowSource {
             "STORED_GROSS" => Self::StoredGross,
             "NET_CONTRIBUTION_FALLBACK" => Self::NetContributionFallback,
             "MIXED" => Self::Mixed,
+            "MIXED_EXACT" => Self::MixedExact,
             _ => Self::Unknown,
         }
     }
@@ -241,6 +395,7 @@ impl ExternalFlowSource {
                 | Self::ActivityDerived
                 | Self::StoredGross
                 | Self::Mixed
+                | Self::MixedExact
         )
     }
 
@@ -281,6 +436,10 @@ impl ExternalFlowSource {
             (Self::RemovedLotBasisFallback, _) | (_, Self::RemovedLotBasisFallback) => {
                 Self::RemovedLotBasisFallback
             }
+            // Distinct exact sources: provenance is complete, only heterogeneous.
+            // The guard makes this unreachable when either side is degraded, so
+            // `Mixed` keeps meaning "at least one constituent is degraded".
+            (left, right) if !left.is_degraded() && !right.is_degraded() => Self::MixedExact,
             _ => Self::Mixed,
         }
     }

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -1127,10 +1127,9 @@ impl ValuationService {
                 Self::subtract_flow_floor_zero(value.external_inflow_base, *inflow_to_remove);
             value.external_outflow_base =
                 Self::subtract_flow_floor_zero(value.external_outflow_base, *outflow_to_remove);
-            value.external_flow_source = Self::combine_external_flow_sources(
-                value.external_flow_source,
-                ExternalFlowSource::CashAmount,
-            );
+            // Netting removes scope-internal legs; it does not introduce a
+            // differently-valued flow, so the day keeps the provenance of the
+            // flows that survive. Stamping a source here would invent one.
         }
     }
 
@@ -5428,7 +5427,340 @@ mod tests {
 
         assert_eq!(aggregate[1].external_inflow_base, Decimal::ZERO);
         assert_eq!(aggregate[1].external_outflow_base, Decimal::ZERO);
-        assert_eq!(aggregate[1].external_flow_source, ExternalFlowSource::Mixed);
+        // Netting only subtracts; the row keeps the provenance it had before
+        // (the stored-gross marker the fixture rows carry), never a stamped one.
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::StoredGross
+        );
+    }
+
+    /// Two-account scope where an internal transfer moves 100 from `a1` to
+    /// `a2` on 2026-05-02 and every per-account leg carries `source`.
+    fn internal_transfer_histories(source: ExternalFlowSource) -> Vec<Vec<DailyAccountValuation>> {
+        let mut out_leg = valuation(
+            "a1",
+            "2026-05-02",
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            dec!(100),
+        );
+        out_leg.external_flow_source = source;
+        let mut in_leg = valuation(
+            "a2",
+            "2026-05-02",
+            dec!(100),
+            dec!(100),
+            dec!(100),
+            Decimal::ZERO,
+        );
+        in_leg.external_flow_source = source;
+        vec![
+            vec![
+                valuation(
+                    "a1",
+                    "2026-05-01",
+                    dec!(100),
+                    dec!(100),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+                out_leg,
+            ],
+            vec![
+                valuation(
+                    "a2",
+                    "2026-05-01",
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+                in_leg,
+            ],
+        ]
+    }
+
+    fn internal_transfer_adjustments() -> HashMap<NaiveDate, (Decimal, Decimal)> {
+        let flow_date = NaiveDate::parse_from_str("2026-05-02", "%Y-%m-%d").unwrap();
+        HashMap::from([(flow_date, (dec!(100), dec!(100)))])
+    }
+
+    // Issue #1609, defect 2: an in-kind transfer whose both legs sit inside the
+    // scope never reaches the authoritative activity map, so the netting pass
+    // runs. It must leave the quote-derived provenance alone instead of
+    // stamping CashAmount and manufacturing a degraded Mixed day.
+    #[test]
+    fn netting_keeps_quote_derived_source_for_in_kind_internal_transfer() {
+        let account_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+        let adjustments = internal_transfer_adjustments();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            internal_transfer_histories(ExternalFlowSource::QuoteDerivedMarketValue),
+            Some(&no_authoritative_flows),
+            Some(&adjustments),
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_inflow_base, Decimal::ZERO);
+        assert_eq!(aggregate[1].external_outflow_base, Decimal::ZERO);
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::QuoteDerivedMarketValue
+        );
+        assert!(!aggregate[1].external_flow_source.is_degraded());
+        assert!(!aggregate[1]
+            .external_flow_source
+            .is_unavailable_for_returns());
+    }
+
+    #[test]
+    fn netting_keeps_cash_source_for_cash_internal_transfer() {
+        let account_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+        let adjustments = internal_transfer_adjustments();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            internal_transfer_histories(ExternalFlowSource::CashAmount),
+            Some(&no_authoritative_flows),
+            Some(&adjustments),
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_inflow_base, Decimal::ZERO);
+        assert_eq!(aggregate[1].external_outflow_base, Decimal::ZERO);
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::CashAmount
+        );
+        assert!(!aggregate[1].external_flow_source.is_degraded());
+    }
+
+    // Absorbing markers must survive the netting pass untouched: it may only
+    // shrink amounts, never relabel a day that still gates returns.
+    #[test]
+    fn netting_preserves_absorbing_sources() {
+        for source in [
+            ExternalFlowSource::Unknown,
+            ExternalFlowSource::UnknownBoundaryTransfer,
+            ExternalFlowSource::UnpricedHoldingsTransition,
+            ExternalFlowSource::RemovedLotBasisFallback,
+        ] {
+            let mut histories = internal_transfer_histories(ExternalFlowSource::CashAmount);
+            histories[0][1].external_flow_source = source;
+            let account_ids = vec!["a1".to_string(), "a2".to_string()];
+            let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+            let adjustments = internal_transfer_adjustments();
+
+            let aggregate = ValuationService::aggregate_scoped_valuations(
+                "accounts:test",
+                &account_ids,
+                "USD",
+                histories,
+                Some(&no_authoritative_flows),
+                Some(&adjustments),
+            )
+            .expect("complete scoped histories should aggregate");
+
+            assert_eq!(
+                aggregate[1].external_flow_source, source,
+                "netting must not relabel {source:?}",
+            );
+        }
+    }
+
+    // A quiet day (no stored flows, no net-contribution movement) that happens
+    // to have an adjustment entry stays NoFlow; it used to be stamped CashAmount.
+    #[test]
+    fn netting_leaves_no_flow_row_untouched() {
+        let histories = vec![
+            vec![
+                valuation(
+                    "a1",
+                    "2026-05-01",
+                    dec!(100),
+                    dec!(100),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+                valuation(
+                    "a1",
+                    "2026-05-02",
+                    dec!(100),
+                    dec!(100),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+            ],
+            vec![
+                valuation(
+                    "a2",
+                    "2026-05-01",
+                    dec!(50),
+                    dec!(50),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+                valuation(
+                    "a2",
+                    "2026-05-02",
+                    dec!(50),
+                    dec!(50),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+            ],
+        ];
+        let account_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+        let adjustments = internal_transfer_adjustments();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            histories,
+            Some(&no_authoritative_flows),
+            Some(&adjustments),
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_inflow_base, Decimal::ZERO);
+        assert_eq!(aggregate[1].external_outflow_base, Decimal::ZERO);
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::NoFlow
+        );
+    }
+
+    // Legacy rows (pre-compiler `UNKNOWN` with empty flow columns) fall back to
+    // the net-contribution delta. The netting pass must not promote that
+    // fallback to an explicit-gross Mixed row, or the performance layer would
+    // trust the floored amounts instead of re-deriving the delta.
+    #[test]
+    fn netting_leaves_net_contribution_fallback_row_untouched() {
+        let legacy = |account_id: &str, date: &str, total: Decimal| {
+            let mut row = valuation(account_id, date, total, total, Decimal::ZERO, Decimal::ZERO);
+            row.external_flow_source = ExternalFlowSource::Unknown;
+            row
+        };
+        let histories = vec![
+            vec![
+                legacy("a1", "2026-05-01", dec!(100)),
+                legacy("a1", "2026-05-02", Decimal::ZERO),
+            ],
+            vec![
+                legacy("a2", "2026-05-01", Decimal::ZERO),
+                legacy("a2", "2026-05-02", dec!(100)),
+            ],
+            vec![
+                legacy("a3", "2026-05-01", Decimal::ZERO),
+                legacy("a3", "2026-05-02", dec!(50)),
+            ],
+        ];
+        let account_ids = vec!["a1".to_string(), "a2".to_string(), "a3".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+        let adjustments = internal_transfer_adjustments();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            histories,
+            Some(&no_authoritative_flows),
+            Some(&adjustments),
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::NetContributionFallback
+        );
+        assert!(!aggregate[1].external_flow_source.is_explicit_gross());
+    }
+
+    // Issue #1609 "Evidence": the same transfer day must not flip between
+    // degraded and clean depending on which unrelated accounts share the
+    // scope. P = {a1, a2} runs the netting pass; Q = {a1, a2, a3} has an
+    // unrelated cash withdrawal that makes the day authoritative and skips it.
+    #[test]
+    fn netting_is_deterministic_across_scope_membership() {
+        let flow_date = NaiveDate::parse_from_str("2026-05-02", "%Y-%m-%d").unwrap();
+        let adjustments = internal_transfer_adjustments();
+
+        let smaller_scope_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+        let smaller_scope = ValuationService::aggregate_scoped_valuations(
+            "accounts:p",
+            &smaller_scope_ids,
+            "USD",
+            internal_transfer_histories(ExternalFlowSource::QuoteDerivedMarketValue),
+            Some(&no_authoritative_flows),
+            Some(&adjustments),
+        )
+        .expect("complete scoped histories should aggregate");
+
+        let mut withdrawal_day = valuation(
+            "a3",
+            "2026-05-02",
+            dec!(50),
+            dec!(50),
+            Decimal::ZERO,
+            dec!(50),
+        );
+        withdrawal_day.external_flow_source = ExternalFlowSource::CashAmount;
+        let mut superset_histories =
+            internal_transfer_histories(ExternalFlowSource::QuoteDerivedMarketValue);
+        superset_histories.push(vec![
+            valuation(
+                "a3",
+                "2026-05-01",
+                dec!(100),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            withdrawal_day,
+        ]);
+        let superset_scope_ids = vec!["a1".to_string(), "a2".to_string(), "a3".to_string()];
+        let authoritative_flows = HashMap::from([(
+            flow_date,
+            DailyFlowAmounts {
+                inflow: Decimal::ZERO,
+                outflow: dec!(50),
+                source: ExternalFlowSource::CashAmount,
+            },
+        )]);
+        let superset_scope = ValuationService::aggregate_scoped_valuations(
+            "accounts:q",
+            &superset_scope_ids,
+            "USD",
+            superset_histories,
+            Some(&authoritative_flows),
+            Some(&adjustments),
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(
+            smaller_scope[1].external_flow_source,
+            ExternalFlowSource::QuoteDerivedMarketValue
+        );
+        assert_eq!(smaller_scope[1].external_outflow_base, Decimal::ZERO);
+        assert_eq!(
+            superset_scope[1].external_flow_source,
+            ExternalFlowSource::CashAmount
+        );
+        assert_eq!(superset_scope[1].external_outflow_base, dec!(50));
+        assert!(!smaller_scope[1].external_flow_source.is_degraded());
+        assert!(!superset_scope[1].external_flow_source.is_degraded());
     }
 
     #[test]

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -3376,6 +3376,64 @@ mod tests {
         }
     }
 
+    // Issue #1609: the converse contract. Merging two exact provenances must
+    // never manufacture degradation.
+    #[test]
+    fn combiner_never_adds_degradation() {
+        for a in ALL_FLOW_SOURCES {
+            for b in ALL_FLOW_SOURCES {
+                let combined = ValuationService::combine_activity_flow_sources(a, b);
+                if !a.is_degraded() && !b.is_degraded() {
+                    assert!(
+                        !combined.is_degraded(),
+                        "combine({a:?}, {b:?}) = {combined:?} invented degradation",
+                    );
+                    assert!(
+                        !combined.is_unavailable_for_returns(),
+                        "combine({a:?}, {b:?}) = {combined:?} invented unavailability",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn combiner_mixes_exact_with_degraded_into_mixed() {
+        for (exact, degraded) in [
+            (
+                ExternalFlowSource::CashAmount,
+                ExternalFlowSource::StoredGross,
+            ),
+            (
+                ExternalFlowSource::QuoteDerivedMarketValue,
+                ExternalFlowSource::ActivityDerived,
+            ),
+            (
+                ExternalFlowSource::MixedExact,
+                ExternalFlowSource::NetContributionFallback,
+            ),
+            (
+                ExternalFlowSource::CashAmount,
+                ExternalFlowSource::CostBasisFallback,
+            ),
+            (
+                ExternalFlowSource::CashAmount,
+                ExternalFlowSource::LegacyActivityAmountFallback,
+            ),
+        ] {
+            for (left, right) in [(exact, degraded), (degraded, exact)] {
+                let combined = ValuationService::combine_activity_flow_sources(left, right);
+                assert_eq!(
+                    combined,
+                    ExternalFlowSource::Mixed,
+                    "combine({left:?}, {right:?}) must be the degraded mixture",
+                );
+                assert!(combined.is_degraded());
+                assert!(combined.is_explicit_gross());
+            }
+        }
+    }
+
     #[test]
     fn combiner_keeps_unknown_over_known_cash() {
         assert_eq!(
@@ -5756,6 +5814,356 @@ mod tests {
         assert_eq!(superset_scope[1].external_outflow_base, dec!(50));
         assert!(!smaller_scope[1].external_flow_source.is_degraded());
         assert!(!superset_scope[1].external_flow_source.is_degraded());
+    }
+
+    // Issue #1609, defect 1 at the day-map level: a cash movement and a
+    // quote-priced in-kind transfer on the same day are both exact, so the
+    // day's provenance is the exact mixture in either arrival order.
+    #[test]
+    fn add_external_flow_amount_merges_same_day_exact_sources_into_mixed_exact() {
+        let flow_date = date("2026-05-02");
+        for order in [
+            [
+                (dec!(50), true, ExternalFlowSource::CashAmount),
+                (dec!(120), true, ExternalFlowSource::QuoteDerivedMarketValue),
+            ],
+            [
+                (dec!(120), true, ExternalFlowSource::QuoteDerivedMarketValue),
+                (dec!(50), true, ExternalFlowSource::CashAmount),
+            ],
+        ] {
+            let mut flows_by_date = HashMap::new();
+            for (amount, is_outflow, source) in order {
+                ValuationService::add_external_flow_amount(
+                    &mut flows_by_date,
+                    flow_date,
+                    amount,
+                    is_outflow,
+                    source,
+                );
+            }
+
+            let day = flows_by_date.get(&flow_date).expect("flow day recorded");
+            assert_eq!(day.inflow, Decimal::ZERO);
+            assert_eq!(day.outflow, dec!(170));
+            assert_eq!(day.source, ExternalFlowSource::MixedExact);
+            assert!(!day.source.is_degraded());
+        }
+    }
+
+    #[test]
+    fn add_external_flow_amount_keeps_mixed_for_degraded_same_day_source() {
+        let flow_date = date("2026-05-02");
+        let mut flows_by_date = HashMap::new();
+        for (amount, is_outflow, source) in [
+            (dec!(50), false, ExternalFlowSource::CashAmount),
+            (dec!(120), true, ExternalFlowSource::QuoteDerivedMarketValue),
+            (dec!(80), true, ExternalFlowSource::CostBasisFallback),
+        ] {
+            ValuationService::add_external_flow_amount(
+                &mut flows_by_date,
+                flow_date,
+                amount,
+                is_outflow,
+                source,
+            );
+        }
+
+        let day = flows_by_date.get(&flow_date).expect("flow day recorded");
+        assert_eq!(day.inflow, dec!(50));
+        assert_eq!(day.outflow, dec!(200));
+        assert_eq!(day.source, ExternalFlowSource::Mixed);
+        assert!(day.source.is_degraded());
+
+        // An unresolved transfer boundary still absorbs an exact mixture.
+        ValuationService::add_external_flow_amount(
+            &mut flows_by_date,
+            flow_date,
+            Decimal::ZERO,
+            true,
+            ExternalFlowSource::UnknownBoundaryTransfer,
+        );
+        let day = flows_by_date.get(&flow_date).expect("flow day recorded");
+        assert_eq!(day.source, ExternalFlowSource::UnknownBoundaryTransfer);
+    }
+
+    #[test]
+    fn add_external_flow_amount_skips_zero_amount_without_touching_source() {
+        let flow_date = date("2026-05-02");
+        let mut flows_by_date = HashMap::new();
+        ValuationService::add_external_flow_amount(
+            &mut flows_by_date,
+            flow_date,
+            dec!(120),
+            true,
+            ExternalFlowSource::QuoteDerivedMarketValue,
+        );
+        ValuationService::add_external_flow_amount(
+            &mut flows_by_date,
+            flow_date,
+            Decimal::ZERO,
+            true,
+            ExternalFlowSource::CashAmount,
+        );
+
+        let day = flows_by_date.get(&flow_date).expect("flow day recorded");
+        assert_eq!(day.outflow, dec!(120));
+        assert_eq!(day.source, ExternalFlowSource::QuoteDerivedMarketValue);
+    }
+
+    /// Two accounts with an exact flow each on 2026-05-02: `a1` carries
+    /// `first` as an inflow of 10, `a2` carries `second` as an outflow of 20.
+    fn same_day_exact_flow_histories(
+        first: ExternalFlowSource,
+        second: ExternalFlowSource,
+    ) -> Vec<Vec<DailyAccountValuation>> {
+        let mut first_day = valuation(
+            "a1",
+            "2026-05-02",
+            dec!(110),
+            dec!(110),
+            dec!(10),
+            Decimal::ZERO,
+        );
+        first_day.external_flow_source = first;
+        let mut second_day = valuation(
+            "a2",
+            "2026-05-02",
+            dec!(180),
+            dec!(180),
+            Decimal::ZERO,
+            dec!(20),
+        );
+        second_day.external_flow_source = second;
+        vec![
+            vec![
+                valuation(
+                    "a1",
+                    "2026-05-01",
+                    dec!(100),
+                    dec!(100),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+                first_day,
+            ],
+            vec![
+                valuation(
+                    "a2",
+                    "2026-05-01",
+                    dec!(200),
+                    dec!(200),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+                second_day,
+            ],
+        ]
+    }
+
+    // Issue #1609, defect 1 at the scope level: per-account rows with
+    // different exact sources aggregate into the exact mixture.
+    #[test]
+    fn scoped_aggregation_merges_exact_sources_into_mixed_exact() {
+        let account_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            same_day_exact_flow_histories(
+                ExternalFlowSource::CashAmount,
+                ExternalFlowSource::QuoteDerivedMarketValue,
+            ),
+            Some(&no_authoritative_flows),
+            None,
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_inflow_base, dec!(10));
+        assert_eq!(aggregate[1].external_outflow_base, dec!(20));
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::MixedExact
+        );
+        assert!(!aggregate[1].external_flow_source.is_degraded());
+        assert!(!aggregate[1]
+            .external_flow_source
+            .is_unavailable_for_returns());
+    }
+
+    #[test]
+    fn scoped_aggregation_absorbs_exact_source_into_mixed_exact() {
+        let account_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            same_day_exact_flow_histories(
+                ExternalFlowSource::MixedExact,
+                ExternalFlowSource::CashAmount,
+            ),
+            Some(&no_authoritative_flows),
+            None,
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_inflow_base, dec!(10));
+        assert_eq!(aggregate[1].external_outflow_base, dec!(20));
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::MixedExact
+        );
+    }
+
+    // Regression guard: a degraded constituent still makes the aggregate day
+    // the degraded mixture.
+    #[test]
+    fn scoped_aggregation_keeps_mixed_degraded_for_exact_plus_stored_gross() {
+        let account_ids = vec!["a1".to_string(), "a2".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            same_day_exact_flow_histories(
+                ExternalFlowSource::CashAmount,
+                ExternalFlowSource::StoredGross,
+            ),
+            Some(&no_authoritative_flows),
+            None,
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_flow_source, ExternalFlowSource::Mixed);
+        assert!(aggregate[1].external_flow_source.is_degraded());
+        assert!(!aggregate[1]
+            .external_flow_source
+            .is_unavailable_for_returns());
+    }
+
+    // A stored exact mixture is explicit gross, so the flow-setting pass keeps
+    // its amounts instead of re-deriving them from the net-contribution delta.
+    #[test]
+    fn scoped_aggregation_preserves_stored_mixed_exact_flows() {
+        let mut mixed_exact_day =
+            valuation("a1", "2026-05-02", dec!(130), dec!(130), dec!(50), dec!(20));
+        mixed_exact_day.external_flow_source = ExternalFlowSource::MixedExact;
+        let histories = vec![vec![
+            valuation(
+                "a1",
+                "2026-05-01",
+                dec!(100),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            mixed_exact_day,
+        ]];
+        let account_ids = vec!["a1".to_string()];
+        let no_authoritative_flows: HashMap<NaiveDate, DailyFlowAmounts> = HashMap::new();
+
+        let aggregate = ValuationService::aggregate_scoped_valuations(
+            "accounts:test",
+            &account_ids,
+            "USD",
+            histories,
+            Some(&no_authoritative_flows),
+            None,
+        )
+        .expect("complete scoped histories should aggregate");
+
+        assert_eq!(aggregate[1].external_inflow_base, dec!(50));
+        assert_eq!(aggregate[1].external_outflow_base, dec!(20));
+        assert_eq!(
+            aggregate[1].external_flow_source,
+            ExternalFlowSource::MixedExact
+        );
+    }
+
+    // Issue #1609 at the activity level: the real economics resolver stamps a
+    // cash withdrawal `CashAmount` and a quote-priced in-kind transfer
+    // `QuoteDerivedMarketValue`. Folded into one day they form the exact
+    // mixture. An in-kind transfer-in without a quote degrades to its cost
+    // basis, and that day becomes the degraded mixture instead.
+    #[test]
+    fn same_day_cash_and_quoted_transfer_economics_fold_into_mixed_exact() {
+        let flow_date = date("2026-06-01");
+        let withdrawal =
+            transfer_activity(ACTIVITY_TYPE_WITHDRAWAL, None, None, None, Some(dec!(50)));
+        let transfer_out = transfer_activity(
+            ACTIVITY_TYPE_TRANSFER_OUT,
+            Some("AAPL"),
+            Some(dec!(10)),
+            Some(dec!(8)),
+            None,
+        );
+        let transfer_in = transfer_activity(
+            ACTIVITY_TYPE_TRANSFER_IN,
+            Some("AAPL"),
+            Some(dec!(10)),
+            Some(dec!(8)),
+            None,
+        );
+        let quote = quote("AAPL", dec!(12), "USD");
+
+        let cash = ValuationService::resolve_activity_economics_for_boundary(
+            &withdrawal,
+            None,
+            TransferBoundary::External,
+        );
+        let priced = ValuationService::resolve_activity_economics_for_boundary(
+            &transfer_out,
+            Some(&quote),
+            TransferBoundary::External,
+        );
+        let unpriced = ValuationService::resolve_activity_economics_for_boundary(
+            &transfer_in,
+            None,
+            TransferBoundary::External,
+        );
+        assert_eq!(cash.performance_flow_source, ExternalFlowSource::CashAmount);
+        assert_eq!(cash.performance_flow_value, dec!(50));
+        assert_eq!(
+            priced.performance_flow_source,
+            ExternalFlowSource::QuoteDerivedMarketValue
+        );
+        assert_eq!(priced.performance_flow_value, dec!(120));
+        assert_eq!(
+            unpriced.performance_flow_source,
+            ExternalFlowSource::CostBasisFallback
+        );
+        assert_eq!(unpriced.performance_flow_value, dec!(80));
+
+        let fold = |legs: [(&ResolvedActivityEconomics, bool); 2]| {
+            let mut flows_by_date = HashMap::new();
+            for (economics, is_outflow) in legs {
+                ValuationService::add_external_flow_amount(
+                    &mut flows_by_date,
+                    flow_date,
+                    economics.performance_flow_value,
+                    is_outflow,
+                    economics.performance_flow_source,
+                );
+            }
+            *flows_by_date.get(&flow_date).expect("flow day recorded")
+        };
+
+        let exact_day = fold([(&cash, true), (&priced, true)]);
+        assert_eq!(exact_day.inflow, Decimal::ZERO);
+        assert_eq!(exact_day.outflow, dec!(170));
+        assert_eq!(exact_day.source, ExternalFlowSource::MixedExact);
+        assert!(!exact_day.source.is_degraded());
+
+        let degraded_day = fold([(&cash, true), (&unpriced, false)]);
+        assert_eq!(degraded_day.inflow, dec!(80));
+        assert_eq!(degraded_day.outflow, dec!(50));
+        assert_eq!(degraded_day.source, ExternalFlowSource::Mixed);
+        assert!(degraded_day.source.is_degraded());
     }
 
     #[test]

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -3069,21 +3069,8 @@ mod tests {
     // provenance must remain at least as unavailable/degraded. Otherwise the
     // downstream TWR/IRR availability gates can be silently bypassed.
 
-    const ALL_FLOW_SOURCES: [ExternalFlowSource; 13] = [
-        ExternalFlowSource::NoFlow,
-        ExternalFlowSource::Unknown,
-        ExternalFlowSource::CashAmount,
-        ExternalFlowSource::QuoteDerivedMarketValue,
-        ExternalFlowSource::CostBasisFallback,
-        ExternalFlowSource::RemovedLotBasisFallback,
-        ExternalFlowSource::LegacyActivityAmountFallback,
-        ExternalFlowSource::UnknownBoundaryTransfer,
-        ExternalFlowSource::UnpricedHoldingsTransition,
-        ExternalFlowSource::ActivityDerived,
-        ExternalFlowSource::StoredGross,
-        ExternalFlowSource::NetContributionFallback,
-        ExternalFlowSource::Mixed,
-    ];
+    // The enum's own exhaustive list, so a new variant is covered here too.
+    const ALL_FLOW_SOURCES: [ExternalFlowSource; 14] = ExternalFlowSource::ALL;
 
     #[test]
     fn combiner_is_idempotent_for_every_source() {
@@ -3147,12 +3134,20 @@ mod tests {
 
     #[test]
     fn combiner_mixes_two_distinct_known_gross_sources() {
+        // Both inputs are exact, so the mixture is the exact one (#1609).
         assert_eq!(
             ValuationService::combine_activity_flow_sources(
                 ExternalFlowSource::CashAmount,
                 ExternalFlowSource::QuoteDerivedMarketValue,
             ),
-            ExternalFlowSource::Mixed,
+            ExternalFlowSource::MixedExact,
+        );
+        assert_eq!(
+            ValuationService::combine_activity_flow_sources(
+                ExternalFlowSource::QuoteDerivedMarketValue,
+                ExternalFlowSource::CashAmount,
+            ),
+            ExternalFlowSource::MixedExact,
         );
     }
 

--- a/crates/storage-sqlite/src/portfolio/valuation/model.rs
+++ b/crates/storage-sqlite/src/portfolio/valuation/model.rs
@@ -206,4 +206,47 @@ mod tests {
         );
         assert_eq!(valuation.basis_status, BasisStatus::PartialUnknown);
     }
+
+    // Issue #1609: the exact mixture is a new persisted code. It must survive
+    // the DB round trip as itself, not collapse into the safe `UNKNOWN` fallback.
+    #[test]
+    fn mixed_exact_flow_source_roundtrips_through_the_db_row() {
+        let db_value = DailyAccountValuationDB {
+            id: "valuation-2".to_string(),
+            account_id: "account-1".to_string(),
+            valuation_date: NaiveDate::from_ymd_opt(2026, 4, 23).unwrap(),
+            account_currency: "USD".to_string(),
+            base_currency: "USD".to_string(),
+            fx_rate_to_base: "1".to_string(),
+            cash_balance: "10".to_string(),
+            investment_market_value: "20".to_string(),
+            total_value: "30".to_string(),
+            cost_basis: "25".to_string(),
+            net_contribution: "5".to_string(),
+            cash_balance_base: "10".to_string(),
+            investment_market_value_base: "20".to_string(),
+            total_value_base: "30".to_string(),
+            cost_basis_base: "25".to_string(),
+            net_contribution_base: "5".to_string(),
+            external_inflow_base: "50".to_string(),
+            external_outflow_base: "70".to_string(),
+            external_flow_source: "MIXED_EXACT".to_string(),
+            performance_eligible_value_base: "30".to_string(),
+            value_status: "COMPLETE".to_string(),
+            basis_status: "COMPLETE".to_string(),
+            calculated_at: "2026-04-23T00:00:00Z".to_string(),
+        };
+
+        let valuation = DailyAccountValuation::from(db_value);
+        assert_eq!(
+            valuation.external_flow_source,
+            wealthfolio_core::portfolio::valuation::ExternalFlowSource::MixedExact
+        );
+        assert!(!valuation.external_flow_source.is_degraded());
+
+        let stored = DailyAccountValuationDB::from(valuation);
+        assert_eq!(stored.external_flow_source, "MIXED_EXACT");
+        assert_eq!(stored.external_inflow_base, "50");
+        assert_eq!(stored.external_outflow_base, "70");
+    }
 }

--- a/docs/features/performance-semantics-design.md
+++ b/docs/features/performance-semantics-design.md
@@ -479,6 +479,13 @@ Compatibility values such as `ACTIVITY_DERIVED`, `STORED_GROSS`,
 rows or aggregate views, but they are not valid new producer sources for
 compiled activity economics.
 
+A day that combines several distinct flow sources is stored as one of two
+mixture values. `MIXED_EXACT` means every constituent was exact (`CASH_AMOUNT`
+or `QUOTE_DERIVED_MARKET_VALUE`, for example a cash withdrawal and a
+quote-priced in-kind transfer on the same day); it is explicit gross and not
+degraded. `MIXED` means at least one constituent was degraded, and stays
+degraded. Merging exact sources never produces `MIXED`.
+
 ### Event Finalizer And Attribution Ledger
 
 Use a two-stage pipeline:
@@ -699,7 +706,8 @@ The architecture is complete only when these criteria are all true:
 - New compiled activity flows write only compiler-owned producer sources:
   `CASH_AMOUNT`, `QUOTE_DERIVED_MARKET_VALUE`, `COST_BASIS_FALLBACK`,
   `REMOVED_LOT_BASIS_FALLBACK`, `LEGACY_ACTIVITY_AMOUNT_FALLBACK`,
-  `UNKNOWN_BOUNDARY_TRANSFER`, or `UNKNOWN`.
+  `UNKNOWN_BOUNDARY_TRANSFER`, or `UNKNOWN`. A stored day that merges several of
+  them carries `MIXED_EXACT` when all were exact and `MIXED` otherwise.
 - Legacy source values remain readable and degraded, but they are not normal
   producers for new calculation rows.
 - Performance attribution is built from finalized event effects. Residual is a

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -866,7 +866,8 @@ export interface AccountValuation {
     | 'ACTIVITY_DERIVED'
     | 'STORED_GROSS'
     | 'NET_CONTRIBUTION_FALLBACK'
-    | 'MIXED';
+    | 'MIXED'
+    | 'MIXED_EXACT';
   performanceEligibleValueBase: number;
   valueStatus: ValuationStatus;
   basisStatus: BasisStatus;


### PR DESCRIPTION
# fix(valuation): exact flow mixtures are no longer reported as degraded provenance

Fixes #1609.

## Problem

`ExternalFlowSource::combine` turned any two distinct non-absorbing sources into `Mixed`, and `is_degraded()` listed `Mixed` unconditionally. A day that combined two _exact_ sources (a cash movement and a quote-priced in-kind transfer) was therefore flagged as degraded flow data: the performance tab warned "External cash flow provenance is incomplete…" and `dataQuality.status` became `partial`, although nothing had been estimated.

A second defect made this appear non-deterministic. The scope-internal transfer netting pass subtracted the internal legs and then stamped the day with a hardcoded `CashAmount`. An in-kind transfer whose both legs sit inside a portfolio scope produced `QuoteDerivedMarketValue ⊕ CashAmount = Mixed`, so the same accounts on the same day warned under one portfolio and were clean under a superset portfolio that happened to contain an unrelated cash withdrawal.

## Changes (one commit each)

1. **Netting pass no longer stamps a source.** Netting removes flow; it never adds a differently-valued one, so the day keeps the provenance of the flows that survive. Explicit-gross rows still read their stored (netted) amounts, absorbing markers were already untouched, and a legacy net-contribution fallback row now keeps falling through to the delta instead of being promoted to a floored explicit-gross mixture.
2. **`Mixed` is split into `Mixed` and `MixedExact`.** `MixedExact` (`MIXED_EXACT`) is produced only when every constituent is non-degraded; it is explicit gross, not degraded, and not unavailable. `Mixed` now means "at least one constituent is degraded" and keeps its predicates. The combiner still never drops degradation and now never adds it: the exact sources are closed under `combine`. The TS unions and the performance-semantics design doc are updated.
3. **Regression coverage at every level**: combiner properties, the day map (`add_external_flow_amount`), the real activity-economics resolver, the scope aggregate, the scoped activity pipeline, and the performance layer.

## Compatibility

- Older binaries read `MIXED_EXACT` through the `from_code` fallback as `Unknown`, which is the safe (returns-unavailable) direction.
- No migration. Portfolio-scope results are computed in memory and are correct immediately. Per-account rows already persisted as `MIXED` recompute to `MIXED_EXACT` on the next full recalculation.

## Verification

- `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace` (3261 passed), `cargo check -p wealthfolio-server --release`.
- Frontend: `format:check`, `lint` (0 errors), `type-check`, `pnpm test` (1985 passed), `pnpm build`, addon-sandbox Playwright (9 passed).
- Each commit is green on its own tree.
- Pre-fix checks: with the netting stamp restored, 6 of the new netting tests fail; with the exact-mixture combine arm removed, 9 of the new tests fail.
- HTTP repro against `wealthfolio-server` built at the base commit and at HEAD (offline fixture mode, synthetic accounts): see table below.

Setup: securities accounts A, B, C, E; manual-quoted security at 10.00; A buys 500 units, then A→B in-kind transfer of 500 units on D (legs linked, internal); C has an unrelated cash withdrawal on D; E has a cash withdrawal and an external in-kind transfer-out of 200 units on D2. Portfolio P = {A, B}, Q = {A, B, C}. Full recalculation, then `POST /performance/summary` and `GET /valuations/history`.

| Scope / row                             | Base (`eee633cff`)                      | HEAD                     |
| --------------------------------------- | --------------------------------------- | ------------------------ |
| P `{A,B}` data quality                  | `partial` + provenance warning          | `ok`, no warning         |
| Q `{A,B,C}` data quality                | `ok`                                    | `ok`                     |
| A alone data quality                    | `ok`                                    | `ok`                     |
| E alone data quality (defect 1)         | `partial` + provenance warning          | `ok`, no warning         |
| A stored row on D `externalFlowSource`  | `QUOTE_DERIVED_MARKET_VALUE` (out 5000) | unchanged                |
| E stored row on D2 `externalFlowSource` | `MIXED` (out 2100)                      | `MIXED_EXACT` (out 2100) |

The base build reproduces the issue exactly: the smaller portfolio warns while its superset is clean, and the same-day exact inputs are persisted as `MIXED`.


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
