### PR TITLE
fix(net-worth): make breakdown layout responsive to card width

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install addon sandbox browsers
         run: pnpm exec playwright install --with-deps chromium firefox webkit
 
+      - name: Run net worth layout regression tests
+        run: pnpm test:e2e:net-worth
+
       - name: Run addon sandbox browser tests
         run: pnpm test:e2e:addon-sandbox
         env:

--- a/apps/frontend/e2e/net-worth/index.html
+++ b/apps/frontend/e2e/net-worth/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Net worth layout regression</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/test/browser/net-worth.tsx"></script>
+  </body>
+</html>

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -22,10 +22,14 @@ import {
   type SelectedCategory,
 } from "./utils";
 
-// name | % | value | Δ. Fixed widths so columns line up across rows (each row is
-// its own grid). On mobile the % column and the Δ-percent collapse.
-const ROW_GRID =
-  "grid grid-cols-[minmax(0,1fr)_4.5rem_5.75rem] md:grid-cols-[minmax(0,1fr)_3rem_7rem_9.5rem] items-center gap-x-3 md:gap-x-4";
+// Every section shares the same tracks, including the net-worth total. Layout
+// follows the card width, since a desktop dashboard can still have narrow cards.
+const SHARED_GRID =
+  "col-span-full grid grid-cols-(--breakdown-columns) gap-x-3 supports-[grid-template-columns:subgrid]:grid-cols-subgrid @min-[40rem]/breakdown:gap-x-4";
+const ROW_GRID = `${SHARED_GRID} items-baseline gap-y-1`;
+const NAME_CELL = "col-span-full min-w-0 @min-[28rem]/breakdown:col-span-1";
+const AMOUNT_CELL =
+  "min-w-0 text-right text-xs tabular-nums [overflow-wrap:anywhere] @min-[40rem]/breakdown:text-sm";
 
 function ChangeCell({ change, currency }: { change: Change; currency: string }) {
   const formatting = useNumberFormatting();
@@ -38,14 +42,12 @@ function ChangeCell({ change, currency }: { change: Change; currency: string }) 
       : "text-destructive";
   const sign = isZero ? "" : change.amount > 0 ? "+" : "-";
   return (
-    <div className="flex items-baseline justify-end gap-1.5 md:gap-2">
-      <span
-        className={`inline-flex shrink-0 items-baseline whitespace-nowrap text-xs tabular-nums md:text-sm ${color}`}
-      >
+    <div className="@min-[48rem]/breakdown:flex-row @min-[48rem]/breakdown:flex-wrap @min-[48rem]/breakdown:items-baseline @min-[48rem]/breakdown:justify-end flex min-w-0 flex-col items-end gap-x-2 gap-y-0.5 text-right">
+      <span className={`${AMOUNT_CELL} ${color}`}>
         {sign}
         <CompactAmount value={Math.abs(change.amount)} currency={currency} />
       </span>
-      <span className="text-muted-foreground/60 hidden w-12 shrink-0 text-right text-sm tabular-nums md:block">
+      <span className={`text-muted-foreground/60 ${AMOUNT_CELL}`}>
         {formatChangePercent(change, t("insights:networth.breakdown_table.new"), formatting)}
       </span>
     </div>
@@ -93,14 +95,16 @@ function BreakdownRow({
           : undefined
       }
     >
-      <div className="flex min-w-0 items-center gap-2.5">
+      <div className={`${NAME_CELL} flex items-center gap-2.5`}>
         <div className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: dotColor }} />
-        <span className="text-foreground truncate text-xs md:text-sm">{name}</span>
+        <span className="text-foreground @min-[40rem]/breakdown:text-sm min-w-0 text-xs [overflow-wrap:anywhere]">
+          {name}
+        </span>
       </div>
-      <span className="text-muted-foreground/70 hidden text-right text-sm tabular-nums md:block">
+      <span className="text-muted-foreground/70 @min-[40rem]/breakdown:block hidden text-right text-sm tabular-nums">
         {percentOfSection.toFixed(1)}%
       </span>
-      <span className="text-foreground justify-self-end text-xs tabular-nums md:text-sm">
+      <span className={`text-foreground ${AMOUNT_CELL}`}>
         {negative && value !== 0 ? "-" : ""}
         <CompactAmount value={value} currency={currency} />
       </span>
@@ -134,144 +138,162 @@ export function BreakdownTable({
   const [liabilitiesOpen, setLiabilitiesOpen] = useState(true);
 
   return (
-    <DashboardCard
-      title={t("insights:networth.breakdown")}
-      meta={t("insights:networth.breakdown_table.change_over", { period: periodLabel })}
-    >
-      {/* Assets — collapsible */}
-      <Collapsible open={assetsOpen} onOpenChange={setAssetsOpen}>
-        <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
-          <span className="flex items-center gap-1.5 text-sm font-semibold">
-            <Icons.ChevronRight
-              className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${assetsOpen ? "rotate-90" : ""}`}
-            />
-            {t("insights:networth.breakdown_table.assets")}
-          </span>
-          <span className="text-success text-sm font-semibold tabular-nums">
-            <CompactAmount value={data.assets.total} currency={currency} />
-          </span>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          {/* Composition — proportion of assets (the rows below are its legend) */}
-          <div className="border-border/60 mb-1 mt-2.5 border-b pb-3">
-            <CompositionBar data={data} />
-          </div>
+    <div className="@container/breakdown min-w-0">
+      <DashboardCard
+        title={t("insights:networth.breakdown")}
+        meta={t("insights:networth.breakdown_table.change_over", { period: periodLabel })}
+      >
+        <div className="grid-cols-(--breakdown-columns) @min-[28rem]/breakdown:[--breakdown-columns:minmax(0,1fr)_minmax(0,max-content)_minmax(0,max-content)] @min-[40rem]/breakdown:[--breakdown-columns:minmax(0,1fr)_max-content_minmax(0,max-content)_minmax(0,max-content)] @min-[40rem]/breakdown:gap-x-4 grid gap-x-3 [--breakdown-columns:repeat(2,minmax(0,1fr))]">
+          {/* Assets — collapsible */}
+          <Collapsible className={SHARED_GRID} open={assetsOpen} onOpenChange={setAssetsOpen}>
+            <CollapsibleTrigger className="col-span-full flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 text-left">
+              <span className="flex items-center gap-1.5 text-sm font-semibold">
+                <Icons.ChevronRight
+                  className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${assetsOpen ? "rotate-90" : ""}`}
+                />
+                {t("insights:networth.breakdown_table.assets")}
+              </span>
+              <span className="text-success min-w-0 text-sm font-semibold tabular-nums [overflow-wrap:anywhere]">
+                <CompactAmount value={data.assets.total} currency={currency} />
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent className={SHARED_GRID}>
+              {/* Composition — proportion of assets (the rows below are its legend) */}
+              <div className="border-border/60 col-span-full mb-1 mt-2.5 border-b pb-3">
+                <CompositionBar data={data} />
+              </div>
 
-          {/* Column labels */}
-          <div className={`${ROW_GRID} pt-2`}>
-            <span className={CARD_LABEL}>{t("insights:networth.breakdown_table.category")}</span>
-            <span className={`${CARD_LABEL} hidden text-right md:block`}>%</span>
-            <span className={`${CARD_LABEL} justify-self-end`}>
-              {t("insights:networth.breakdown_table.value")}
-            </span>
-            <span className={`${CARD_LABEL} justify-self-end`}>
-              {t("insights:networth.breakdown_table.delta_period", { period: periodLabel })}
-            </span>
-          </div>
+              {/* Column labels */}
+              <div className={`${ROW_GRID} pt-2`}>
+                <span className={`${CARD_LABEL} ${NAME_CELL}`}>
+                  {t("insights:networth.breakdown_table.category")}
+                </span>
+                <span className={`${CARD_LABEL} @min-[40rem]/breakdown:block hidden text-right`}>
+                  %
+                </span>
+                <span className={`${CARD_LABEL} min-w-0 text-right [overflow-wrap:anywhere]`}>
+                  {t("insights:networth.breakdown_table.value")}
+                </span>
+                <span className={`${CARD_LABEL} min-w-0 text-right [overflow-wrap:anywhere]`}>
+                  {t("insights:networth.breakdown_table.delta_period", { period: periodLabel })}
+                </span>
+              </div>
 
-          <div className="divide-border/40 divide-y">
-            {data.assets.breakdown.map((item) => (
-              <BreakdownRow
-                key={item.category}
-                name={item.name}
-                dotColor={CATEGORY_CSS_COLORS[item.category] ?? "var(--muted-foreground)"}
-                value={item.value}
-                percentOfSection={
-                  data.assets.total > 0 ? (item.value / data.assets.total) * 100 : 0
-                }
-                change={deriveChange(seriesFor(history, item.category), false)}
-                currency={currency}
-                onClick={() =>
-                  onSelect({
-                    key: item.category,
-                    name: item.name,
-                    value: item.value,
-                    isLiability: false,
-                    isInvestment: item.category === "investments",
-                    children: item.children ?? [],
-                  })
-                }
-              />
-            ))}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-
-      {/* Separator carrying the "−" operator (Assets − Liabilities), aligned to the icon column */}
-      {hasLiabilities && (
-        <div className="my-3 flex items-center gap-1.5">
-          <span className="text-muted-foreground w-3.5 shrink-0 text-center text-sm font-normal">
-            −
-          </span>
-          <div className="border-border/60 flex-1 border-t" />
-        </div>
-      )}
-
-      {/* Liabilities — collapsible */}
-      {hasLiabilities && (
-        <Collapsible open={liabilitiesOpen} onOpenChange={setLiabilitiesOpen}>
-          <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
-            <span className="flex items-center gap-1.5 text-sm font-semibold">
-              <Icons.ChevronRight
-                className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${liabilitiesOpen ? "rotate-90" : ""}`}
-              />
-              {t("insights:networth.breakdown_table.liabilities")}
-            </span>
-            <span className="text-destructive text-sm font-semibold tabular-nums">
-              -<CompactAmount value={data.liabilities.total} currency={currency} />
-            </span>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="divide-border/40 divide-y pt-1">
-              {data.liabilities.breakdown.map((item, index) => {
-                const key = item.assetId ?? `${item.category}-${index}`;
-                const series = item.assetId ? seriesFor(history, item.assetId) : [];
-                return (
+              <div className={`${SHARED_GRID} divide-border/40 divide-y`}>
+                {data.assets.breakdown.map((item) => (
                   <BreakdownRow
-                    key={key}
+                    key={item.category}
                     name={item.name}
-                    dotColor={CATEGORY_CSS_COLORS.liabilities}
+                    dotColor={CATEGORY_CSS_COLORS[item.category] ?? "var(--muted-foreground)"}
                     value={item.value}
-                    negative
                     percentOfSection={
-                      data.liabilities.total > 0 ? (item.value / data.liabilities.total) * 100 : 0
+                      data.assets.total > 0 ? (item.value / data.assets.total) * 100 : 0
                     }
-                    change={deriveChange(series, true)}
+                    change={deriveChange(seriesFor(history, item.category), false)}
                     currency={currency}
-                    onClick={
-                      item.assetId
-                        ? () =>
-                            onSelect({
-                              key: item.assetId!,
-                              name: item.name,
-                              value: item.value,
-                              isLiability: true,
-                              isInvestment: false,
-                              children: [],
-                            })
-                        : undefined
+                    onClick={() =>
+                      onSelect({
+                        key: item.category,
+                        name: item.name,
+                        value: item.value,
+                        isLiability: false,
+                        isInvestment: item.category === "investments",
+                        children: item.children ?? [],
+                      })
                     }
                   />
-                );
-              })}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-      )}
+                ))}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
 
-      {/* Net Worth total — label indented (chevron-sized spacer) to align with the
+          {/* Separator carrying the "−" operator (Assets − Liabilities), aligned to the icon column */}
+          {hasLiabilities && (
+            <div className="col-span-full my-3 flex items-center gap-1.5">
+              <span className="text-muted-foreground w-3.5 shrink-0 text-center text-sm font-normal">
+                −
+              </span>
+              <div className="border-border/60 flex-1 border-t" />
+            </div>
+          )}
+
+          {/* Liabilities — collapsible */}
+          {hasLiabilities && (
+            <Collapsible
+              className={SHARED_GRID}
+              open={liabilitiesOpen}
+              onOpenChange={setLiabilitiesOpen}
+            >
+              <CollapsibleTrigger className="col-span-full flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 text-left">
+                <span className="flex items-center gap-1.5 text-sm font-semibold">
+                  <Icons.ChevronRight
+                    className={`text-muted-foreground h-3.5 w-3.5 transition-transform ${liabilitiesOpen ? "rotate-90" : ""}`}
+                  />
+                  {t("insights:networth.breakdown_table.liabilities")}
+                </span>
+                <span className="text-destructive min-w-0 text-sm font-semibold tabular-nums [overflow-wrap:anywhere]">
+                  -<CompactAmount value={data.liabilities.total} currency={currency} />
+                </span>
+              </CollapsibleTrigger>
+              <CollapsibleContent className={SHARED_GRID}>
+                <div className={`${SHARED_GRID} divide-border/40 divide-y pt-1`}>
+                  {data.liabilities.breakdown.map((item, index) => {
+                    const key = item.assetId ?? `${item.category}-${index}`;
+                    const series = item.assetId ? seriesFor(history, item.assetId) : [];
+                    return (
+                      <BreakdownRow
+                        key={key}
+                        name={item.name}
+                        dotColor={CATEGORY_CSS_COLORS.liabilities}
+                        value={item.value}
+                        negative
+                        percentOfSection={
+                          data.liabilities.total > 0
+                            ? (item.value / data.liabilities.total) * 100
+                            : 0
+                        }
+                        change={deriveChange(series, true)}
+                        currency={currency}
+                        onClick={
+                          item.assetId
+                            ? () =>
+                                onSelect({
+                                  key: item.assetId!,
+                                  name: item.name,
+                                  value: item.value,
+                                  isLiability: true,
+                                  isInvestment: false,
+                                  children: [],
+                                })
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+
+          {/* Net Worth total — label indented (chevron-sized spacer) to align with the
           Assets/Liabilities section labels; value/Δ stay in the grid columns. */}
-      <div className={`${ROW_GRID} border-border/60 mt-3 border-t pt-3`}>
-        <span className="flex items-center gap-1.5 text-sm font-bold">
-          <span className="text-muted-foreground w-3.5 shrink-0 text-center font-normal">=</span>
-          {t("insights:networth.breakdown_table.net_worth")}
-        </span>
-        <span className="hidden md:block" />
-        <span className="justify-self-end text-sm font-bold tabular-nums">
-          <CompactAmount value={data.netWorth} currency={currency} />
-        </span>
-        <ChangeCell change={netWorthChange} currency={currency} />
-      </div>
-    </DashboardCard>
+          <div className={`${ROW_GRID} border-border/60 mt-3 border-t pt-3`}>
+            <span
+              className={`${NAME_CELL} flex items-baseline gap-1.5 text-sm font-bold [overflow-wrap:anywhere]`}
+            >
+              <span className="text-muted-foreground w-3.5 shrink-0 text-center font-normal">
+                =
+              </span>
+              {t("insights:networth.breakdown_table.net_worth")}
+            </span>
+            <span className="@min-[40rem]/breakdown:block hidden" />
+            <span className={`${AMOUNT_CELL} font-bold`}>
+              <CompactAmount value={data.netWorth} currency={currency} />
+            </span>
+            <ChangeCell change={netWorthChange} currency={currency} />
+          </div>
+        </div>
+      </DashboardCard>
+    </div>
   );
 }

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -24,6 +24,7 @@ import {
 
 // Every section shares the same tracks, including the net-worth total. Layout
 // follows the card width, since a desktop dashboard can still have narrow cards.
+// Without subgrid, fractional tracks keep independently sized rows aligned.
 const SHARED_GRID =
   "col-span-full grid grid-cols-(--breakdown-columns) gap-x-3 supports-[grid-template-columns:subgrid]:grid-cols-subgrid @min-[40rem]/breakdown:gap-x-4";
 const ROW_GRID = `${SHARED_GRID} items-baseline gap-y-1`;
@@ -43,9 +44,9 @@ function ChangeCell({ change, currency }: { change: Change; currency: string }) 
   const sign = isZero ? "" : change.amount > 0 ? "+" : "-";
   return (
     <div className="@min-[48rem]/breakdown:flex-row @min-[48rem]/breakdown:flex-wrap @min-[48rem]/breakdown:items-baseline @min-[48rem]/breakdown:justify-end flex min-w-0 flex-col items-end gap-x-2 gap-y-0.5 text-right">
-      <span className={`${AMOUNT_CELL} ${color}`}>
+      <span className={`${AMOUNT_CELL} ${color} inline-flex items-baseline justify-end`}>
         {sign}
-        <CompactAmount value={Math.abs(change.amount)} currency={currency} />
+        <CompactAmount className="min-w-0" value={Math.abs(change.amount)} currency={currency} />
       </span>
       <span className={`text-muted-foreground/60 ${AMOUNT_CELL}`}>
         {formatChangePercent(change, t("insights:networth.breakdown_table.new"), formatting)}
@@ -104,9 +105,9 @@ function BreakdownRow({
       <span className="text-muted-foreground/70 @min-[40rem]/breakdown:block hidden text-right text-sm tabular-nums">
         {percentOfSection.toFixed(1)}%
       </span>
-      <span className={`text-foreground ${AMOUNT_CELL}`}>
+      <span className={`text-foreground ${AMOUNT_CELL} inline-flex items-baseline justify-end`}>
         {negative && value !== 0 ? "-" : ""}
-        <CompactAmount value={value} currency={currency} />
+        <CompactAmount className="min-w-0" value={value} currency={currency} />
       </span>
       <ChangeCell change={change} currency={currency} />
     </div>
@@ -143,7 +144,7 @@ export function BreakdownTable({
         title={t("insights:networth.breakdown")}
         meta={t("insights:networth.breakdown_table.change_over", { period: periodLabel })}
       >
-        <div className="grid-cols-(--breakdown-columns) @min-[28rem]/breakdown:[--breakdown-columns:minmax(0,1fr)_minmax(0,max-content)_minmax(0,max-content)] @min-[40rem]/breakdown:[--breakdown-columns:minmax(0,1fr)_max-content_minmax(0,max-content)_minmax(0,max-content)] @min-[40rem]/breakdown:gap-x-4 grid gap-x-3 [--breakdown-columns:repeat(2,minmax(0,1fr))]">
+        <div className="grid-cols-(--breakdown-columns) @min-[28rem]/breakdown:[--breakdown-fallback-columns:repeat(3,minmax(0,1fr))] @min-[40rem]/breakdown:[--breakdown-fallback-columns:minmax(0,2fr)_4rem_minmax(0,1.5fr)_minmax(0,2fr)] supports-[grid-template-columns:subgrid]:@min-[28rem]/breakdown:[--breakdown-columns:minmax(0,1fr)_minmax(0,max-content)_minmax(0,max-content)] supports-[grid-template-columns:subgrid]:@min-[40rem]/breakdown:[--breakdown-columns:minmax(0,1fr)_max-content_minmax(0,max-content)_minmax(0,max-content)] @min-[40rem]/breakdown:gap-x-4 grid gap-x-3 [--breakdown-columns:var(--breakdown-fallback-columns)] [--breakdown-fallback-columns:repeat(2,minmax(0,1fr))]">
           {/* Assets — collapsible */}
           <Collapsible className={SHARED_GRID} open={assetsOpen} onOpenChange={setAssetsOpen}>
             <CollapsibleTrigger className="col-span-full flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-1 text-left">
@@ -231,8 +232,13 @@ export function BreakdownTable({
                   />
                   {t("insights:networth.breakdown_table.liabilities")}
                 </span>
-                <span className="text-destructive min-w-0 text-sm font-semibold tabular-nums [overflow-wrap:anywhere]">
-                  -<CompactAmount value={data.liabilities.total} currency={currency} />
+                <span className="text-destructive inline-flex min-w-0 items-baseline justify-end text-sm font-semibold tabular-nums [overflow-wrap:anywhere]">
+                  -
+                  <CompactAmount
+                    className="min-w-0"
+                    value={data.liabilities.total}
+                    currency={currency}
+                  />
                 </span>
               </CollapsibleTrigger>
               <CollapsibleContent className={SHARED_GRID}>

--- a/apps/frontend/src/test/browser/net-worth.tsx
+++ b/apps/frontend/src/test/browser/net-worth.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { createRoot } from "react-dom/client";
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
@@ -45,28 +46,151 @@ const history: ParsedHistoryPoint[] = [
   },
 ];
 
-async function renderFixture() {
-  await i18next.use(initReactI18next).init({
-    lng: "de",
-    resources: { de: { insights: de } },
-    interpolation: { escapeValue: false },
-  });
-  createRoot(document.getElementById("root")!).render(
-    <FormattingProvider locale="de-DE">
+function Fixture() {
+  const params = new URLSearchParams(location.search);
+  const [width, setWidth] = useState(params.get("width") ?? "auto");
+  const [fallback, setFallback] = useState(params.get("fallback") === "1");
+  const [scenario, setScenario] = useState(params.get("scenario") ?? "growth");
+  const [locale, setLocale] = useState(params.get("locale") ?? "de-DE");
+  const [hidden, setHidden] = useState(false);
+  const current = structuredClone(data);
+  const points = structuredClone(history);
+  if (scenario === "extreme") {
+    current.assets.breakdown[0].value = 1_234_567_890_123_456_000;
+    current.assets.total = current.assets.breakdown[0].value + 400_000;
+    current.netWorth = current.assets.total - current.liabilities.total;
+    points[1].breakdown.investments = current.assets.breakdown[0].value;
+    points[1].netWorth = current.netWorth;
+  } else if (scenario === "loss") {
+    points[0].breakdown = { investments: 24_691_356, properties: 800_000, mortgage: 600_000 };
+    points[0].netWorth = 24_891_356;
+  } else if (scenario === "zero") {
+    points[0] = { ...points[1], date: points[0].date };
+  } else if (scenario === "new") {
+    points[0].breakdown = { investments: 0, properties: 0, mortgage: 0 };
+    points[0].netWorth = 0;
+  } else if (scenario === "negative") {
+    current.liabilities.breakdown[0].value = 30_000_000;
+    current.liabilities.total = 30_000_000;
+    current.netWorth = current.assets.total - current.liabilities.total;
+    points[1].netWorth = current.netWorth;
+    points[1].breakdown.mortgage = 30_000_000;
+  } else if (scenario === "assets-only") {
+    current.liabilities = { total: 0, breakdown: [] };
+    current.netWorth = current.assets.total;
+    points[1].netWorth = current.netWorth;
+  }
+  points[1].totalAssets = current.assets.total;
+  points[1].totalLiabilities = current.liabilities.total;
+  points[1].portfolioValue = current.assets.breakdown[0].value;
+  return (
+    <FormattingProvider locale={locale}>
       <PrivacyContext.Provider
-        value={{ isBalanceHidden: false, toggleBalanceVisibility: () => undefined }}
+        value={{ isBalanceHidden: hidden, toggleBalanceVisibility: () => setHidden(!hidden) }}
       >
-        <main aria-label="Net worth card" style={{ padding: 16 }}>
+        <aside
+          className="flex flex-wrap items-center gap-4 border-b p-4"
+          aria-label="Fixture controls"
+        >
+          <label>
+            Card width{" "}
+            <select
+              aria-label="Card width"
+              value={width}
+              onChange={(e) => setWidth(e.target.value)}
+            >
+              {[
+                "auto",
+                "240",
+                "288",
+                "320",
+                "447",
+                "448",
+                "560",
+                "639",
+                "640",
+                "767",
+                "768",
+                "960",
+              ].map((value) => (
+                <option key={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Scenario{" "}
+            <select
+              aria-label="Scenario"
+              value={scenario}
+              onChange={(e) => setScenario(e.target.value)}
+            >
+              {["growth", "loss", "zero", "new", "negative", "assets-only", "extreme"].map(
+                (value) => (
+                  <option key={value}>{value}</option>
+                ),
+              )}
+            </select>
+          </label>
+          <label>
+            Number locale{" "}
+            <select
+              aria-label="Number locale"
+              value={locale}
+              onChange={(e) => setLocale(e.target.value)}
+            >
+              {["de-DE", "en-US", "fr-FR", "ja-JP"].map((value) => (
+                <option key={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={fallback}
+              onChange={(e) => setFallback(e.target.checked)}
+            />{" "}
+            Simulate no subgrid
+          </label>
+          <label>
+            <input type="checkbox" checked={hidden} onChange={(e) => setHidden(e.target.checked)} />{" "}
+            Hide balances
+          </label>
+        </aside>
+        <nav className="flex gap-4 px-4 pt-3 text-sm underline" aria-label="Reproductions">
+          <a href="?width=960&fallback=1">Column alignment case</a>
+          <a href="?width=240&scenario=extreme&locale=en-US">Sign wrapping case</a>
+        </nav>
+        <p className="px-4 pt-3 text-sm">
+          Fixed implementation. Compare Value alignment with “Simulate no subgrid”; narrow the card
+          to inspect signs and wrapping. This simulates the CSS fallback, not an older browser
+          engine.
+        </p>
+        {fallback && (
+          <style>{`main [class*="supports-[grid-template-columns:subgrid]"] { grid-template-columns: var(--breakdown-fallback-columns) !important; }`}</style>
+        )}
+        <main
+          aria-label="Net worth card"
+          style={{ padding: 16, width: width === "auto" ? undefined : Number(width) + 32 }}
+        >
           <BreakdownTable
-            data={data}
-            history={history}
+            data={current}
+            history={points}
             currency="EUR"
             periodLabel="ALL"
             onSelect={() => undefined}
           />
         </main>
       </PrivacyContext.Provider>
-    </FormattingProvider>,
+    </FormattingProvider>
   );
+}
+
+async function renderFixture() {
+  await i18next.use(initReactI18next).init({
+    lng: "de",
+    resources: { de: { insights: de } },
+    interpolation: { escapeValue: false },
+  });
+  createRoot(document.getElementById("root")!).render(<Fixture />);
 }
 void renderFixture();

--- a/apps/frontend/src/test/browser/net-worth.tsx
+++ b/apps/frontend/src/test/browser/net-worth.tsx
@@ -1,0 +1,72 @@
+import { createRoot } from "react-dom/client";
+import i18next from "i18next";
+import { initReactI18next } from "react-i18next";
+import { FormattingProvider } from "@wealthfolio/ui";
+import { PrivacyContext } from "@/context/privacy-context";
+import de from "@/i18n/locales/de/insights.json";
+import { BreakdownTable } from "@/pages/net-worth/components/breakdown-table";
+import type { ParsedHistoryPoint, ParsedNetWorth } from "@/pages/net-worth/components/utils";
+import "@/globals.css";
+
+const data: ParsedNetWorth = {
+  netWorth: 12_445_678,
+  assets: {
+    total: 12_745_678,
+    breakdown: [
+      { category: "investments", name: "Investments", value: 12_345_678 },
+      { category: "properties", name: "Property with a long category name", value: 400_000 },
+    ],
+  },
+  liabilities: {
+    total: 300_000,
+    breakdown: [{ category: "liabilities", assetId: "mortgage", name: "Mortgage", value: 300_000 }],
+  },
+};
+const history: ParsedHistoryPoint[] = [
+  {
+    date: "2020-01-01",
+    netWorth: 100,
+    totalAssets: 100,
+    totalLiabilities: 0,
+    portfolioValue: 100,
+    alternativeAssetsValue: 0,
+    netContribution: 0,
+    breakdown: { investments: 100, properties: 0, mortgage: 0 },
+  },
+  {
+    date: "2026-09-06",
+    netWorth: data.netWorth,
+    totalAssets: data.assets.total,
+    totalLiabilities: data.liabilities.total,
+    portfolioValue: 12_345_678,
+    alternativeAssetsValue: 400_000,
+    netContribution: 0,
+    breakdown: { investments: 12_345_678, properties: 400_000, mortgage: 300_000 },
+  },
+];
+
+async function renderFixture() {
+  await i18next.use(initReactI18next).init({
+    lng: "de",
+    resources: { de: { insights: de } },
+    interpolation: { escapeValue: false },
+  });
+  createRoot(document.getElementById("root")!).render(
+    <FormattingProvider locale="de-DE">
+      <PrivacyContext.Provider
+        value={{ isBalanceHidden: false, toggleBalanceVisibility: () => undefined }}
+      >
+        <main aria-label="Net worth card" style={{ padding: 16 }}>
+          <BreakdownTable
+            data={data}
+            history={history}
+            currency="EUR"
+            periodLabel="ALL"
+            onSelect={() => undefined}
+          />
+        </main>
+      </PrivacyContext.Provider>
+    </FormattingProvider>,
+  );
+}
+void renderFixture();

--- a/e2e/net-worth/layout.spec.ts
+++ b/e2e/net-worth/layout.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test";
+
+for (const width of [320, 592, 992]) {
+  test(`German growth values stay contained at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 1100 });
+    await page.goto("/e2e/net-worth/");
+    const card = page.getByRole("main", { name: "Net worth card" });
+    await expect(card.getByRole("button", { name: /^Investments / })).toBeVisible();
+    await expect(card.getByText("123.456,8×", { exact: true })).toBeVisible();
+    await expect(card.getByText(/^=\s*Nettovermögen$/)).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
+
+    if (width === 992) {
+      // With ample space, a compact multiple should not break mid-number.
+      const lines = await card.getByText("123.456,8×", { exact: true }).evaluate((label) => {
+        const range = document.createRange();
+        range.selectNodeContents(label);
+        return range.getClientRects().length;
+      });
+      expect(lines).toBe(1);
+    }
+
+    const violations = await card.evaluate((root) => {
+      const errors: string[] = [];
+      // Use painted text rectangles: element boxes alone miss text spilling out
+      // of a fixed-width label (the original w-12 regression).
+      const bounds = root.firstElementChild!.getBoundingClientRect();
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        const node = walker.currentNode;
+        if (!node.textContent?.trim()) continue;
+        const range = document.createRange();
+        range.selectNodeContents(node);
+        const parent = node.parentElement!.getBoundingClientRect();
+        for (const rect of range.getClientRects()) {
+          if (!rect.width || !rect.height) continue;
+          if (rect.left < bounds.left - 1 || rect.right > bounds.right + 1) {
+            errors.push(`Outside card: ${node.textContent}`);
+          }
+          if (rect.left < parent.left - 1 || rect.right > parent.right + 1) {
+            errors.push(`Outside label: ${node.textContent}`);
+          }
+        }
+      }
+      // A flex child can spill into the neighboring grid column even when
+      // the grid cell itself is correctly positioned (the min-w-12-only fix).
+      for (const element of root.querySelectorAll("div, span")) {
+        const rect = element.getBoundingClientRect();
+        if (!rect.width || !rect.height) continue;
+        const parent = element.parentElement!.getBoundingClientRect();
+        if (rect.left < parent.left - 1 || rect.right > parent.right + 1) {
+          errors.push(`Outside cell: ${element.textContent}`);
+        }
+      }
+      // Include category rows and the net-worth footer. Compare adjacent cells
+      // only when they occupy the same line, allowing the narrow stacked layout.
+      const rows = [...root.querySelectorAll('[role="button"]')];
+      const total = [...root.querySelectorAll("div")].find((element) =>
+        [...element.children].some((child) => child.textContent?.trim() === "=Nettovermögen"),
+      );
+      if (total) rows.push(total);
+      else errors.push("Net worth footer was not checked");
+      for (const row of rows) {
+        const cells = [...row.children].map((element) => element.getBoundingClientRect());
+        for (let i = 0; i < cells.length; i++) {
+          for (let j = i + 1; j < cells.length; j++) {
+            const a = cells[i],
+              b = cells[j];
+            const horizontal = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+            const vertical = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+            if (horizontal > 1 && vertical > 1)
+              errors.push(`Overlapping cells: ${row.textContent}`);
+          }
+        }
+      }
+      return errors;
+    });
+    expect(violations).toEqual([]);
+  });
+}

--- a/e2e/net-worth/layout.spec.ts
+++ b/e2e/net-worth/layout.spec.ts
@@ -1,5 +1,60 @@
 import { expect, test } from "@playwright/test";
 
+function layoutViolations(root: HTMLElement) {
+  const errors: string[] = [];
+  // Use painted text rectangles: element boxes alone miss text spilling out
+  // of a fixed-width label (the original w-12 regression).
+  const bounds = root.firstElementChild!.getBoundingClientRect();
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (!node.textContent?.trim()) continue;
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    const parent = node.parentElement!.getBoundingClientRect();
+    for (const rect of range.getClientRects()) {
+      if (!rect.width || !rect.height) continue;
+      if (rect.left < bounds.left - 1 || rect.right > bounds.right + 1) {
+        errors.push(`Outside card: ${node.textContent}`);
+      }
+      if (rect.left < parent.left - 1 || rect.right > parent.right + 1) {
+        errors.push(`Outside label: ${node.textContent}`);
+      }
+    }
+  }
+  // A flex child can spill into the neighboring grid column even when
+  // the grid cell itself is correctly positioned (the min-w-12-only fix).
+  for (const element of root.querySelectorAll("div, span")) {
+    const rect = element.getBoundingClientRect();
+    if (!rect.width || !rect.height) continue;
+    const parent = element.parentElement!.getBoundingClientRect();
+    if (rect.left < parent.left - 1 || rect.right > parent.right + 1) {
+      errors.push(`Outside cell: ${element.textContent}`);
+    }
+  }
+  // Include category rows and the net-worth footer. Compare adjacent cells
+  // only when they occupy the same line, allowing the narrow stacked layout.
+  const rows = [...root.querySelectorAll('[role="button"]')];
+  const total = [...root.querySelectorAll("div")].find((element) =>
+    [...element.children].some((child) => child.textContent?.trim() === "=Nettovermögen"),
+  );
+  if (total) rows.push(total);
+  else errors.push("Net worth footer was not checked");
+  for (const row of rows) {
+    const cells = [...row.children].map((element) => element.getBoundingClientRect());
+    for (let i = 0; i < cells.length; i++) {
+      for (let j = i + 1; j < cells.length; j++) {
+        const a = cells[i],
+          b = cells[j];
+        const horizontal = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+        const vertical = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+        if (horizontal > 1 && vertical > 1) errors.push(`Overlapping cells: ${row.textContent}`);
+      }
+    }
+  }
+  return errors;
+}
+
 for (const width of [320, 592, 992]) {
   test(`German growth values stay contained at ${width}px`, async ({ page }) => {
     await page.setViewportSize({ width, height: 1100 });
@@ -20,61 +75,136 @@ for (const width of [320, 592, 992]) {
       expect(lines).toBe(1);
     }
 
-    const violations = await card.evaluate((root) => {
-      const errors: string[] = [];
-      // Use painted text rectangles: element boxes alone miss text spilling out
-      // of a fixed-width label (the original w-12 regression).
-      const bounds = root.firstElementChild!.getBoundingClientRect();
-      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-      while (walker.nextNode()) {
-        const node = walker.currentNode;
-        if (!node.textContent?.trim()) continue;
-        const range = document.createRange();
-        range.selectNodeContents(node);
-        const parent = node.parentElement!.getBoundingClientRect();
-        for (const rect of range.getClientRects()) {
-          if (!rect.width || !rect.height) continue;
-          if (rect.left < bounds.left - 1 || rect.right > bounds.right + 1) {
-            errors.push(`Outside card: ${node.textContent}`);
-          }
-          if (rect.left < parent.left - 1 || rect.right > parent.right + 1) {
-            errors.push(`Outside label: ${node.textContent}`);
-          }
-        }
-      }
-      // A flex child can spill into the neighboring grid column even when
-      // the grid cell itself is correctly positioned (the min-w-12-only fix).
-      for (const element of root.querySelectorAll("div, span")) {
-        const rect = element.getBoundingClientRect();
-        if (!rect.width || !rect.height) continue;
-        const parent = element.parentElement!.getBoundingClientRect();
-        if (rect.left < parent.left - 1 || rect.right > parent.right + 1) {
-          errors.push(`Outside cell: ${element.textContent}`);
-        }
-      }
-      // Include category rows and the net-worth footer. Compare adjacent cells
-      // only when they occupy the same line, allowing the narrow stacked layout.
-      const rows = [...root.querySelectorAll('[role="button"]')];
-      const total = [...root.querySelectorAll("div")].find((element) =>
-        [...element.children].some((child) => child.textContent?.trim() === "=Nettovermögen"),
-      );
-      if (total) rows.push(total);
-      else errors.push("Net worth footer was not checked");
-      for (const row of rows) {
-        const cells = [...row.children].map((element) => element.getBoundingClientRect());
-        for (let i = 0; i < cells.length; i++) {
-          for (let j = i + 1; j < cells.length; j++) {
-            const a = cells[i],
-              b = cells[j];
-            const horizontal = Math.min(a.right, b.right) - Math.max(a.left, b.left);
-            const vertical = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
-            if (horizontal > 1 && vertical > 1)
-              errors.push(`Overlapping cells: ${row.textContent}`);
-          }
-        }
-      }
-      return errors;
-    });
+    const violations = await card.evaluate(layoutViolations);
     expect(violations).toEqual([]);
   });
 }
+
+// Card widths straddle every container-query boundary, independently of viewport.
+const cardWidths = [240, 288, 320, 447, 448, 560, 639, 640, 767, 768, 960];
+for (const fallback of [false, true]) {
+  for (const width of cardWidths) {
+    test(`columns align at card ${width}px, fallback=${fallback}`, async ({ page }) => {
+      await page.setViewportSize({ width: 1280, height: 1200 });
+      await page.goto(`/e2e/net-worth/?width=${width}&fallback=${Number(fallback)}`);
+      const card = page.getByRole("main", { name: "Net worth card" });
+      await expect(card.getByText("123.456,8×", { exact: true })).toBeVisible();
+      await page.evaluate(() => document.fonts.ready);
+      if (fallback) {
+        const tracks = await card
+          .getByRole("button", { name: /^Investments / })
+          .evaluate((row) => getComputedStyle(row).gridTemplateColumns);
+        expect(tracks).not.toContain("subgrid");
+      }
+      for (const scenario of ["growth", "loss", "zero", "new", "negative", "assets-only"]) {
+        await page.getByLabel("Scenario", { exact: true }).selectOption(scenario);
+        const edges = await card.evaluate((root) => {
+          // Header, category rows and footer all have four logical cells;
+          // the share cell remains in the DOM when hidden on narrow cards.
+          return [...root.querySelectorAll("div")]
+            .filter((row) => row.children.length === 4 && row.classList.contains("items-baseline"))
+            .map((row) => ({
+              label: row.children[0].textContent,
+              value: row.children[2].getBoundingClientRect().right,
+              delta: row.children[3].getBoundingClientRect().right,
+            }));
+        });
+        expect.soft(await card.evaluate(layoutViolations), `${scenario}: containment`).toEqual([]);
+        expect(edges.length).toBeGreaterThanOrEqual(4);
+        for (const edge of edges) {
+          expect
+            .soft(Math.abs(edge.value - edges[0].value), `${scenario}: Value ${edge.label}`)
+            .toBeLessThanOrEqual(1);
+          expect
+            .soft(Math.abs(edge.delta - edges[0].delta), `${scenario}: Delta ${edge.label}`)
+            .toBeLessThanOrEqual(1);
+        }
+      }
+    });
+  }
+}
+
+for (const fallback of [false, true]) {
+  for (const width of cardWidths) {
+    test(`sign stays with first digit at card ${width}px, fallback=${fallback}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1280, height: 1200 });
+      await page.goto(`/e2e/net-worth/?width=${width}&fallback=${Number(fallback)}`);
+      const card = page.getByRole("main", { name: "Net worth card" });
+      await expect(card.getByText("123.456,8×", { exact: true })).toBeVisible();
+      await page.evaluate(() => document.fonts.ready);
+      if (fallback) {
+        const tracks = await card
+          .getByRole("button", { name: /^Investments / })
+          .evaluate((row) => getComputedStyle(row).gridTemplateColumns);
+        expect(tracks).not.toContain("subgrid");
+      }
+      for (const locale of ["de-DE", "en-US", "fr-FR", "ja-JP"]) {
+        await page.getByLabel("Number locale").selectOption(locale);
+        for (const scenario of ["growth", "loss", "negative", "extreme"]) {
+          await page.getByLabel("Scenario", { exact: true }).selectOption(scenario);
+          const result = await card.evaluate((root) => {
+            const errors: string[] = [];
+            let checked = 0;
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+            while (walker.nextNode()) {
+              const node = walker.currentNode;
+              const signIndex = node.textContent?.search(/[+−-]/) ?? -1;
+              if (signIndex < 0 || !/^[\s+−-]/.test(node.textContent ?? "")) continue;
+              const parent = node.parentElement!;
+              const descendants = document.createTreeWalker(parent, NodeFilter.SHOW_TEXT);
+              let digitNode: Node | undefined;
+              let digitIndex = -1;
+              while (descendants.nextNode()) {
+                const index = descendants.currentNode.textContent?.search(/\d/) ?? -1;
+                if (index >= 0) {
+                  digitNode = descendants.currentNode;
+                  digitIndex = index;
+                  break;
+                }
+              }
+              if (!digitNode) continue;
+              const sign = document.createRange();
+              sign.setStart(node, signIndex);
+              sign.setEnd(node, signIndex + 1);
+              const digit = document.createRange();
+              digit.setStart(digitNode, digitIndex);
+              digit.setEnd(digitNode, digitIndex + 1);
+              const a = sign.getBoundingClientRect(),
+                b = digit.getBoundingClientRect();
+              if (!a.width || !b.width) continue;
+              checked++;
+              if (Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top) <= 1)
+                errors.push(`Separated sign: ${parent.textContent}`);
+            }
+            return { checked, errors };
+          });
+          expect(result.checked).toBeGreaterThan(0);
+          expect.soft(result.errors, `${locale}, ${scenario}`).toEqual([]);
+        }
+      }
+    });
+  }
+}
+
+test("sections collapse independently and privacy hides amounts", async ({ page }) => {
+  await page.goto("/e2e/net-worth/");
+  const card = page.getByRole("main", { name: "Net worth card" });
+  const investment = card.getByRole("button", { name: /^Investments / });
+  const mortgage = card.getByRole("button", { name: /^Mortgage / });
+  await expect(investment).toBeVisible();
+  const toggles = card.locator("button[aria-expanded]");
+  await toggles.nth(0).click();
+  await expect(investment).toBeHidden();
+  await expect(mortgage).toBeVisible();
+  await expect(card.getByText(/^=\s*Nettovermögen$/)).toBeVisible();
+  await toggles.nth(0).click();
+  await expect(investment).toBeVisible();
+  await toggles.nth(1).click();
+  await expect(mortgage).toBeHidden();
+  await expect(investment).toBeVisible();
+  await page.getByLabel("Hide balances").check();
+  await expect(investment.getByText("••••", { exact: true }).first()).toBeVisible();
+  await expect(investment).not.toContainText("12,35");
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:ui": "pnpm --filter frontend test:ui",
     "test:coverage": "pnpm --filter frontend test:coverage",
     "test:e2e": "node scripts/run-e2e.mjs",
+    "test:e2e:net-worth": "playwright test --config playwright.net-worth.config.ts",
     "test:e2e:addon-sandbox": "node scripts/run-addon-sandbox-e2e.mjs",
     "test:e2e:ui": "node scripts/run-e2e.mjs --ui",
     "lint": "pnpm --filter frontend lint && pnpm -r lint",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./e2e",
-  testIgnore: "**/addon-sandbox/**",
+  testIgnore: ["**/addon-sandbox/**", "**/net-worth/**"],
   /* Run tests in files sequentially to ensure onboarding runs before activity tests */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.net-worth.config.ts
+++ b/playwright.net-worth.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/net-worth",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "line",
+  use: {
+    baseURL: "http://127.0.0.1:4175",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm --filter frontend exec vite --host 127.0.0.1 --port 4175",
+    url: "http://127.0.0.1:4175/e2e/net-worth/",
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
Large localized changes in the Net Worth breakdown can exceed the fixed Δ column. Giving only the ratio label a minimum width can push the amount into the neighboring Value column; for example, German formatting of a balance growing from €100 to €12,345,678 produces `+12,35 Mio. €` and `123.456,8×`.

The layout now follows card width using Tailwind container queries. Shared subgrid columns align headers, assets, liabilities, and the net-worth total. Browsers without subgrid use common fractional tracks and a fixed share-column width so individual rows cannot size their columns differently. Narrow cards place category names above the values; medium cards stack the Δ amount and ratio; wide cards allow them side by side. Signed amounts use baseline-aligned flex layout to prevent a sign being stranded above its amount.

The real-component interactive fixture exposes card width, number locale, balance scenarios, privacy, and a simulated no-subgrid mode. The dedicated PR-check step runs 48 Chromium tests covering containment, overlap, cross-row alignment, sign wrapping, section collapse, and privacy. Cases straddle all three container-query breakpoints; sign checks include four number locales and extreme amounts.

Fixes #1649. Supersedes #1661.

Thanks to @jannikmenzel for reporting the remaining overflow and proposing #1661, and @kryofin for the earlier baseline/formatting fix in #1458.

Validation:
- 48 Chromium tests passed via `pnpm test:e2e:net-worth`.
- The same suite passed in Firefox and WebKit with a temporary review configuration: 96 additional tests.
- Before the fixes, seven fallback-alignment tests and two separated-sign tests failed; all now pass.
- Existing net-worth utility tests: 9 passed.
- Web and Tauri frontend builds, frontend type-check, formatting, and diff checks passed. Targeted frontend ESLint reported only the fixture's Fast Refresh export warning.
- Browser control confirmed the 240px sign case and 960px fallback alignment case.

The fallback is simulated by forcing its grid template in modern engines; historical browser binaries and the native Tauri runtime were not tested directly.
