### PR TITLE
feat(dashboard): add unrealized P&L display option

### DIFF
--- a/apps/frontend/src/components/ticker-search.tsx
+++ b/apps/frontend/src/components/ticker-search.tsx
@@ -29,6 +29,7 @@ interface QuoteInfo {
 }
 
 interface SearchProps {
+  id?: string;
   selectedResult?: SymbolSearchResult;
   defaultValue?: string;
   value?: string;
@@ -207,6 +208,7 @@ function focusRelativeTo(anchor: HTMLElement, direction: "next" | "prev") {
 const TickerSearchInput = forwardRef<HTMLButtonElement, SearchProps>(
   (
     {
+      id,
       selectedResult,
       defaultValue,
       value,
@@ -478,6 +480,7 @@ const TickerSearchInput = forwardRef<HTMLButtonElement, SearchProps>(
         <Popover open={open} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>
             <Button
+              id={id}
               variant="outline"
               role="combobox"
               className={cn(

--- a/apps/frontend/src/lib/holding-performance.ts
+++ b/apps/frontend/src/lib/holding-performance.ts
@@ -6,7 +6,7 @@ export type HoldingPerformanceMetric =
   | "totalGain"
   | "totalReturn";
 
-export type HoldingPerformanceMode = "daily" | "pnl" | "return";
+export type HoldingPerformanceMode = "daily" | "unrealized" | "pnl" | "return";
 
 type HoldingPerformanceValues = Pick<
   Holding,
@@ -47,6 +47,9 @@ export function getBaseHoldingPerformancePercentForMode(
   holding: HoldingPerformanceModeValues,
   mode: HoldingPerformanceMode,
 ): number | null {
+  if (mode === "unrealized") {
+    return getBaseHoldingPerformancePercent(holding, "unrealizedGain");
+  }
   if (mode === "daily") return holding.dayChangePct ?? null;
   if (mode === "return") {
     return (

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -111,6 +111,7 @@ export function AssetsTable({
           return (
             <button
               type="button"
+              data-testid={`security-${asset.instrumentType}-${asset.displayCode}`}
               onClick={() => navigate(`/holdings/${encodeURIComponent(asset.id)}`)}
               className="hover:bg-muted/60 focus-visible:ring-ring group flex w-full items-center gap-2.5 rounded-md py-1 text-left transition"
             >

--- a/apps/frontend/src/pages/asset/create-security-dialog.tsx
+++ b/apps/frontend/src/pages/asset/create-security-dialog.tsx
@@ -33,7 +33,7 @@ import {
   SelectValue,
 } from "@wealthfolio/ui/components/ui/select";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -105,6 +105,7 @@ export function CreateSecurityDialog({
   submitLabel,
 }: CreateSecurityDialogProps) {
   const { t } = useTranslation();
+  const searchId = useId();
   const resolvedTitle = title ?? t("asset:createSecurity.title");
   const resolvedDescription = description ?? t("asset:createSecurity.description");
   const resolvedSubmitLabel = submitLabel ?? t("asset:createSecurity.submit_label");
@@ -356,10 +357,11 @@ export function CreateSecurityDialog({
             {/* Ticker search - auto-populates form fields on selection */}
             {open && (
               <div className="space-y-2">
-                <label className="text-sm font-medium">
+                <label htmlFor={searchId} className="text-sm font-medium">
                   {t("asset:createSecurity.search_label")}
                 </label>
                 <TickerSearchInput
+                  id={searchId}
                   onSelectResult={handleTickerSelect}
                   placeholder={t("asset:createSecurity.search_placeholder")}
                   defaultCurrency={defaultCurrency}

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -25,7 +25,7 @@ import { Link, useNavigate } from "react-router-dom";
 const MAX_DISPLAYED_HOLDINGS = 7;
 const MAX_STACKED_AVATARS = 5;
 const PERFORMANCE_MODE_KEY = "dashboard-holdings-widget-performance-mode";
-type PerformanceMode = "daily" | "pnl" | "return";
+type PerformanceMode = "daily" | "unrealized" | "pnl" | "return";
 
 interface TopHoldingsProps {
   holdings: Holding[];
@@ -77,7 +77,9 @@ function HoldingRow({
       ? (holding.totalReturn?.base ?? holding.totalGain?.base ?? 0)
       : performanceMode === "pnl"
         ? (holding.totalGain?.base ?? holding.unrealizedGain?.base ?? 0)
-        : (holding.dayChange?.base ?? 0);
+        : performanceMode === "unrealized"
+          ? (holding.unrealizedGain?.base ?? 0)
+          : (holding.dayChange?.base ?? 0);
   const gainPercent = getBaseHoldingPerformancePercentForMode(holding, performanceMode);
 
   return (
@@ -258,13 +260,17 @@ export function TopHoldings({ holdings, isLoading, baseCurrency }: TopHoldingsPr
               ? (a.totalReturn?.base ?? a.totalGain?.base ?? 0)
               : performanceMode === "pnl"
                 ? (a.totalGain?.base ?? a.unrealizedGain?.base ?? 0)
-                : (a.dayChange?.base ?? 0);
+                : performanceMode === "unrealized"
+                  ? (a.unrealizedGain?.base ?? 0)
+                  : (a.dayChange?.base ?? 0);
           const gainB =
             performanceMode === "return"
               ? (b.totalReturn?.base ?? b.totalGain?.base ?? 0)
               : performanceMode === "pnl"
                 ? (b.totalGain?.base ?? b.unrealizedGain?.base ?? 0)
-                : (b.dayChange?.base ?? 0);
+                : performanceMode === "unrealized"
+                  ? (b.unrealizedGain?.base ?? 0)
+                  : (b.dayChange?.base ?? 0);
           return gainB - gainA;
         }
         return (b.marketValue?.base ?? 0) - (a.marketValue?.base ?? 0);
@@ -311,7 +317,7 @@ export function TopHoldings({ holdings, isLoading, baseCurrency }: TopHoldingsPr
               <p className="text-muted-foreground px-2 py-1.5 text-xs font-medium uppercase tracking-wider">
                 {t("dashboard:holdings.filter_show")}
               </p>
-              {(["daily", "pnl", "return"] as const).map((v) => (
+              {(["daily", "unrealized", "pnl", "return"] as const).map((v) => (
                 <button
                   key={v}
                   className="hover:bg-accent flex w-full items-center justify-between rounded-xl px-3 py-3 text-sm font-medium transition-colors"
@@ -321,7 +327,9 @@ export function TopHoldings({ holdings, isLoading, baseCurrency }: TopHoldingsPr
                     ? t("dashboard:holdings.perf_daily_change")
                     : v === "pnl"
                       ? t("dashboard:holdings.perf_total_pnl")
-                      : t("dashboard:holdings.perf_total_return")}
+                      : v === "unrealized"
+                        ? t("holdings:unrealized_pnl")
+                        : t("dashboard:holdings.perf_total_return")}
                   <span
                     className={cn(
                       "flex h-4 w-4 items-center justify-center rounded-full border-2",

--- a/crates/market-data/src/provider/fixture/mod.rs
+++ b/crates/market-data/src/provider/fixture/mod.rs
@@ -138,11 +138,21 @@ impl FixtureProvider {
         catalog: &FixtureCatalog,
         symbol: &str,
     ) -> Result<FixtureInstrument, MarketDataError> {
+        let symbol = symbol.trim();
+        let bare_symbol = symbol.rsplit_once(':').map_or(symbol, |(_, bare)| bare);
         catalog
             .instruments
             .iter()
+            // An alias on an earlier fixture must not shadow a real ticker.
             .find(|instrument| {
-                instrument.provider == self.provider_id && instrument.matches_symbol(symbol)
+                instrument.provider == self.provider_id
+                    && (instrument.symbol.eq_ignore_ascii_case(symbol)
+                        || instrument.symbol.eq_ignore_ascii_case(bare_symbol))
+            })
+            .or_else(|| {
+                catalog.instruments.iter().find(|instrument| {
+                    instrument.provider == self.provider_id && instrument.matches_symbol(symbol)
+                })
             })
             .cloned()
             .or_else(|| self.synthetic_fx_instrument(symbol))
@@ -958,6 +968,46 @@ mod tests {
         assert!(reciprocal.volume.is_none());
 
         remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn exact_symbol_beats_another_instruments_alias() {
+        let provider = FixtureProvider::new(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../e2e/fixtures/quotes"),
+        );
+
+        // APC.DE (Apple) appears first and aliases APC, which also identifies ARKO.
+        for symbol in ["APC", "apc", " APC ", "XNAS:APC"] {
+            let profile = provider.get_profile(symbol).await.unwrap();
+            assert_eq!(profile.name.as_deref(), Some("ARKO Petroleum Corp."));
+            let instrument = ProviderInstrument::EquitySymbol {
+                symbol: Arc::from(symbol),
+            };
+            let quote = provider
+                .get_latest_quote(&quote_context(), instrument.clone())
+                .await
+                .unwrap();
+            assert_eq!(quote.currency, "USD");
+            let history = provider
+                .get_historical_quotes(
+                    &quote_context(),
+                    instrument,
+                    Utc.with_ymd_and_hms(2026, 5, 11, 0, 0, 0).unwrap(),
+                    Utc.with_ymd_and_hms(2026, 5, 12, 23, 59, 59).unwrap(),
+                )
+                .await
+                .unwrap();
+            assert!(history.iter().all(|quote| quote.currency == "USD"));
+        }
+        assert_eq!(
+            provider
+                .get_profile("APC.DE")
+                .await
+                .unwrap()
+                .name
+                .as_deref(),
+            Some("Apple Inc.")
+        );
     }
 
     #[tokio::test]

--- a/e2e/02-activities.spec.ts
+++ b/e2e/02-activities.spec.ts
@@ -1215,19 +1215,21 @@ test.describe("Activity Creation Tests", () => {
   test("21. Verify activity count in activities page", async () => {
     await gotoActivities(page);
 
-    // Wait for activities to load
-    await page.waitForTimeout(1000);
-
-    // Count activity rows - we created activities:
+    // Count activities - we created activities:
     // deposit, withdrawal, 2 buys, sell, 2 dividends,
     // internal cash transfer (creates 2), external cash transfer out (1), external cash transfer in (1),
     // internal securities transfer (creates 2), external securities transfer in (1),
     // 1 fee, credit, cash adjustment, option-expiry adjustment, interest, 1 tax, split, custom buy
     // Total: 19 existing activities + 3 new-form activities = 22
-    const activityRows = page.locator("tbody tr");
-    const rowCount = await activityRows.count();
-
-    // We should have at least 22 activities
-    expect(rowCount).toBeGreaterThanOrEqual(22);
+    // The table is virtualized, so mounted rows do not represent the total.
+    const activityCount = page.getByRole("main").getByRole("status");
+    await expect
+      .poll(async () => {
+        const match = (await activityCount.textContent())?.match(
+          /^\s*\d+\s*\/\s*(\d+)\s+activities\s*$/,
+        );
+        return match ? Number(match[1]) : 0;
+      })
+      .toBeGreaterThanOrEqual(22);
   });
 });

--- a/e2e/07-asset-creation.spec.ts
+++ b/e2e/07-asset-creation.spec.ts
@@ -28,7 +28,9 @@ test.describe("Asset Creation", () => {
     await expect(page.getByRole("heading", { name: "Securities" })).toBeVisible({ timeout: 10000 });
 
     await page.getByRole("button", { name: "Add Security" }).click();
-    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("dialog", { name: "Add Security", exact: true })).toBeVisible({
+      timeout: 5000,
+    });
     await expect(page.getByRole("heading", { name: "Add Security" })).toBeVisible({
       timeout: 3000,
     });
@@ -45,7 +47,9 @@ test.describe("Asset Creation", () => {
     }
 
     await page.getByRole("button", { name: "Add Security" }).click();
-    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("dialog", { name: "Add Security", exact: true })).toBeVisible({
+      timeout: 5000,
+    });
 
     // Fill Symbol
     const symbolInput = page.getByPlaceholder("e.g., AAPL");
@@ -62,7 +66,9 @@ test.describe("Asset Creation", () => {
     await page.getByRole("button", { name: "Create Security" }).click();
 
     // Dialog should close
-    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("dialog", { name: "Add Security", exact: true })).not.toBeVisible({
+      timeout: 10000,
+    });
 
     await page.waitForTimeout(1000);
 
@@ -87,16 +93,15 @@ test.describe("Asset Creation", () => {
     await page.waitForTimeout(1000);
 
     // Skip if AAPL already exists (likely from earlier specs like CSV import)
-    const existingRow = page.getByRole("row").filter({ hasText: "AAPL" });
-    if (await existingRow.isVisible().catch(() => false)) {
-      return;
-    }
+    const existingStock = page.getByTestId("security-EQUITY-AAPL");
+    test.skip((await existingStock.count()) > 0, "AAPL already exists");
 
+    const dialog = page.getByRole("dialog", { name: "Add Security", exact: true });
     await page.getByRole("button", { name: "Add Security" }).click();
-    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
 
     // Click the search combobox trigger to open the search popover
-    const searchTrigger = page.getByRole("combobox", { name: /search/i });
+    const searchTrigger = dialog.getByRole("combobox", { name: "Search", exact: true });
     await searchTrigger.click();
 
     // Fill the actual CommandInput inside the popover
@@ -120,16 +125,15 @@ test.describe("Asset Creation", () => {
     await aaplOption.click();
 
     // Verify symbol field got auto-filled
-    const symbolInput = page.getByPlaceholder("e.g., AAPL");
+    const symbolInput = dialog.getByPlaceholder("e.g., AAPL");
     await expect(symbolInput).toHaveValue(/AAPL/i);
 
     // Click Create Security
-    await page.getByRole("button", { name: "Create Security" }).click();
-    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 10000 });
+    await dialog.getByRole("button", { name: "Create Security", exact: true }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
     await page.waitForTimeout(1000);
-    const aaplRow = page.getByRole("row").filter({ hasText: "AAPL" });
-    await expect(aaplRow.first()).toBeVisible({ timeout: 10000 });
+    await expect(existingStock.first()).toBeVisible({ timeout: 10000 });
   });
 
   test("5. Edit asset — add notes", async () => {
@@ -201,7 +205,9 @@ test.describe("Asset Creation", () => {
     await expect(page.getByRole("heading", { name: "Securities" })).toBeVisible({ timeout: 10000 });
 
     await page.getByRole("button", { name: "Add Security" }).click();
-    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("dialog", { name: "Add Security", exact: true })).toBeVisible({
+      timeout: 5000,
+    });
 
     // Click Create without filling anything
     await page.getByRole("button", { name: "Create Security" }).click();
@@ -213,6 +219,8 @@ test.describe("Asset Creation", () => {
 
     // Close dialog
     await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("dialog", { name: "Add Security", exact: true })).not.toBeVisible({
+      timeout: 5000,
+    });
   });
 });


### PR DESCRIPTION
## Unrealized P&L in dashboard holdings

Adds **Unrealized P&L** to the Holdings widget's Show menu. Selecting it displays the existing base-currency unrealized gain and its percentage, updates Gain sorting to use that amount, and saves the selection using the existing preference.

The feature is frontend-only: the holdings payload already contains unrealized gain and cost basis. The percentage uses base-currency cost basis to include FX effects, and the label reuses existing translations.

### Validation

- Existing holdings widget and performance helper tests: 7 passed.
- ESLint and Prettier passed for the changed frontend files.
- Frontend type check passed with the combined changes.
- Web and desktop frontend builds passed for the Unrealized P&L change; UI package types were regenerated before the web build.

### Test fixes

- Count activities using the total in the status label rather than mounted rows in the virtualized table.
- Scope asset-creation selectors to the Add Security dialog and identify securities by instrument type and symbol.
- Associate the security search label with its combobox so role-based selectors can find it reliably.
- Prefer exact fixture symbols over another instrument's aliases, with regression coverage for APC, case/whitespace variants, and exchange-prefixed symbols.
- Fixture provider tests: 7 passed. Updated Playwright scenarios were not rerun as part of preparing this PR.
