### PR TITLE
fix(assets): render Last Updated on alternative asset detail page

### DIFF
--- a/apps/frontend/src/pages/asset/alternative-asset-content.tsx
+++ b/apps/frontend/src/pages/asset/alternative-asset-content.tsx
@@ -603,7 +603,7 @@ const AlternativeAssetDetailCard: React.FC<AlternativeAssetDetailCardProps> = ({
             <div className="flex justify-between">
               <span className="text-muted-foreground">{t("asset:altContent.last_updated")}</span>
               <span className="font-medium">
-                {dateFormatting.formatCalendarDate(holding.valuationDate)}
+                {dateFormatting.formatDate(holding.valuationDate)}
               </span>
             </div>
           )}


### PR DESCRIPTION
## What

The **Last Updated** row on the alternative-asset detail page (`/holdings/:assetId`) always rendered the `-` placeholder instead of the valuation date. This switches that one row to the timestamp-aware formatter.

Fixes #1670

## Why

`AlternativeHolding.valuation_date` is a `DateTime<Utc>` (`crates/core/src/assets/alternative_assets_model.rs`), and both the Axum and Tauri layers serialize it with `to_rfc3339()`, so the frontend receives `"2026-09-06T12:00:00+00:00"`.

`alternative-asset-content.tsx` formatted it with `formatCalendarDate`, whose `toCalendarDate` helper accepts a bare calendar date and nothing else:

```ts
return /^\d{4}-\d{2}-\d{2}$/.test(value) ? parseDate(value) : null;
```

The `T…+00:00` suffix fails that regex, so the parse returned `null` and `formatCalendarDate` fell through to its `"-"` placeholder. The neighbouring **Purchase Date** row survived because `purchase_date` is an `Option<NaiveDate>` and arrives as a bare `YYYY-MM-DD`.

## The change

```diff
-                {dateFormatting.formatCalendarDate(holding.valuationDate)}
+                {dateFormatting.formatDate(holding.valuationDate)}
```

`formatDate` comes from the same `useDateFormatting()` hook already in scope, parses full timestamps, and defaults to the same `dateStyle: "medium"` output — so the rendered string is unchanged in style and the row now simply matches the **Last Valued** column that `alternative-holdings-table.tsx` already renders from the identical value via the identical function.

Valuation timestamps are stored at `T12:00:00Z`, so rendering them in the user's timezone rather than forced UTC cannot shift the displayed calendar day.

## Alternatives considered

Narrowing `valuation_date` to a `NaiveDate` backend-side would make the field consistent with every other date on that struct, but it is a serialization change touching both the server and Tauri command layers plus their response types, and the two other frontend consumers already cope with the timestamp. Left out of scope.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
