### PR TITLE
fix(assets): preserve valuation and quote calendar dates

### DIFF
--- a/apps/frontend/src/pages/asset/alternative-asset-content.tsx
+++ b/apps/frontend/src/pages/asset/alternative-asset-content.tsx
@@ -603,7 +603,7 @@ const AlternativeAssetDetailCard: React.FC<AlternativeAssetDetailCardProps> = ({
             <div className="flex justify-between">
               <span className="text-muted-foreground">{t("asset:altContent.last_updated")}</span>
               <span className="font-medium">
-                {dateFormatting.formatDate(holding.valuationDate)}
+                {dateFormatting.formatCalendarDate(holding.valuationDate.split("T")[0])}
               </span>
             </div>
           )}

--- a/apps/frontend/src/pages/asset/alternative-assets/components/update-valuation-modal.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/update-valuation-modal.tsx
@@ -48,7 +48,7 @@ interface UpdateValuationModalProps {
   assetName: string;
   /** Current recorded value as decimal string */
   currentValue: string;
-  /** Last updated date as ISO string (YYYY-MM-DD) */
+  /** Last updated date as a calendar date or UTC ISO timestamp */
   lastUpdatedDate: string;
   /** Currency code (e.g., "USD") */
   currency: string;
@@ -233,7 +233,7 @@ function formatDisplayDate(
 ): string {
   if (!isoDate) return "N/A";
   try {
-    return formatting.formatCalendarDate(isoDate, {
+    return formatting.formatCalendarDate(isoDate.split("T")[0], {
       year: "numeric",
       month: "short",
       day: "numeric",

--- a/apps/frontend/src/pages/asset/alternative-assets/components/valuation-date-display.test.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/valuation-date-display.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { FormattingProvider } from "@wealthfolio/ui";
+import { describe, expect, it, vi } from "vitest";
+import type { AlternativeAssetHolding } from "@/lib/types";
+import { AlternativeHoldingsTable } from "@/pages/holdings/components/alternative-holdings-table";
+import { UpdateValuationModal } from "./update-valuation-modal";
+
+vi.mock("@/hooks/use-balance-privacy", () => ({
+  useBalancePrivacy: () => ({ isBalanceHidden: false }),
+}));
+vi.mock("../hooks/use-alternative-asset-mutations", () => ({
+  useAlternativeAssetMutations: () => ({
+    updateValuationMutation: { mutateAsync: vi.fn(), isPending: false },
+  }),
+}));
+
+const holding: AlternativeAssetHolding = {
+  id: "asset-1",
+  kind: "other",
+  name: "Test asset",
+  symbol: "Other",
+  currency: "USD",
+  marketValue: "100",
+  valuationDate: "2026-09-06T12:00:00+00:00",
+};
+
+describe("valuation calendar dates", () => {
+  it.each(["Pacific/Auckland", "Pacific/Kiritimati", "America/Los_Angeles"])(
+    "preserves Last Valued in %s",
+    (timezone) => {
+      render(
+        <FormattingProvider locale="en-US" timezone={timezone}>
+          <AlternativeHoldingsTable holdings={[holding]} isLoading={false} />
+        </FormattingProvider>,
+      );
+      expect(screen.getByText("Sep 6, 2026")).toBeInTheDocument();
+    },
+  );
+
+  it.each(["2026-09-06", "2026-09-06T12:00:00+00:00", "2026-09-06T00:00:00+00:00"])(
+    "shows the last valuation for date input %s",
+    (lastUpdatedDate) => {
+      render(
+        <FormattingProvider locale="en-US" timezone="Pacific/Kiritimati">
+          <UpdateValuationModal
+            open
+            onOpenChange={vi.fn()}
+            assetId={holding.id}
+            assetName={holding.name}
+            currentValue={holding.marketValue}
+            currency={holding.currency}
+            lastUpdatedDate={lastUpdatedDate}
+          />
+        </FormattingProvider>,
+      );
+      expect(screen.getByText(/Last updated: Sep 6, 2026/)).toBeInTheDocument();
+    },
+  );
+});

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
@@ -108,6 +108,34 @@ describe("ValueHistoryDataGrid mobile", () => {
     mockUseIsMobileViewport.mockReturnValue(true);
   });
 
+  it.each(["2026-09-06T12:00:00+00:00", "2026-09-06T00:00:00+00:00"])(
+    "preserves the saved day when editing a valuation at %s",
+    async (timestamp) => {
+      const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+      renderGrid({
+        data: [{ ...createQuote("2026-09-06", 495_000), timestamp }],
+        onSaveQuote,
+      });
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: `Edit ${displayDate("2026-09-06")}, $495,000.00`,
+        }),
+      );
+      fireEvent.change(screen.getByRole("textbox", { name: "Balance" }), {
+        target: { value: "510000" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await waitFor(() =>
+        expect(onSaveQuote).toHaveBeenCalledWith(
+          expect.objectContaining({
+            timestamp: "2026-09-06T00:00:00Z",
+            close: 510_000,
+          }),
+        ),
+      );
+    },
+  );
+
   it("provides contextual row actions and a labelled notes field", () => {
     renderGrid();
 

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
@@ -24,30 +24,18 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { createColumnHelper } from "@tanstack/react-table";
 import type { Quote } from "@/lib/types";
+import { parseLocalDate } from "@/lib/utils";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { ValueHistoryToolbar } from "./value-history-toolbar";
 import { format } from "date-fns";
 
-const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
-const UTC_MIDNIGHT_REGEX = /^\d{4}-\d{2}-\d{2}T00:00:00(?:\.\d+)?Z$/;
 const MOBILE_PAGE_SIZE = 20;
-
-// Parse YYYY-MM-DD as local midnight to avoid timezone shifts in date-only values.
-const parseLocalDate = (dateOnly: string): Date => new Date(dateOnly + "T00:00:00");
-
-// Preserve legacy non-midnight timestamps while treating canonical midnight UTC as date-only.
-const parseCalendarDate = (value: string): Date => {
-  const trimmed = value.trim();
-  if (DATE_ONLY_REGEX.test(trimmed)) return parseLocalDate(trimmed);
-  if (UTC_MIDNIGHT_REGEX.test(trimmed)) return parseLocalDate(trimmed.substring(0, 10));
-  return new Date(trimmed);
-};
 
 // Helper to normalize date values (handles both Date objects and strings from DateCell)
 const normalizeDate = (value: Date | string): Date => {
   if (value instanceof Date) return value;
-  return parseCalendarDate(value);
+  return parseLocalDate(value);
 };
 
 // Round number to 2 decimal places (standard for alternative assets)
@@ -88,10 +76,11 @@ interface ValueHistoryDataGridProps {
 // Generate a temporary ID for new entries
 const generateTempId = () => `temp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
+// Quotes use the UTC calendar day; keep that day in local date-picker state.
 // Convert Quote to ValueHistoryEntry with rounding
 const toValueHistoryEntry = (quote: Quote): ValueHistoryEntry => ({
   id: quote.id,
-  date: parseCalendarDate(quote.timestamp),
+  date: parseLocalDate(quote.timestamp),
   value: roundToDecimals(quote.close),
   notes: quote.notes ?? "",
   currency: quote.currency,

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.test.ts
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { Quote } from "@/lib/types";
+import { format } from "date-fns";
 import { toQuoteEntry } from "./quote-history-utils";
 
 describe("quote history edit state", () => {
@@ -19,6 +20,8 @@ describe("quote history edit state", () => {
       volume: 0,
       currency: "CNY",
     };
+
+    expect(format(toQuoteEntry(quote).date, "yyyy-MM-dd")).toBe("2026-07-11");
 
     expect(toQuoteEntry(quote)).toMatchObject({
       open: 1.4018,

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
@@ -1,5 +1,6 @@
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import type { Quote } from "@/lib/types";
+import { parseLocalDate } from "@/lib/utils";
 import { createColumnHelper } from "@tanstack/react-table";
 import {
   Button,
@@ -22,7 +23,7 @@ import { toQuoteEntry, type QuoteEntry } from "./quote-history-utils";
 // Helper to normalize date values (handles both Date objects and strings from DateCell)
 const normalizeDate = (value: Date | string): Date => {
   if (value instanceof Date) return value;
-  return new Date(value);
+  return parseLocalDate(value);
 };
 
 const QUOTE_DECIMAL_PRECISION = 8;
@@ -54,7 +55,7 @@ const toQuote = (entry: QuoteEntry, assetId: string): Quote => {
     id: entry.id.startsWith("temp-") ? `${datePart}_${assetId.toUpperCase()}` : entry.id,
     createdAt: new Date().toISOString(),
     dataSource: "MANUAL",
-    timestamp: entry.date.toISOString(),
+    timestamp: format(entry.date, "yyyy-MM-dd'T'00:00:00'Z'"),
     assetId: assetId,
     open: entry.open,
     high: entry.high,

--- a/apps/frontend/src/pages/asset/quote-history-localization.test.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-localization.test.tsx
@@ -1,9 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { FormattingProvider, useDataGrid } from "@wealthfolio/ui";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import type { Quote } from "@/lib/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { QuoteEntry } from "./quote-history-utils";
 import { QuoteHistoryDataGrid } from "./quote-history-data-grid";
 
 vi.mock("@/hooks/use-platform", () => ({ useIsMobileViewport: vi.fn() }));
@@ -56,5 +58,40 @@ describe("QuoteHistoryDataGrid localization", () => {
 
     expect(screen.getByText("18.08.26")).toBeInTheDocument();
     expect(screen.queryByText("2026-08-18")).not.toBeInTheDocument();
+  });
+  it.each([false, true])("preserves the quote day through editing (mobile: %s)", (mobile) => {
+    vi.mocked(useIsMobileViewport).mockReturnValue(mobile);
+    const onSaveQuote = vi.fn();
+    render(
+      <MemoryRouter>
+        <FormattingProvider locale="en-US" uiLocale="en">
+          <QuoteHistoryDataGrid
+            data={[quote]}
+            assetId="asset-1"
+            currency="EUR"
+            isManualDataSource
+            onSaveQuote={onSaveQuote}
+            onDeleteQuote={vi.fn()}
+          />
+        </FormattingProvider>
+      </MemoryRouter>,
+    );
+    const grid = vi.mocked(useDataGrid).mock.calls.at(-1)![0] as unknown as {
+      data: QuoteEntry[];
+      onDataChange: (entries: QuoteEntry[]) => void;
+    };
+    expect([
+      grid.data[0].date.getFullYear(),
+      grid.data[0].date.getMonth(),
+      grid.data[0].date.getDate(),
+    ]).toEqual([2026, 7, 18]);
+    act(() => grid.onDataChange(grid.data.map((entry) => ({ ...entry, close: 12 }))));
+    fireEvent.click(screen.getByRole("button", { name: /^Save/ }));
+    expect(onSaveQuote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timestamp: "2026-08-18T00:00:00Z",
+        close: 12,
+      }),
+    );
   });
 });

--- a/apps/frontend/src/pages/asset/quote-history-utils.ts
+++ b/apps/frontend/src/pages/asset/quote-history-utils.ts
@@ -1,4 +1,5 @@
 import type { Quote } from "@/lib/types";
+import { parseLocalDate } from "@/lib/utils";
 
 export interface QuoteEntry {
   id: string;
@@ -16,7 +17,7 @@ export interface QuoteEntry {
 export function toQuoteEntry(quote: Quote): QuoteEntry {
   return {
     id: quote.id,
-    date: new Date(quote.timestamp),
+    date: parseLocalDate(quote.timestamp),
     open: quote.open,
     high: quote.high,
     low: quote.low,

--- a/apps/frontend/src/pages/holdings/components/alternative-holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/alternative-holdings-table.tsx
@@ -206,7 +206,7 @@ export function AlternativeHoldingsTable({
         ),
         cell: ({ row }) => {
           const holding = row.original;
-          const formatted = formatting.formatDate(holding.valuationDate, {
+          const formatted = formatting.formatCalendarDate(holding.valuationDate.split("T")[0], {
             year: "numeric",
             month: "short",
             day: "numeric",


### PR DESCRIPTION
A September 6 valuation saved at noon UTC displays as September 7 in UTC+12/+14. Midnight UTC quotes can display as September 5 west of UTC. Editing a shifted history row can then save the quote under a different day.

Follow-up to #1672. Preserve the saved calendar day in alternative holdings, asset details, the Update Valuation dialog, and the active value/quote history grids. Read UTC quote timestamps into local calendar-date picker state and serialize manual quote edits at UTC midnight for the selected day, matching the existing alternative history editor. Also accept both date-only values and UTC timestamps in the valuation dialog, fixing its remaining `-` placeholder when opened from asset details.

### Storage contract checked

- Alternative-asset creation/update converts `NaiveDate` inputs to noon UTC (`crates/core/src/assets/alternative_assets_service.rs`). Quote imports do the same (`crates/core/src/quotes/import.rs`).
- SQLite derives its separate `day` column from the UTC timestamp and preserves the timestamp (`crates/storage-sqlite/src/market_data/model.rs`). The core quote service also uses the UTC date for manual quote IDs.
- Both Tauri and Axum pass quote updates to that service. Both serialize alternative holding valuation timestamps as RFC3339 UTC.
- The alternative history editor already writes midnight UTC. The general quote history editor previously serialized local picker dates with `toISOString()`, which could persist the previous UTC day east of UTC; this change fixes that write path as well.

No schema or stored-data migration. Previously misdated saved quotes cannot be reliably reconstructed from the timestamp alone. The unused legacy `QuoteHistoryTable` is outside this change.

### Validation

- Focused display and edit/save regressions across Pacific/Auckland, Pacific/Kiritimati and America/Los_Angeles.
- 24 focused tests pass in each timezone. Running those tests against unchanged `main` in Auckland produces 8 failures, confirming the regressions.
- Full frontend suite: 243 files, 2,053 tests passed.
- `pnpm build:types`, `pnpm build`, and `pnpm build:tauri` passed (web and desktop frontend targets; Rust unchanged).
- Changed-file Prettier and ESLint checks passed; ESLint reports one existing Fast Refresh warning in `alternative-asset-content.tsx`.
