### PR TITLE
Clarify retirement projections and refine planner and launcher UI

### DIFF
--- a/apps/frontend/src/components/app-launcher.tsx
+++ b/apps/frontend/src/components/app-launcher.tsx
@@ -634,7 +634,7 @@ export function AppLauncher() {
           "flex-1",
           isMobileViewport
             ? "max-h-[calc(80vh-160px)] px-2 pb-8"
-            : "h-[min(420px,calc(100dvh_-_6rem))] flex-none max-h-none",
+            : "h-[min(420px,calc(100dvh_-_6rem))] max-h-none flex-none",
         )}
       >
         {!hasResults && <CommandEmpty>{t("common:component.no_matches_found")}</CommandEmpty>}

--- a/apps/frontend/src/components/app-launcher.tsx
+++ b/apps/frontend/src/components/app-launcher.tsx
@@ -627,12 +627,14 @@ export function AppLauncher() {
         autoFocus={!isMobileViewport && open}
         value={search}
         onValueChange={setSearch}
-        className={cn(isMobileViewport ? "text-base" : "py-8")}
+        className="text-base"
       />
       <CommandList
         className={cn(
           "flex-1",
-          isMobileViewport ? "max-h-[calc(80vh-160px)] px-2 pb-8" : "max-h-[420px]",
+          isMobileViewport
+            ? "max-h-[calc(80vh-160px)] px-2 pb-8"
+            : "h-[min(420px,calc(100dvh_-_6rem))] flex-none max-h-none",
         )}
       >
         {!hasResults && <CommandEmpty>{t("common:component.no_matches_found")}</CommandEmpty>}
@@ -781,7 +783,11 @@ export function AppLauncher() {
   }
 
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      contentClassName="w-[calc(100%_-_2rem)] max-w-[720px] rounded-[28px] [&>button]:top-6 [&_[cmdk-item]]:rounded-xl [&_[data-cmdk-input-wrapper]]:h-16 [&_[data-cmdk-input-wrapper]]:px-5"
+    >
       <DialogTitle className="sr-only">{t("common:component.command_palette")}</DialogTitle>
       <DialogDescription className="sr-only">
         {t("common:component.command_palette_description")}

--- a/apps/frontend/src/features/goals/pages/goal-detail-page.tsx
+++ b/apps/frontend/src/features/goals/pages/goal-detail-page.tsx
@@ -222,12 +222,12 @@ export default function GoalDetailPage() {
       </Button>
     ) : null;
   const mobileRetirementTabs = hasRetirementTabs ? (
-    <div className="mb-4 overflow-x-auto pb-1 md:hidden">
+    <div className="mb-4 flex overflow-x-auto pb-1 md:hidden">
       <AnimatedToggleGroup
         variant="default"
         size="sm"
         rounded="full"
-        className="bg-muted/60 p-1"
+        className="bg-muted/60 mx-auto shrink-0 p-1"
         items={retirementTabItems}
         value={activeTab}
         onValueChange={setActiveTab}

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -2,7 +2,7 @@ import { GoalFundingEditor } from "@/features/goals/components/goal-funding-edit
 import {
   DEFAULT_RETURN_SLIDER_MAX,
   RATE_SLIDER_INCREMENT,
-  highReturnWarning,
+  HIGH_RETURN_WARNING_THRESHOLD,
 } from "@/features/goals/components/goal-lever-constants";
 import {
   GoalLeverRow as LeverRow,
@@ -119,6 +119,7 @@ function SidebarMonthlyRow({
   currency: string;
 }) {
   const formatting = useAmountFormatting();
+  const { t } = useTranslation();
   return (
     <div className="flex items-center justify-between gap-3 py-3 first:pt-1 last:pb-1">
       <div className="min-w-0">
@@ -129,7 +130,7 @@ function SidebarMonthlyRow({
         <span className="text-foreground text-sm font-semibold">
           {formatting.formatAmount(amount, currency)}
         </span>
-        <span className="text-muted-foreground text-xs">/mo</span>
+        <span className="text-muted-foreground text-xs">{t("goals:save_up.per_month_suffix")}</span>
       </div>
     </div>
   );
@@ -148,7 +149,7 @@ function SidebarTotalRow({ amount, currency }: { amount: number; currency: strin
         <span className="text-foreground text-sm font-semibold">
           {formatting.formatAmount(amount, currency)}
         </span>
-        <span className="text-muted-foreground text-xs">/mo</span>
+        <span className="text-muted-foreground text-xs">{t("goals:save_up.per_month_suffix")}</span>
       </div>
     </div>
   );
@@ -160,6 +161,12 @@ function pctOfTotal(
   formatting: Pick<ReturnType<typeof useNumberFormatting>, "formatPercent">,
 ) {
   return formatting.formatPercent(total > 0 ? value / total : 0, { digits: 0 });
+}
+
+function highReturnWarning(value: number, t: TFunction) {
+  return value > HIGH_RETURN_WARNING_THRESHOLD
+    ? t("goals:sidebar.warnings.high_return")
+    : undefined;
 }
 
 function highInflationWarning(value: number, t: TFunction) {
@@ -738,7 +745,7 @@ export function SidebarConfigurator({
               step={0.001}
               suffix="%"
               format={(v) => (v * 100).toFixed(1)}
-              warning={highReturnWarning(draft.investment.preRetirementAnnualReturn)}
+              warning={highReturnWarning(draft.investment.preRetirementAnnualReturn, t)}
             />
             <LeverRow
               label={t("goals:sidebar.assumptions.return_during_retirement")}
@@ -756,7 +763,7 @@ export function SidebarConfigurator({
               step={0.001}
               suffix="%"
               format={(v) => (v * 100).toFixed(1)}
-              warning={highReturnWarning(draft.investment.retirementAnnualReturn)}
+              warning={highReturnWarning(draft.investment.retirementAnnualReturn, t)}
             />
             <LeverRow
               label={t("goals:sidebar.assumptions.annual_investment_fee")}
@@ -903,7 +910,9 @@ export function SidebarConfigurator({
                       </span>
                       <span className="text-foreground shrink-0 text-sm font-semibold tabular-nums">
                         {amountFormatting.formatAmount(item.monthlyAmount, currency)}
-                        <span className="text-muted-foreground text-xs font-normal">/mo</span>
+                        <span className="text-muted-foreground text-xs font-normal">
+                          {t("goals:save_up.per_month_suffix")}
+                        </span>
                       </span>
                     </button>
                     <button
@@ -935,7 +944,7 @@ export function SidebarConfigurator({
                         max={sliderMaxFor(item.monthlyAmount, 20000, 5000)}
                         step={100}
                         prefix={moneyPrefix}
-                        suffix="/mo"
+                        suffix={t("goals:save_up.per_month_suffix")}
                         format={(v) => String(Math.round(v))}
                       />
                       <div className="grid grid-cols-2 gap-3">
@@ -1169,7 +1178,9 @@ export function SidebarConfigurator({
                       </span>
                       <span className="text-foreground shrink-0 text-sm font-semibold tabular-nums">
                         {amountFormatting.formatAmount(amount, currency)}
-                        <span className="text-muted-foreground text-xs font-normal">/mo</span>
+                        <span className="text-muted-foreground text-xs font-normal">
+                          {t("goals:save_up.per_month_suffix")}
+                        </span>
                       </span>
                     </button>
                     <button
@@ -1232,7 +1243,7 @@ export function SidebarConfigurator({
                             max={sliderMaxFor(amount, 10000, 2500)}
                             step={50}
                             prefix={moneyPrefix}
-                            suffix="/mo"
+                            suffix={t("goals:save_up.per_month_suffix")}
                             format={(v) => String(Math.round(v))}
                           />
                         )}
@@ -1258,7 +1269,7 @@ export function SidebarConfigurator({
                               max={sliderMaxFor(s.monthlyContribution ?? 0, 10000, 2500)}
                               step={50}
                               prefix={moneyPrefix}
-                              suffix="/mo"
+                              suffix={t("goals:save_up.per_month_suffix")}
                               format={(v) => String(Math.round(v))}
                             />
                             <LeverRow
@@ -1278,6 +1289,7 @@ export function SidebarConfigurator({
                               format={(v) => (v * 100).toFixed(1)}
                               warning={highReturnWarning(
                                 s.accumulationReturn ?? planAccumulationReturn(draft),
+                                t,
                               )}
                             />
                             <LeverRow
@@ -1332,7 +1344,7 @@ export function SidebarConfigurator({
                                 step={0.001}
                                 suffix="%"
                                 format={(v) => (v * 100).toFixed(1)}
-                                warning={highReturnWarning(payoutPhaseReturn(s, draft))}
+                                warning={highReturnWarning(payoutPhaseReturn(s, draft), t)}
                               />
                             )}
                             {s.startAge <= draft.personal.currentAge && (
@@ -1345,7 +1357,7 @@ export function SidebarConfigurator({
                                 max={sliderMaxFor(s.monthlyAmount ?? amount, 10000, 2500)}
                                 step={50}
                                 prefix={moneyPrefix}
-                                suffix="/mo"
+                                suffix={t("goals:save_up.per_month_suffix")}
                                 format={(v) => String(Math.round(v))}
                               />
                             )}
@@ -1519,7 +1531,7 @@ export function SidebarConfigurator({
               step={0.001}
               suffix="%"
               format={(v) => (v * 100).toFixed(1)}
-              warning={highReturnWarning(draft.investment.preRetirementAnnualReturn)}
+              warning={highReturnWarning(draft.investment.preRetirementAnnualReturn, t)}
             />
             <LeverRow
               label={t("goals:sidebar.assumptions.return_during_retirement")}
@@ -1536,7 +1548,7 @@ export function SidebarConfigurator({
               step={0.001}
               suffix="%"
               format={(v) => (v * 100).toFixed(1)}
-              warning={highReturnWarning(draft.investment.retirementAnnualReturn)}
+              warning={highReturnWarning(draft.investment.retirementAnnualReturn, t)}
             />
             <LeverRow
               label={t("goals:sidebar.assumptions.annual_investment_fee")}

--- a/apps/frontend/src/features/goals/retirement-planner/components/simulation-percentage.test.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/simulation-percentage.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TooltipProvider } from "@wealthfolio/ui/components/ui/tooltip";
+import { SimulationPercentage } from "./simulation-percentage";
+import { simulationReferenceBand } from "../lib/simulation-reference";
+
+function renderPercentage(rate: number, plannerMode: "fire" | "traditional" = "fire") {
+  return render(
+    <TooltipProvider delayDuration={0}>
+      <SimulationPercentage rate={rate} plannerMode={plannerMode} />
+    </TooltipProvider>,
+  );
+}
+
+describe("simulation reference bands", () => {
+  it.each([
+    [0, "low"],
+    [0.7449, "low"],
+    [0.745, "middle"],
+    [0.75, "middle"],
+    [0.8949, "middle"],
+    [0.895, "high"],
+    [0.9, "high"],
+    [1, "high"],
+  ] as const)("uses displayed rounding for %s", (rate, expected) => {
+    expect(simulationReferenceBand(rate)).toBe(expected);
+  });
+
+  it("shows 90% in the upper band when the result rounds up", () => {
+    renderPercentage(0.895);
+    expect(screen.getByRole("button", { name: "90%" })).toHaveClass("dark:text-green-400");
+  });
+
+  it("opens on tap and explains FIRE criteria without a safety rating", async () => {
+    renderPercentage(0.65);
+    fireEvent.click(screen.getByRole("button", { name: "65%" }));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("essential spending");
+    expect(tooltip).toHaveTextContent("also reach financial independence");
+    expect(tooltip).toHaveTextContent("not real-world probabilities");
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+
+  it("opens on keyboard focus and omits FIRE criteria in Traditional mode", async () => {
+    renderPercentage(0.8, "traditional");
+    fireEvent.focus(screen.getByRole("button", { name: "80%" }));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("80%");
+    expect(tooltip).not.toHaveTextContent("financial independence");
+  });
+});

--- a/apps/frontend/src/features/goals/retirement-planner/components/simulation-percentage.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/simulation-percentage.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNumberFormatting } from "@wealthfolio/ui";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
+
+import { simulationReferenceBand } from "../lib/simulation-reference";
+
+const BAND_COLORS = {
+  low: "text-destructive",
+  middle: "text-amber-700 dark:text-amber-400",
+  high: "text-[hsl(102,32%,39%)] dark:text-green-400",
+};
+
+export function SimulationPercentage({
+  rate,
+  plannerMode,
+}: {
+  rate: number;
+  plannerMode: "fire" | "traditional";
+}) {
+  const { t } = useTranslation();
+  const formatting = useNumberFormatting();
+  const [open, setOpen] = useState(false);
+  const percent = Math.round(rate * 100);
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={`rounded-sm underline decoration-dotted underline-offset-4 focus-visible:outline focus-visible:outline-2 ${BAND_COLORS[simulationReferenceBand(rate)]}`}
+          onClick={(event) => {
+            event.preventDefault();
+            setOpen((previous) => !previous);
+          }}
+        >
+          {formatting.formatPercent(percent / 100, { digits: 0 })}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        className="text-xs"
+        style={{ maxWidth: "min(22rem, calc(100vw - 2rem))" }}
+        collisionPadding={16}
+      >
+        {t(`goals:risk_lab.results.simulation_tooltip_${plannerMode}`, {
+          percent: formatting.formatDecimal(percent),
+        })}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/frontend/src/features/goals/retirement-planner/lib/copy-localization.test.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/copy-localization.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { createInstance } from "i18next";
+import en from "@/i18n/locales/en/goals.json";
+import { deriveRetirementReadiness } from "./dashboard-math";
+
+const catalogs = import.meta.glob<Record<string, unknown>>("@/i18n/locales/*/goals.json", {
+  eager: true,
+  import: "default",
+});
+function flatten(node: Record<string, unknown>, prefix = ""): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(node).flatMap(([key, value]) => {
+      const path = prefix ? `${prefix}.${key}` : key;
+      return typeof value === "string"
+        ? [[path, value]]
+        : Object.entries(flatten(value as Record<string, unknown>, path));
+    }),
+  );
+}
+const english = flatten(en);
+const reviewedKeys = Object.keys(english).filter(
+  (key) =>
+    /^(dashboard\.(guidance|summary|verdict)|risk_lab\.(scenarios|labels))\./.test(key) ||
+    key.includes("simulation_tooltip") ||
+    key.endsWith("of_simulated_paths") ||
+    key.endsWith("percentile_at_age") ||
+    key.endsWith("fi_projected") ||
+    key.endsWith("never_reaches_fi") ||
+    key.endsWith("high_return") ||
+    key.endsWith("drawdown_note") ||
+    key.endsWith("payout_estimate_note") ||
+    key === "risk_lab.montecarlo.heading" ||
+    key.includes("money_lasts_prompt"),
+);
+const placeholders = (text: string) =>
+  [...text.matchAll(/{{(.*?)}}/g)].map((match) => match[1]).sort();
+
+describe("retirement copy localization", () => {
+  it.each(Object.entries(catalogs))(
+    "has matching placeholders and complete messages in %s",
+    (_, catalog) => {
+      const strings = flatten(catalog);
+      for (const key of reviewedKeys) {
+        expect(strings[key], key).toBeTruthy();
+        expect(placeholders(strings[key]), key).toEqual(placeholders(english[key]));
+        expect(strings[key], key).not.toMatch(/retire later|switch.*annuity|recommended/i);
+      }
+    },
+  );
+
+  it("localizes fund outcomes without translating user-entered names", async () => {
+    for (const catalog of Object.values(catalogs)) {
+      const instance = createInstance();
+      await instance.init({
+        lng: "en",
+        resources: { en: { goals: catalog } },
+        interpolation: { escapeValue: false },
+      });
+      const result = deriveRetirementReadiness(
+        {
+          overview: { incomeStreamExhaustion: [{ label: "My pension", exhaustedAge: 79 }] },
+          plannerMode: "fire",
+          isFinanciallyIndependent: false,
+          effectiveFiAge: 55,
+          desiredAge: 55,
+          horizonAge: 90,
+        },
+        instance.t,
+      );
+      expect(result.body).toContain("My pension");
+      expect(result.body).toContain("79");
+      expect(result.body).not.toContain("goals:");
+    }
+  });
+});

--- a/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts
@@ -1,20 +1,15 @@
+import i18next, { type TFunction } from "i18next";
 import { DEFAULT_DC_PAYOUT_ESTIMATE_RATE } from "./constants";
 import { activeExpenseItems } from "./expense-items";
 import type { RetirementIncomeStream, RetirementPlan } from "../types";
 
 export type PlannerMode = "fire" | "traditional";
 
-export function modeLabel(mode: PlannerMode) {
+export function modeLabel(mode: PlannerMode, t: TFunction = i18next.t) {
   return {
-    target: mode === "fire" ? "FIRE Target" : "Retirement Target",
-    targetNet: mode === "fire" ? "FIRE Target (net)" : "Retirement Target (net)",
-    estAge: mode === "fire" ? "Projected FI Age" : "Target Retirement Age",
-    progress: mode === "fire" ? "FIRE Progress" : "Retirement Progress",
-    coast: "Coast FIRE",
-    budgetAt: "Retirement spending coverage",
-    prefix: mode === "fire" ? "FIRE" : "Retirement",
-    targetAge: mode === "fire" ? "Desired retirement age" : "Retirement age",
-    horizonAge: mode === "fire" ? "Plan through age" : "Life expectancy",
+    coast: t("goals:dashboard.milestone.coast_fire"),
+    budgetAt: t("goals:guide.overview.coverage_title"),
+    prefix: mode === "fire" ? "FIRE" : t("goals:type.retirement"),
   };
 }
 
@@ -148,8 +143,12 @@ export function incomeStreamMonthlyAmount(plan: RetirementPlan, stream: Retireme
   return stream.monthlyAmount ?? 0;
 }
 
-export function incomeAgeRangeLabel(stream: RetirementIncomeStream, horizonAge: number) {
-  return `Age ${stream.startAge} → ${horizonAge}`;
+export function incomeAgeRangeLabel(
+  stream: RetirementIncomeStream,
+  horizonAge: number,
+  t: TFunction = i18next.t,
+) {
+  return t("goals:dashboard.coverage.age_range", { start: stream.startAge, end: horizonAge });
 }
 
 export function isIncomeActiveAtAge(stream: RetirementIncomeStream, age: number) {
@@ -161,11 +160,14 @@ export function coverageTimingLabel(
   startAge: number | undefined,
   endAge: number | undefined,
   age: number,
+  t: TFunction = i18next.t,
 ) {
   if (isActive) return null;
-  if (startAge !== undefined && age < startAge) return `Starts at ${startAge}`;
-  if (endAge !== undefined && age >= endAge) return `Ended at ${endAge}`;
-  return "Not active";
+  if (startAge !== undefined && age < startAge)
+    return t("goals:dashboard.coverage.starts_at", { age: startAge });
+  if (endAge !== undefined && age >= endAge)
+    return t("goals:dashboard.coverage.ended_at", { age: endAge });
+  return t("goals:dashboard.coverage.not_active");
 }
 
 interface CoverageSnapshotLike {
@@ -312,14 +314,17 @@ function earliestFundExhaustion(overview: RetirementOverviewLike) {
   );
 }
 
-export function deriveRetirementReadiness({
-  overview,
-  plannerMode,
-  isFinanciallyIndependent,
-  effectiveFiAge,
-  desiredAge,
-  horizonAge,
-}: DeriveRetirementReadinessInput): RetirementReadiness {
+export function deriveRetirementReadiness(
+  {
+    overview,
+    plannerMode,
+    isFinanciallyIndependent,
+    effectiveFiAge,
+    desiredAge,
+    horizonAge,
+  }: DeriveRetirementReadinessInput,
+  t: TFunction = i18next.t,
+): RetirementReadiness {
   if (!overview) {
     return { tone: "watch", problem: "loading", body: null };
   }
@@ -328,7 +333,7 @@ export function deriveRetirementReadiness({
     return {
       tone: "bad",
       problem: "unreachable-target",
-      body: "Target cannot be sized with the current assumptions. Check spending, inflation, returns, and retirement horizon.",
+      body: t("goals:dashboard.guidance.unavailable"),
     };
   }
 
@@ -336,7 +341,7 @@ export function deriveRetirementReadiness({
     return {
       tone: "bad",
       problem: "portfolio-depletion",
-      body: `Projected portfolio runs short during age ${overview.failureAge ?? horizonAge}. Reduce spending, retire later, or add retirement income.`,
+      body: t("goals:dashboard.guidance.depleted", { age: overview.failureAge ?? horizonAge }),
     };
   }
 
@@ -344,7 +349,7 @@ export function deriveRetirementReadiness({
     return {
       tone: "watch",
       problem: "spending-gap",
-      body: `Projected spending gap starts at age ${overview.spendingShortfallAge}. Increase contributions, retire later, reduce retirement spending, or add retirement income.`,
+      body: t("goals:dashboard.guidance.gap", { age: overview.spendingShortfallAge }),
     };
   }
 
@@ -353,7 +358,10 @@ export function deriveRetirementReadiness({
     return {
       tone: "watch",
       problem: "fund-exhaustion",
-      body: `${exhaustion.label} runs out at age ${exhaustion.exhaustedAge} and pays nothing after that. Lower its payout rate, switch it to an annuity, or plan for the portfolio to cover the gap.`,
+      body: t("goals:dashboard.guidance.fund", {
+        label: exhaustion.label,
+        age: exhaustion.exhaustedAge,
+      }),
     };
   }
 
@@ -362,7 +370,7 @@ export function deriveRetirementReadiness({
       return {
         tone: "watch",
         problem: "spending-gap",
-        body: "Short at retirement. Increase contributions, retire later, reduce retirement spending, or add retirement income.",
+        body: t("goals:dashboard.guidance.shortfall"),
       };
     }
     return { tone: "good", problem: "on-track", body: null };
@@ -372,7 +380,7 @@ export function deriveRetirementReadiness({
     return {
       tone: "good",
       problem: "on-track",
-      body: "You have reached financial independence with the current assumptions.",
+      body: t("goals:dashboard.guidance.reached"),
     };
   }
 
@@ -380,7 +388,7 @@ export function deriveRetirementReadiness({
     return {
       tone: "bad",
       problem: "not-reachable",
-      body: `Not reachable by age ${horizonAge} with current assumptions. Consider increasing contributions, extending the desired retirement age, reducing retirement spending, or adding retirement income.`,
+      body: t("goals:dashboard.guidance.not_reached", { age: horizonAge }),
     };
   }
 
@@ -392,6 +400,6 @@ export function deriveRetirementReadiness({
   return {
     tone: yearsLate <= 3 ? "watch" : "bad",
     problem: "late",
-    body: `${yearsLate} year${yearsLate !== 1 ? "s" : ""} after your desired age. Consider increasing contributions, extending the desired retirement age, or reducing retirement spending.`,
+    body: t("goals:dashboard.guidance.late", { count: yearsLate }),
   };
 }

--- a/apps/frontend/src/features/goals/retirement-planner/lib/expense-items.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/expense-items.ts
@@ -1,3 +1,4 @@
+import i18next, { type TFunction } from "i18next";
 import type { ExpenseBudget, ExpenseItem } from "../types";
 
 const DEFAULT_ITEM_LABELS = ["Living", "Healthcare", "Housing", "Travel", "Other spending"];
@@ -85,10 +86,17 @@ export function isExpenseActiveAtAge(item: ExpenseItem, age: number) {
   );
 }
 
-export function expenseAgeRangeLabel(item: ExpenseItem, horizonAge: number) {
+export function expenseAgeRangeLabel(
+  item: ExpenseItem,
+  horizonAge: number,
+  t: TFunction = i18next.t,
+) {
   const startAge = normalizeOptionalAge(item.startAge);
   const endAge = normalizeOptionalAge(item.endAge);
-  const start = startAge === undefined ? "Retirement" : `Age ${startAge}`;
+  const start =
+    startAge === undefined
+      ? t("goals:type.retirement")
+      : t("goals:dashboard.age_label", { age: startAge });
   const end = endAge === undefined ? horizonAge : endAge;
   return `${start} → ${end}`;
 }

--- a/apps/frontend/src/features/goals/retirement-planner/lib/simulation-reference.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/simulation-reference.ts
@@ -1,0 +1,4 @@
+export function simulationReferenceBand(rate: number) {
+  const percent = Math.round(rate * 100);
+  return percent < 75 ? "low" : percent < 90 ? "middle" : "high";
+}

--- a/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.test.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
-import { FormattingProvider } from "@wealthfolio/ui";
+import { createAmountFormatting, FormattingProvider } from "@wealthfolio/ui";
 import { TooltipProvider } from "@wealthfolio/ui/components/ui/tooltip";
 import { describe, expect, it, vi } from "vitest";
 import type { RetirementOverview } from "@/lib/types";
@@ -53,12 +53,21 @@ function milestone(name: string) {
 
 describe("retirement spending milestones", () => {
   it("uses calculated scenario targets and converts their value basis", () => {
+    const formatting = createAmountFormatting("en-US");
     renderOverview(120_000, 800_000);
-    expect(milestone("Lean FIRE").getByText("$60K")).toBeInTheDocument();
-    expect(milestone("Fat FIRE").getByText("$400K")).toBeInTheDocument();
+    expect(
+      milestone("Lean FIRE").getByText(formatting.formatCompactAmount(60_000, "USD")),
+    ).toBeInTheDocument();
+    expect(
+      milestone("Fat FIRE").getByText(formatting.formatCompactAmount(400_000, "USD")),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByText("Nominal", { exact: true }));
-    expect(milestone("Lean FIRE").getByText("$120K")).toBeInTheDocument();
-    expect(milestone("Fat FIRE").getByText("$800K")).toBeInTheDocument();
+    expect(
+      milestone("Lean FIRE").getByText(formatting.formatCompactAmount(120_000, "USD")),
+    ).toBeInTheDocument();
+    expect(
+      milestone("Fat FIRE").getByText(formatting.formatCompactAmount(800_000, "USD")),
+    ).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "You're projected to reach financial independence at age 50.",
     );

--- a/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.test.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { FormattingProvider } from "@wealthfolio/ui";
+import { TooltipProvider } from "@wealthfolio/ui/components/ui/tooltip";
+import { describe, expect, it, vi } from "vitest";
+import type { RetirementOverview } from "@/lib/types";
+import { DEFAULT_RETIREMENT_PLAN } from "../lib/plan-adapter";
+import DashboardPage from "./dashboard-page";
+
+vi.mock("../components/sidebar-configurator", () => ({ SidebarConfigurator: () => null }));
+vi.mock("../components/retirement-snapshot-table", () => ({ RetirementSnapshotTable: () => null }));
+
+function renderOverview(lean: number | null, fat: number | null) {
+  const overview = {
+    analysisMode: "fire",
+    status: "on_track",
+    successStatus: "on_track",
+    fiAge: 50,
+    retirementStartAge: 50,
+    portfolioNow: 100_000,
+    portfolioAtGoalAge: 400_000,
+    netFireTarget: 500_000,
+    requiredCapitalAtGoalAge: 400_000,
+    requiredCapitalReachable: true,
+    leanRequiredCapitalAtGoalAge: lean,
+    fatRequiredCapitalAtGoalAge: fat,
+    shortfallAtGoalAge: 0,
+    surplusAtGoalAge: 0,
+    coastAmountToday: 50_000,
+    targetReconciliation: {
+      inflationFactorToTarget: 2,
+      requiredCapitalNominal: 400_000,
+      requiredCapitalTodayValue: 200_000,
+    },
+    trajectory: [],
+  } as unknown as RetirementOverview;
+  render(
+    <FormattingProvider locale="en-US">
+      <TooltipProvider>
+        <DashboardPage
+          plan={DEFAULT_RETIREMENT_PLAN}
+          plannerMode="fire"
+          isLoading={false}
+          portfolioData={{ totalValue: 100_000, holdings: [], isLoading: false, error: null }}
+          retirementOverview={overview}
+        />
+      </TooltipProvider>
+    </FormattingProvider>,
+  );
+}
+function milestone(name: string) {
+  return within(screen.getByText(name, { exact: true }).closest<HTMLElement>(".p-4")!);
+}
+
+describe("retirement spending milestones", () => {
+  it("uses calculated scenario targets and converts their value basis", () => {
+    renderOverview(120_000, 800_000);
+    expect(milestone("Lean FIRE").getByText("$60K")).toBeInTheDocument();
+    expect(milestone("Fat FIRE").getByText("$400K")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Nominal", { exact: true }));
+    expect(milestone("Lean FIRE").getByText("$120K")).toBeInTheDocument();
+    expect(milestone("Fat FIRE").getByText("$800K")).toBeInTheDocument();
+
+  });
+
+  it("distinguishes a valid zero target from an unavailable target", () => {
+    renderOverview(0, null);
+    expect(milestone("Lean FIRE").getByText("DONE")).toBeInTheDocument();
+    expect(milestone("Fat FIRE").getByText("—")).toBeInTheDocument();
+    expect(milestone("Fat FIRE").queryByText("DONE")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.test.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.test.tsx
@@ -59,7 +59,10 @@ describe("retirement spending milestones", () => {
     fireEvent.click(screen.getByText("Nominal", { exact: true }));
     expect(milestone("Lean FIRE").getByText("$120K")).toBeInTheDocument();
     expect(milestone("Fat FIRE").getByText("$800K")).toBeInTheDocument();
-
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "You're projected to reach financial independence at age 50.",
+    );
+    expect(screen.getByRole("heading", { level: 1 })).not.toHaveTextContent("—");
   });
 
   it("distinguishes a valid zero target from an unavailable target", () => {

--- a/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.tsx
@@ -1053,7 +1053,12 @@ export default function DashboardPage({
                   {
                     key: "lean",
                     label: t("goals:dashboard.milestone.lean_fire"),
-                    value: targetAtGoalDisplay * 0.7,
+                    value:
+                      retirementOverview?.leanRequiredCapitalAtGoalAge == null
+                        ? null
+                        : chartValueMode === "nominal"
+                          ? retirementOverview.leanRequiredCapitalAtGoalAge
+                          : retirementOverview.leanRequiredCapitalAtGoalAge / inflationFactorToGoal,
                     hint: t("goals:dashboard.milestone.lean_hint"),
                     tip: t("goals:dashboard.milestone.lean_tip"),
                   },
@@ -1067,16 +1072,26 @@ export default function DashboardPage({
                   {
                     key: "fat",
                     label: t("goals:dashboard.milestone.fat_fire"),
-                    value: targetAtGoalDisplay * 1.5,
+                    value:
+                      retirementOverview?.fatRequiredCapitalAtGoalAge == null
+                        ? null
+                        : chartValueMode === "nominal"
+                          ? retirementOverview.fatRequiredCapitalAtGoalAge
+                          : retirementOverview.fatRequiredCapitalAtGoalAge / inflationFactorToGoal,
                     hint: t("goals:dashboard.milestone.fat_hint"),
                     tip: t("goals:dashboard.milestone.fat_tip"),
                   },
                 ].map((m) => {
-                  const pct = m.value > 0 ? Math.min(1, milestonePortfolioDisplay / m.value) : 0;
-                  const reached = milestonePortfolioDisplay >= m.value && m.value > 0;
+                  const pct =
+                    m.value == null
+                      ? 0
+                      : m.value === 0
+                        ? 1
+                        : Math.min(1, milestonePortfolioDisplay / m.value);
+                  const reached = m.value != null && milestonePortfolioDisplay >= m.value;
                   return (
                     <div key={m.key} className="p-4">
-                      <div className="mb-1.5 flex items-center gap-1.5">
+                      <div className="mb-1.5 flex flex-wrap items-center gap-1.5">
                         <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-wider">
                           {m.label}
                         </span>
@@ -1104,7 +1119,7 @@ export default function DashboardPage({
                         )}
                       </div>
                       <div className="text-[17px] font-semibold tabular-nums tracking-tight">
-                        {formatting.formatCompactAmount(m.value, currency)}
+                        {m.value == null ? "—" : formatting.formatCompactAmount(m.value, currency)}
                       </div>
                       <div className="bg-muted/60 mt-2 h-[3px] overflow-hidden rounded-sm">
                         <div

--- a/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.tsx
@@ -749,7 +749,7 @@ export default function DashboardPage({
                     )}
                   </h1>
 
-                  <p className="text-muted-foreground mt-4 max-w-[620px] text-sm leading-relaxed">
+                  <p className="text-muted-foreground mt-4 max-w-[620px] text-sm leading-relaxed xl:max-w-4xl">
                     <Trans
                       t={t}
                       i18nKey={

--- a/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/dashboard-page.tsx
@@ -13,7 +13,7 @@ import {
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { useCallback, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import {
   COVERAGE_COLORS,
   RetirementCoverageChart,
@@ -193,7 +193,7 @@ export default function DashboardPage({
   const formatting = useAmountFormatting();
   const numberFormatting = useNumberFormatting();
   const { t } = useTranslation();
-  const L = modeLabel(plannerMode);
+  const L = modeLabel(plannerMode, t);
   const isTraditionalMode = plannerMode === "traditional";
   const { totalValue, error } = portfolioData;
   const portfolioNow = retirementOverview?.portfolioNow ?? totalValue;
@@ -457,14 +457,17 @@ export default function DashboardPage({
           number | null
         >((earliest, age) => (earliest == null ? age : Math.min(earliest, age)), null)
     : null;
-  const readiness = deriveRetirementReadiness({
-    overview: retirementOverview,
-    plannerMode,
-    isFinanciallyIndependent,
-    effectiveFiAge,
-    desiredAge: plan.personal.targetRetirementAge,
-    horizonAge: plan.personal.planningHorizonAge,
-  });
+  const readiness = deriveRetirementReadiness(
+    {
+      overview: retirementOverview,
+      plannerMode,
+      isFinanciallyIndependent,
+      effectiveFiAge,
+      desiredAge: plan.personal.targetRetirementAge,
+      horizonAge: plan.personal.planningHorizonAge,
+    },
+    t,
+  );
   const heroHealth =
     readiness.tone === "good" ? "on_track" : readiness.tone === "watch" ? "at_risk" : "off_track";
   const heroGuidance = readiness.body;
@@ -539,7 +542,9 @@ export default function DashboardPage({
               retirementOverview.portfolioAtGoalAge;
             const portfolioAtTarget =
               chartValueMode === "nominal" ? portfolioAtTargetNominal : portfolioAtTargetToday;
-            const monthlyContribLabel = `${formatting.formatCompactAmount(plan.investment.monthlyContribution, currency)}/mo`;
+            const monthlyContribLabel = t("goals:dashboard.coverage.amount_per_mo", {
+              amount: formatting.formatCompactAmount(plan.investment.monthlyContribution, currency),
+            });
             const annualBudgetToday =
               targetReconciliation?.plannedAnnualExpensesTodayValue ?? totalBudget * 12;
             const annualBudgetNominal =
@@ -597,7 +602,9 @@ export default function DashboardPage({
                             ? traditionalBadge
                             : yearsFromDesired != null && yearsFromDesired > 0
                               ? t("goals:dashboard.badge.years_late", { count: yearsFromDesired })
-                              : t("goals:dashboard.badge.never_reaches_fi")}
+                              : t("goals:dashboard.badge.never_reaches_fi", {
+                                  age: plan.personal.planningHorizonAge,
+                                })}
                         </Badge>
                       )}
                     </div>
@@ -718,38 +725,14 @@ export default function DashboardPage({
                         </span>
                       </>
                     ) : effectiveFiAge != null ? (
-                      <>
-                        {t("goals:dashboard.verdict.fi_at_prefix")}{" "}
-                        <span className={`font-medium ${statusAccent} whitespace-nowrap`}>
-                          {t("goals:dashboard.verdict.age", { age: effectiveFiAge })}
-                        </span>
-                        {yearsFromDesired != null && yearsFromDesired !== 0 ? (
-                          <>
-                            {" — "}
-                            <span className="text-muted-foreground font-sans text-[0.6em] font-normal italic">
-                              {yearsFromDesired > 0
-                                ? t("goals:dashboard.verdict.years_after", {
-                                    count: yearsFromDesired,
-                                  })
-                                : t("goals:dashboard.verdict.years_before", {
-                                    count: -yearsFromDesired,
-                                  })}{" "}
-                              {t("goals:dashboard.verdict.your_goal_of", {
-                                age: plan.personal.targetRetirementAge,
-                              })}
-                            </span>
-                          </>
-                        ) : (
-                          <>
-                            {" — "}
-                            <span className="text-muted-foreground font-sans text-[0.6em] font-normal italic">
-                              {t("goals:dashboard.verdict.right_on_goal", {
-                                age: plan.personal.targetRetirementAge,
-                              })}
-                            </span>
-                          </>
-                        )}
-                      </>
+                      <Trans
+                        t={t}
+                        i18nKey="goals:dashboard.verdict.fi_projected"
+                        values={{ age: effectiveFiAge }}
+                        components={{
+                          age: <span className={`font-medium ${statusAccent} whitespace-nowrap`} />,
+                        }}
+                      />
                     ) : (
                       <>
                         {t("goals:dashboard.verdict.not_reachable_prefix")}{" "}
@@ -767,55 +750,58 @@ export default function DashboardPage({
                   </h1>
 
                   <p className="text-muted-foreground mt-4 max-w-[620px] text-sm leading-relaxed">
-                    {t("goals:dashboard.summary.at_your_current_prefix")}{" "}
-                    <span className="text-foreground tabular-nums">{monthlyContribLabel}</span>{" "}
-                    {t("goals:dashboard.summary.contribution")}{" "}
-                    {!requiredCapitalReachable ? (
-                      <>{t("goals:dashboard.summary.capital_not_available")}</>
-                    ) : isTraditionalMode ? (
-                      <>
-                        {t("goals:dashboard.summary.projected_balance_is")}{" "}
-                        <ValueModeTooltip
-                          valueMode={chartValueMode}
-                          currency={currency}
-                          todayValue={portfolioAtTargetToday}
-                          nominalValue={portfolioAtTargetNominal}
-                        >
-                          <span className="text-foreground tabular-nums">
-                            {formatting.formatCompactAmount(portfolioAtTarget, currency)}
-                          </span>
-                        </ValueModeTooltip>{" "}
-                        {t("goals:dashboard.summary.vs_required_capital_of")}{" "}
-                        <ValueModeTooltip
-                          valueMode={chartValueMode}
-                          currency={currency}
-                          todayValue={targetTodayAtGoal}
-                          nominalValue={targetNominalAtGoal}
-                        >
-                          <span className="text-foreground tabular-nums">
-                            {formatting.formatCompactAmount(targetAtGoalDisplay, currency)}
-                          </span>
-                        </ValueModeTooltip>{" "}
-                        {t("goals:dashboard.summary.at_age", {
-                          age: plan.personal.targetRetirementAge,
-                        })}
-                      </>
-                    ) : (
-                      <>
-                        {t("goals:dashboard.summary.the_plan_funds")}{" "}
-                        <ValueModeTooltip
-                          valueMode={chartValueMode}
-                          currency={currency}
-                          todayValue={annualBudgetToday}
-                          nominalValue={annualBudgetNominal}
-                        >
-                          <span className="text-foreground tabular-nums">{annualBudgetLabel}</span>
-                        </ValueModeTooltip>
-                        {t("goals:dashboard.summary.per_yr_expenses_to_age", {
-                          age: plan.personal.planningHorizonAge,
-                        })}
-                      </>
-                    )}
+                    <Trans
+                      t={t}
+                      i18nKey={
+                        !requiredCapitalReachable
+                          ? "goals:dashboard.summary.unavailable"
+                          : isTraditionalMode
+                            ? "goals:dashboard.summary.traditional"
+                            : "goals:dashboard.summary.fire"
+                      }
+                      values={{
+                        contribution: monthlyContribLabel,
+                        age: isTraditionalMode
+                          ? plan.personal.targetRetirementAge
+                          : plan.personal.planningHorizonAge,
+                        balance: formatting.formatCompactAmount(portfolioAtTarget, currency),
+                        target: formatting.formatCompactAmount(targetAtGoalDisplay, currency),
+                        budget: annualBudgetLabel,
+                      }}
+                      components={{
+                        contribution: <span className="text-foreground tabular-nums" />,
+                        balance: (
+                          <ValueModeTooltip
+                            valueMode={chartValueMode}
+                            currency={currency}
+                            todayValue={portfolioAtTargetToday}
+                            nominalValue={portfolioAtTargetNominal}
+                          >
+                            {null}
+                          </ValueModeTooltip>
+                        ),
+                        target: (
+                          <ValueModeTooltip
+                            valueMode={chartValueMode}
+                            currency={currency}
+                            todayValue={targetTodayAtGoal}
+                            nominalValue={targetNominalAtGoal}
+                          >
+                            {null}
+                          </ValueModeTooltip>
+                        ),
+                        budget: (
+                          <ValueModeTooltip
+                            valueMode={chartValueMode}
+                            currency={currency}
+                            todayValue={annualBudgetToday}
+                            nominalValue={annualBudgetNominal}
+                          >
+                            {null}
+                          </ValueModeTooltip>
+                        ),
+                      }}
+                    />
                     {requiredCapitalReachable &&
                       !isTraditionalMode &&
                       goalShortfall > 0 &&
@@ -1386,7 +1372,7 @@ export default function DashboardPage({
                                     {s.label}
                                   </span>
                                   <span className="text-muted-foreground block truncate text-[11px]">
-                                    {incomeAgeRangeLabel(s, plan.personal.planningHorizonAge)}
+                                    {incomeAgeRangeLabel(s, plan.personal.planningHorizonAge, t)}
                                     {status ? ` · ${status}` : ""}
                                   </span>
                                 </span>

--- a/apps/frontend/src/features/goals/retirement-planner/pages/guide-page.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/guide-page.tsx
@@ -114,7 +114,6 @@ export default function GuidePage({ country }: { country?: string }) {
           </Term>
           <Term t={t("goals:guide.concepts.inflation_title")}>
             {t("goals:guide.concepts.inflation_desc")}
-            {isIT && ` ${t("goals:guide.concepts.inflation_it_note")}`}
           </Term>
           <Term t={t("goals:guide.concepts.returns_title")}>
             {t("goals:guide.concepts.returns_desc")}

--- a/apps/frontend/src/features/goals/retirement-planner/pages/risk-lab-page.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/risk-lab-page.tsx
@@ -396,12 +396,6 @@ function PlanResilienceHero({
     <Card className="overflow-hidden shadow-sm">
       <CardContent className="space-y-4 p-5 md:p-6">
         <div className="flex gap-4">
-          <div
-            className={cn(
-              "mt-2 h-14 w-1.5 shrink-0 rounded-full",
-              isBaselineHealthy ? "bg-[hsl(111,25%,48%)]" : "bg-destructive",
-            )}
-          />
           <div className="min-w-0 space-y-3">
             <div>
               <p className="text-muted-foreground text-[9px] font-semibold uppercase tracking-[0.22em]">
@@ -419,7 +413,7 @@ function PlanResilienceHero({
                 </span>
                 .
               </h2>
-              <p className="text-muted-foreground mt-4 max-w-[620px] text-sm leading-relaxed">
+              <p className="text-muted-foreground mt-4 max-w-[620px] text-sm leading-relaxed xl:max-w-4xl">
                 {risk}
               </p>
             </div>
@@ -523,12 +517,6 @@ function severityBadgeClass(severity: StressSeverity) {
   return "bg-muted text-muted-foreground";
 }
 
-function severityRailClass(severity: StressSeverity) {
-  if (severity === "high") return "bg-destructive";
-  if (severity === "medium") return "bg-amber-500";
-  return "bg-border";
-}
-
 function impactTextClass(value: number, badWhenPositive = true) {
   if (Math.abs(value) < 1) return "text-foreground";
   const isBad = badWhenPositive ? value > 0 : value < 0;
@@ -536,7 +524,7 @@ function impactTextClass(value: number, badWhenPositive = true) {
 }
 
 function StressIcon({ id }: { id: StressTestResult["id"] }) {
-  const className = "mt-0.5 size-3.5 shrink-0 text-muted-foreground";
+  const className = "size-3.5 shrink-0 text-muted-foreground";
   switch (id) {
     case "return-drag":
       return <Icons.TrendingDown className={className} />;
@@ -680,17 +668,16 @@ function StressTestsSection({
               key={stress.id}
               className="bg-card relative overflow-hidden rounded-xl border shadow-sm"
             >
-              <div
-                className={cn(
-                  "absolute inset-y-5 left-0 w-0.5 rounded-r-full",
-                  severityRailClass(stress.severity),
-                )}
-              />
               <div className="p-5">
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
-                      <StressIcon id={stress.id} />
+                      <span
+                        aria-hidden="true"
+                        className="bg-muted flex size-7 shrink-0 items-center justify-center rounded-full"
+                      >
+                        <StressIcon id={stress.id} />
+                      </span>
                       <h3 className="text-base font-semibold leading-none">
                         {t(`goals:risk_lab.scenarios.${stress.id}.label`)}
                       </h3>

--- a/apps/frontend/src/features/goals/retirement-planner/pages/risk-lab-page.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/pages/risk-lab-page.tsx
@@ -51,6 +51,8 @@ import type {
   StressTestResult,
 } from "../types";
 
+import { SimulationPercentage } from "../components/simulation-percentage";
+
 type PlannerMode = "fire" | "traditional";
 
 interface Props {
@@ -78,8 +80,19 @@ function fmt(value: number, currency: string, formatting: Pick<FormattingApi, "f
   return formatting.formatAmount(value, currency);
 }
 
-function pct(value: number, formatting: Pick<FormattingApi, "formatPercent">) {
-  return formatting.formatPercent(value, { digits: 0 });
+function localizedBackendLabel(t: TFunction, label: string) {
+  const keys: Record<string, string> = {
+    "Base case": "risk_lab.advanced.base_case",
+    "Crash Year 1 (-30%)": "risk_lab.labels.crash_year_1",
+    "Crash Year 5 (-30%)": "risk_lab.labels.crash_year_5",
+    "Double Crash": "risk_lab.labels.double_crash",
+    "Lost Decade": "risk_lab.labels.lost_decade",
+    "After-fee return": "risk_lab.labels.after_fee_return",
+    "Monthly contribution": "sidebar.plan.monthly_contribution",
+    "Monthly spending": "sidebar.spending.monthly_spending",
+    "Retirement age": "sidebar.plan.retirement_age",
+  };
+  return keys[label] ? t(`goals:${keys[label]}`) : label;
 }
 
 function moneyLastsDefinition(t: TFunction, plannerMode: PlannerMode, horizonAge: number) {
@@ -88,14 +101,6 @@ function moneyLastsDefinition(t: TFunction, plannerMode: PlannerMode, horizonAge
   }
 
   return t("goals:risk_lab.results.money_lasts_definition_fire", { horizonAge });
-}
-
-function moneyLastsSummary(t: TFunction, plannerMode: PlannerMode, horizonAge: number) {
-  if (plannerMode === "traditional") {
-    return t("goals:risk_lab.results.money_lasts_summary_traditional", { horizonAge });
-  }
-
-  return t("goals:risk_lab.results.money_lasts_summary_fire", { horizonAge });
 }
 
 function moneyLastsPrompt(t: TFunction, plannerMode: PlannerMode, horizonAge: number) {
@@ -243,7 +248,9 @@ function deterministicRiskContent(
 
   return (
     <>
-      {t("goals:risk_lab.results.largest_risk", { label: stress.label })}
+      {t("goals:risk_lab.results.largest_risk", {
+        label: t(`goals:risk_lab.scenarios.${stress.id}.label`),
+      })}
       {fragments.length ? ": " : "."}
       {fragments.map((fragment, index) => (
         <Fragment key={index}>
@@ -346,7 +353,6 @@ function PlanResilienceHero({
   plannerMode?: PlannerMode;
 }) {
   const amountFormatting = useAmountFormatting();
-  const numberFormatting = useNumberFormatting();
 
   const { t } = useTranslation();
   const currency = plan.currency;
@@ -461,15 +467,19 @@ function PlanResilienceHero({
           />
           <HeroMetric
             label={t("goals:risk_lab.hero.money_lasts")}
-            value={mc ? pct(mc.successRate, numberFormatting) : "—"}
-            detail={
-              mc
-                ? t("goals:risk_lab.hero.paths_count", {
-                    count: numberFormatting.formatDecimal(mc.nSimulations),
-                  })
-                : t("goals:risk_lab.hero.not_run")
+            value={
+              mc ? <SimulationPercentage rate={mc.successRate} plannerMode={plannerMode} /> : "—"
             }
-            tone={mc ? (mc.successRate >= 0.9 ? "good" : "bad") : "default"}
+            detail={
+              mc ? (
+                <>
+                  {t("goals:risk_lab.results.of_simulated_paths")} ·{" "}
+                  {t("goals:risk_lab.hero.paths_count", { count: mc.nSimulations })}
+                </>
+              ) : (
+                t("goals:risk_lab.hero.not_run")
+              )
+            }
           />
         </div>
       </CardContent>
@@ -681,10 +691,12 @@ function StressTestsSection({
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       <StressIcon id={stress.id} />
-                      <h3 className="text-base font-semibold leading-none">{stress.label}</h3>
+                      <h3 className="text-base font-semibold leading-none">
+                        {t(`goals:risk_lab.scenarios.${stress.id}.label`)}
+                      </h3>
                     </div>
                     <p className="text-muted-foreground mt-3 line-clamp-2 text-sm">
-                      {stress.description}
+                      {t(`goals:risk_lab.scenarios.${stress.id}.description`)}
                     </p>
                   </div>
                   <Badge
@@ -966,7 +978,7 @@ function MonteCarloDistributionSection({
   const desiredAge = plan.personal.targetRetirementAge;
   const isTraditional = plannerMode === "traditional";
   const moneyLastsCopy = moneyLastsDefinition(t, plannerMode, plan.personal.planningHorizonAge);
-  const moneyLastsDetail = moneyLastsSummary(t, plannerMode, plan.personal.planningHorizonAge);
+
   const moneyLastsCta = moneyLastsPrompt(t, plannerMode, plan.personal.planningHorizonAge);
 
   return (
@@ -1064,9 +1076,8 @@ function MonteCarloDistributionSection({
             <div className="bg-muted/10 grid border-b md:grid-cols-5">
               <SimulationMetric
                 label={t("goals:risk_lab.montecarlo.money_lasts")}
-                value={pct(result.successRate, numberFormatting)}
-                detail={moneyLastsDetail}
-                tone={result.successRate >= 0.9 ? "good" : "bad"}
+                value={<SimulationPercentage rate={result.successRate} plannerMode={plannerMode} />}
+                detail={t("goals:risk_lab.results.of_simulated_paths")}
               />
               <SimulationMetric
                 label={
@@ -1087,7 +1098,8 @@ function MonteCarloDistributionSection({
                   result.finalPortfolioAtHorizon.p10,
                   plan.currency,
                 )}
-                detail={t("goals:risk_lab.chart.age_detail", {
+                detail={t("goals:risk_lab.chart.percentile_at_age", {
+                  percentile: 10,
                   age: plan.personal.planningHorizonAge,
                 })}
                 tone={result.finalPortfolioAtHorizon.p10 > 0 ? "default" : "bad"}
@@ -1098,7 +1110,8 @@ function MonteCarloDistributionSection({
                   result.finalPortfolioAtHorizon.p50,
                   plan.currency,
                 )}
-                detail={t("goals:risk_lab.chart.age_detail", {
+                detail={t("goals:risk_lab.chart.percentile_at_age", {
+                  percentile: 50,
                   age: plan.personal.planningHorizonAge,
                 })}
               />
@@ -1108,7 +1121,8 @@ function MonteCarloDistributionSection({
                   result.finalPortfolioAtHorizon.p90,
                   plan.currency,
                 )}
-                detail={t("goals:risk_lab.chart.age_detail", {
+                detail={t("goals:risk_lab.chart.percentile_at_age", {
+                  percentile: 90,
                   age: plan.personal.planningHorizonAge,
                 })}
                 tone="good"
@@ -1400,14 +1414,19 @@ function DecisionHeatmap({
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs text-xs">
                         <div className="text-[10px] font-semibold uppercase tracking-wider">
-                          {matrix.rowLabel} × {matrix.columnLabel}
+                          {localizedBackendLabel(t, matrix.rowLabel)} ×{" "}
+                          {localizedBackendLabel(t, matrix.columnLabel)}
                         </div>
                         <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 tabular-nums">
-                          <span className="text-muted-foreground">{matrix.rowLabel}</span>
+                          <span className="text-muted-foreground">
+                            {localizedBackendLabel(t, matrix.rowLabel)}
+                          </span>
                           <span className="text-right">
                             {formatRow(rowValue, matrix.rowLabels[row] ?? "")}
                           </span>
-                          <span className="text-muted-foreground">{matrix.columnLabel}</span>
+                          <span className="text-muted-foreground">
+                            {localizedBackendLabel(t, matrix.columnLabel)}
+                          </span>
                           <span className="text-right">
                             {formatColumn(columnValue, matrix.columnLabels[column] ?? "")}
                           </span>
@@ -1459,7 +1478,7 @@ function DecisionHeatmap({
                     className="text-muted-foreground/80 mx-auto block whitespace-nowrap text-center text-[11px] font-normal leading-none sm:text-xs"
                     style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
                   >
-                    {matrix.rowLabel}
+                    {localizedBackendLabel(t, matrix.rowLabel)}
                   </span>
                 </td>
               )}
@@ -1473,7 +1492,7 @@ function DecisionHeatmap({
               colSpan={matrix.columnValues.length}
               className="text-muted-foreground/80 px-1 pt-1.5 text-center text-[11px] font-normal leading-none sm:text-xs"
             >
-              {matrix.columnLabel}
+              {localizedBackendLabel(t, matrix.columnLabel)}
             </th>
             <th className="w-3 sm:w-4" />
           </tr>
@@ -1695,6 +1714,7 @@ function SorrChart({
   retirementStartAge: number;
 }) {
   const formatting = useAmountFormatting();
+  const { t } = useTranslation();
   const maxLen = Math.max(...scenarios.map((scenario) => scenario.portfolioPath.length));
   const data = Array.from({ length: maxLen }, (_, index) => {
     const entry: Record<string, number> = { age: retirementStartAge + index };
@@ -1734,6 +1754,7 @@ function SorrChart({
           <Line
             key={scenario.label}
             dataKey={scenario.label}
+            name={localizedBackendLabel(t, scenario.label)}
             stroke={SORR_COLORS[index % SORR_COLORS.length]}
             dot={false}
             activeDot={{ r: 4, stroke: "hsl(var(--card))", strokeWidth: 2 }}
@@ -1858,7 +1879,7 @@ function AdvancedSection({
                 </p>
                 <p className="mt-1 font-semibold tabular-nums">
                   {hardestPath && hardestPathRiskAge
-                    ? `${hardestPath.label} @ ${hardestPathRiskAge}`
+                    ? `${localizedBackendLabel(t, hardestPath.label)} @ ${hardestPathRiskAge}`
                     : t("goals:risk_lab.results.none")}
                 </p>
               </div>
@@ -1898,7 +1919,9 @@ function AdvancedSection({
                       className="size-2 shrink-0 rounded-full"
                       style={{ backgroundColor: SORR_COLORS[index % SORR_COLORS.length] }}
                     />
-                    <span className="text-muted-foreground truncate">{scenario.label}</span>
+                    <span className="text-muted-foreground truncate">
+                      {localizedBackendLabel(t, scenario.label)}
+                    </span>
                   </span>
                   <span
                     className={cn(

--- a/apps/frontend/src/i18n/locales/de/goals.json
+++ b/apps/frontend/src/i18n/locales/de/goals.json
@@ -107,17 +107,17 @@
       "on_track": "Auf Kurs",
       "fi_reached": "FU erreicht",
       "at_risk": "Gefährdet",
-      "never_reaches_fi": "Erreicht FU nie",
+      "never_reaches_fi": "Bis Alter {{age}} nicht prognostiziert",
       "years_late_one": "{{count}} Jahr zu spät",
       "years_late_other": "{{count}} Jahre zu spät"
     },
     "verdict": {
       "age": "Alter {{age}}",
-      "spending_gap_prefix": "Die Ausgabenlücke beginnt bei",
+      "spending_gap_prefix": "Eine Ausgabenlücke wird prognostiziert ab",
       "spending_gap_suffix": "bevor der Plan das Alter von {{age}} erreicht.",
-      "short_prefix": "Mit {{age}} fehlen Ihnen",
+      "short_prefix": "Mit {{age}} Jahren beträgt Ihre prognostizierte Lücke",
       "short_suffix": "um den Ruhestand bis zum Alter von {{age}} zu finanzieren.",
-      "depleted_prefix": "Das Portfolio reicht nicht bis",
+      "depleted_prefix": "Das Portfolio reicht voraussichtlich nicht mehr ab",
       "depleted_suffix": "nach dem Ruhestandsbeginn mit {{age}}.",
       "surplus_prefix": "Sie gehen voraussichtlich mit {{age}} in den Ruhestand, mit",
       "surplus_suffix": "Überschuss.",
@@ -126,33 +126,23 @@
       "fi_reached_prefix": "Sie haben",
       "financial_independence": "finanzielle Unabhängigkeit",
       "fi_reached_suffix": "— unter den aktuellen Annahmen — erreicht.",
-      "fi_at_prefix": "Sie erreichen finanzielle Unabhängigkeit mit",
-      "years_after_one": "{{count}} Jahr danach",
-      "years_after_other": "{{count}} Jahre danach",
-      "years_before_one": "{{count}} Jahr davor",
-      "years_before_other": "{{count}} Jahre davor",
-      "your_goal_of": "Ihr Ziel von {{age}}.",
-      "right_on_goal": "genau auf Ihrem Ziel von {{age}}.",
-      "not_reachable_prefix": "Nicht erreichbar bis",
-      "not_reachable_suffix": "unter den aktuellen Annahmen."
+      "not_reachable_prefix": "Nicht prognostiziert bis",
+      "not_reachable_suffix": "unter den aktuellen Annahmen.",
+      "fi_projected": "Sie erreichen voraussichtlich mit <age>{{age}} Jahren</age> finanzielle Unabhängigkeit."
     },
     "summary": {
-      "at_your_current_prefix": "Bei Ihrer aktuellen",
-      "contribution": "Beitrag,",
-      "capital_not_available": "das erforderliche Kapitalziel ist unter den aktuellen Annahmen nicht erreichbar. Überprüfen Sie Ausgaben, Inflation, Renditen und Lebenserwartung.",
-      "projected_balance_is": "der prognostizierte Ruhestandssaldo beträgt",
-      "vs_required_capital_of": "gegenüber einem erforderlichen Kapital von",
       "at_age": "mit {{age}}.",
-      "the_plan_funds": "der Plan finanziert",
-      "per_yr_expenses_to_age": "/Jahr an Ausgaben bis zum Alter von {{age}}.",
-      "youre_short": "Ihnen fehlen"
+      "youre_short": "Ihre prognostizierte Lücke beträgt",
+      "traditional": "Bei Ihren aktuellen Annahmen und einem Beitrag von <contribution>{{contribution}}</contribution> beträgt das prognostizierte Guthaben mit {{age}} Jahren <balance>{{balance}}</balance>, gegenüber einem Kapitalbedarf von <target>{{target}}</target>.",
+      "fire": "Bei Ihren aktuellen Annahmen und einem Beitrag von <contribution>{{contribution}}</contribution> enthält der Plan Ausgaben von <budget>{{budget}}</budget>/Jahr bis Alter {{age}}.",
+      "unavailable": "Bei Ihren aktuellen Annahmen und einem Beitrag von <contribution>{{contribution}}</contribution> lässt sich das Kapitalziel nicht schätzen. Vergleichen Sie Annahmen unter Was wäre wenn."
     },
     "progress": {
       "portfolio_today": "Portfolio heute",
       "required_at_age": "Erforderlich mit {{age}}",
       "target_at_age": "Ziel mit {{age}}",
-      "capital_needed_tip_traditional": "Kapital, das in Ihrem Ruhestandsalter nach Ausgaben, Einkommen, Steuern, Ruhestandsrenditen und Gebühren benötigt wird. Angezeigt in {{valueLabel}}.",
-      "capital_needed_tip_fire": "Kapital, das in Ihrem gewünschten Ruhestandsalter nach Ausgaben, Einkommen, Steuern, Ruhestandsrenditen und Gebühren benötigt wird. Angezeigt in {{valueLabel}}.",
+      "capital_needed_tip_traditional": "Geschätzter Kapitalbedarf im Zielrentenalter anhand der Annahmen zu Ausgaben, Einkommen, Steuern, Renditen und Gebühren. Angezeigt in {{valueLabel}}.",
+      "capital_needed_tip_fire": "Geschätzter Kapitalbedarf im Zielrentenalter anhand der Annahmen zu Ausgaben, Einkommen, Steuern, Renditen und Gebühren. Angezeigt in {{valueLabel}}.",
       "not_available": "Nicht verfügbar",
       "funded_pct": "{{pct}} % finanziert"
     },
@@ -169,18 +159,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "Beiträge stoppen, trotzdem pünktlich in Rente",
-      "coast_tip_nominal": "Coast-Betrag in Nominalbeträge zu Ihrem gewünschten Ruhestandsalter umgerechnet.",
-      "coast_tip_real": "Kapital, das Sie heute benötigen und das — ohne weitere Beiträge — bis zu Ihrem Ruhestandsalter auf die volle FU anwächst.",
+      "coast_hint": "Geschätztes Kapital heute",
+      "coast_tip_nominal": "Das heute benötigte geschätzte Kapital, ausgedrückt im Geldwert zum Rentenalter anhand der angenommenen Inflation. Dies ist eine Wertumrechnung, kein prognostiziertes Anlagewachstum.",
+      "coast_tip_real": "Geschätztes heutiges Kapital: Das Rentenziel wird mit der angenommenen Rendite vor dem Ruhestand nach Gebühren abgezinst. Die Rentenannahmen bleiben unverändert.",
       "lean_fire": "Lean FIRE",
       "lean_hint": "70 % der geplanten Ausgaben",
-      "lean_tip": "In den Ruhestand mit einem sparsamen Budget — etwa 70 % Ihrer geplanten Ausgaben. Früher machbar, lässt aber wenig Spielraum.",
+      "lean_tip": "Geschätztes Kapital für 70 % Ihrer geplanten Ausgaben bei unveränderten übrigen Annahmen. Dies ist das Lean-FIRE-Szenario des Planers.",
       "fi": "FU",
       "fi_hint": "Volle geplante Ausgaben",
       "fi_tip": "Kapital, das Ihre geplanten Ruhestandsausgaben über den gesamten Ruhestandshorizont finanziert.",
       "fat_fire": "Fat FIRE",
       "fat_hint": "150 % der geplanten Ausgaben",
-      "fat_tip": "In den Ruhestand mit etwa 50 % mehr Ausgaben als geplant — Spielraum für Reisen, Geschenke, Schwankungen und einen höheren Lebensstandard.",
+      "fat_tip": "Geschätztes Kapital für 150 % Ihrer geplanten Ausgaben bei unveränderten übrigen Annahmen. Dies ist das Fat-FIRE-Szenario des Planers.",
       "more_info_about": "Mehr Infos zu {{label}}",
       "done": "ERREICHT"
     },
@@ -217,11 +207,26 @@
       "unfunded": "Nicht finanziert",
       "planned_spending_legend": "Geplante Ausgaben",
       "showing": "Anzeige in {{valueLabel}}",
-      "projection_unavailable": "Die Deckungsprognose ist für diesen Plan nicht verfügbar."
+      "projection_unavailable": "Die Deckungsprognose ist für diesen Plan nicht verfügbar.",
+      "age_range": "Alter {{start}} → {{end}}",
+      "starts_at": "Ab Alter {{age}}",
+      "ended_at": "Endete mit {{age}}",
+      "not_active": "Nicht aktiv"
     },
     "disclaimer": {
       "title": "Eines sollten Sie bedenken",
-      "body": "Dies ist keine Finanzberatung. Betrachten Sie diese Zahlen als Skizze, nicht als Prognose. Alles hier ist eine Simulation auf Basis der von Ihnen eingegebenen Daten: Renditen, Inflation, Beiträge, Steuern und wie lange Sie voraussichtlich leben. Reale Märkte verlaufen nicht geradlinig, Steuerregeln ändern sich und staatliche Programme werden neu geschrieben. Nutzen Sie dies, um Ideen zu prüfen und Lücken zu erkennen, und sprechen Sie dann mit einer qualifizierten Fachperson, bevor Sie schwer umkehrbare Entscheidungen treffen."
+      "body": "Projektionen beruhen auf Ihren Annahmen. Tatsächliche Ergebnisse können abweichen. Keine Finanzberatung."
+    },
+    "guidance": {
+      "unavailable": "Das Ziel lässt sich mit den aktuellen Annahmen nicht schätzen. Vergleichen Sie Annahmen unter Was wäre wenn.",
+      "depleted": "Das Portfolio reicht voraussichtlich ab Alter {{age}} nicht mehr aus. Vergleichen Sie Annahmen unter Was wäre wenn.",
+      "gap": "Ab Alter {{age}} wird eine Ausgabenlücke prognostiziert. Vergleichen Sie Annahmen unter Was wäre wenn.",
+      "fund": "{{label}} ist voraussichtlich mit {{age}} aufgebraucht; die modellierten Zahlungen enden dann. Vergleichen Sie Auszahlungs- und Einkommensannahmen.",
+      "shortfall": "Zum Ruhestand wird eine Lücke prognostiziert. Vergleichen Sie Annahmen unter Was wäre wenn.",
+      "reached": "Das aktuelle Portfolio erreicht unter Ihren Annahmen das geschätzte Ziel für finanzielle Unabhängigkeit.",
+      "not_reached": "Finanzielle Unabhängigkeit wird bis Alter {{age}} nicht prognostiziert. Vergleichen Sie Annahmen unter Was wäre wenn.",
+      "late_one": "Finanzielle Unabhängigkeit wird {{count}} Jahr nach Ihrem Wunschalter prognostiziert. Vergleichen Sie Annahmen unter Was wäre wenn.",
+      "late_other": "Finanzielle Unabhängigkeit wird {{count}} Jahre nach Ihrem Wunschalter prognostiziert. Vergleichen Sie Annahmen unter Was wäre wenn."
     }
   },
   "sidebar": {
@@ -231,7 +236,8 @@
       "high_inflation": "Hohe Inflationsannahme. Langfristige Ausgabenbedarfe reagieren bei diesem Satz empfindlicher.",
       "high_fee": "Hohe Gebührenannahme. Der Gebühreneffekt verringert die langfristigen Renditen erheblich.",
       "high_volatility": "Hohe Volatilitätsannahme. Die Ergebnisbandbreiten können sehr breit werden.",
-      "high_contribution_growth": "Hohe Annahme zum Beitragswachstum. Dies setzt anhaltend starke Sparsteigerungen voraus."
+      "high_contribution_growth": "Hohe Annahme zum Beitragswachstum. Dies setzt anhaltend starke Sparsteigerungen voraus.",
+      "high_return": "Hohe Renditeannahme. Die prognostizierten Guthaben reagieren empfindlich auf diesen Satz."
     },
     "plan": {
       "kicker": "Plan",
@@ -252,14 +258,14 @@
       "desired_retirement_age_hint": "Alter, in dem Sie finanziell unabhängig werden möchten.",
       "retirement_age_hint": "Alter, in dem Sie in Rente gehen möchten.",
       "horizon_age_fire": "Planhorizont (Alter)",
-      "horizon_age_traditional": "Lebenserwartung",
+      "horizon_age_traditional": "Planhorizont (Alter)",
       "horizon_hint": "Alter, bis zu dem der Plan reichen soll.",
       "monthly_contribution": "Monatlicher Beitrag",
       "monthly_contribution_hint": "Wie viel Sie jeden Monat bis zum Ruhestand hinzufügen.",
-      "return_before_hint": "Erwartete jährliche Rendite, während Sie sparen.",
-      "return_during_hint": "Erwartete jährliche Rendite nach Beginn der Entnahmen.",
+      "return_before_hint": "Angenommene jährliche Rendite während des Sparens, vor Anlagegebühren.",
+      "return_during_hint": "Angenommene jährliche Rendite nach Beginn der Entnahmen, vor Anlagegebühren.",
       "annual_fee_hint": "Geschätzte jährliche Portfoliogebühren.",
-      "inflation_hint": "Erwarteter jährlicher Preisanstieg."
+      "inflation_hint": "Angenommener jährlicher Preisanstieg."
     },
     "spending": {
       "kicker": "Ausgaben",
@@ -320,13 +326,13 @@
       "fund_return_before_payout": "Fondsrendite vor Auszahlung",
       "fund_payout_rate": "Auszahlungsrate",
       "fund_payout_mode": "Auszahlungsart",
-      "fund_payout_mode_help": "Eine Rente zahlt lebenslang; eine Entnahme zehrt den Fonds auf, bis er leer ist.",
+      "fund_payout_mode_help": "Die Rentenoption modelliert laufende Zahlungen bis zum Planungshorizont; Entnahmen verbrauchen das Fondsguthaben bis zur Erschöpfung.",
       "annuity": "Rente",
       "drawdown": "Entnahme",
       "fund_return_during_payout": "Fondsrendite während der Auszahlung",
-      "drawdown_note": "Die Entnahme verwendet {{pct}} %/Jahr des Saldos zum Startalter und folgt danach der Wachstumseinstellung unten, bis der Fonds leer ist.",
+      "drawdown_note": "Die geschätzte Entnahme beträgt {{pct}} % des Fondsguthabens pro Jahr. Bei bereits laufenden Auszahlungen hat ein eingegebener Monatsbetrag Vorrang. Danach folgen die Zahlungen der Wachstumseinstellung, bis das Guthaben aufgebraucht ist.",
       "monthly_payout_after_tax": "Monatliche Auszahlung nach Steuern",
-      "payout_estimate_note": "Die geschätzte Auszahlung verwendet {{pct}} %/Jahr des prognostizierten Fondssaldos, sofern Sie keine monatliche Auszahlung eingeben.",
+      "payout_estimate_note": "Die geschätzte Auszahlung beträgt {{pct}} % des Fondsguthabens pro Jahr. Bei bereits laufenden Auszahlungen hat ein eingegebener Monatsbetrag Vorrang.",
       "start_age": "Startalter",
       "income_growth": "Einkommenswachstum",
       "income_growth_help": "Wählen Sie, ob dieses Einkommen mit der Plan-Inflation steigt oder fest bleibt.",
@@ -465,15 +471,15 @@
     "quick_start": {
       "title": "Schnellstart — 5 Schritte",
       "step1_title": "Grundlagen des Plans festlegen",
-      "step1_desc": "Wählen Sie unter Plan-Eingaben den Plantyp, den Geburtsmonat, das Rentenalter, die Lebenserwartung und den monatlichen Beitrag.",
+      "step1_desc": "Legen Sie in den Planeingaben Plantyp, Geburtsmonat, Rentenalter, Planungshorizont und monatlichen Beitrag fest.",
       "step2_title": "Ausgaben im Ruhestand eingeben",
       "step2_desc": "Fügen Sie unter Ausgaben im Ruhestand die monatlichen Ausgabenposten hinzu, die der Plan finanzieren soll. Verwenden Sie heutiges Geld; die Inflation wird durch die Plan-Annahmen berücksichtigt.",
       "step3_title": "Renteneinkommen hinzufügen",
-      "step3_desc": "Fügen Sie unter Renteneinkommen monatliche Einkommensströme hinzu, wie z. B. staatliche Renten (z. B. CPP/OAS in Kanada, Social Security in den USA), Betriebsrenten, Teilzeitarbeit oder Rentenzahlungen. Verwenden Sie Pensionsfonds hinzufügen nur, wenn der Planer eine Auszahlung aus einem Fondsguthaben mit 3,5 %/Jahr schätzen soll, sofern Sie nicht selbst eine monatliche Auszahlung eingeben.",
+      "step3_desc": "Fügen Sie Ruhestandseinkommen wie Renten, Teilzeitarbeit oder Leibrenten hinzu. Bei einem Pensionsfonds basiert die geschätzte monatliche Auszahlung auf dem prognostizierten Guthaben und dem eingestellten jährlichen Auszahlungssatz, sofern kein Monatsbetrag eingegeben wird.",
       "step4_title": "Annahmen, Steuern und Kontoanteile prüfen",
       "step4_desc": "Überprüfen Sie prognostizierte Renditen, Gebühren, Volatilität, Inflation, Steuersätze für Entnahmen, Steuertöpfe und welche Konten das Ziel finanzieren.",
       "step5_title": "Übersicht lesen, dann Was-wäre-wenn öffnen",
-      "step5_desc": "Die Übersicht beantwortet, ob der Basisplan funktioniert, und zeigt die Entwicklung, die Ausgabendeckung und die Plan-Eingaben. Was-wäre-wenn testet denselben Plan über Marktpfade, Stresstests, Entscheidungskarten und erweiterte Prüfungen."
+      "step5_desc": "Die Übersicht zeigt Basisprojektion, Ausgabendeckung und Eingaben. Szenarien vergleichen modellierte Marktverläufe, Belastungen und geänderte Annahmen."
     },
     "overview": {
       "title": "Die Übersicht verstehen",
@@ -493,13 +499,13 @@
     "what_if": {
       "title": "Was-wäre-wenn verstehen",
       "market_paths_title": "Marktpfade",
-      "market_paths_desc": "Testet denselben Plan über viele mögliche Marktpfade unter Verwendung Ihrer Annahmen zu Rendite, Volatilität und Inflation. Der schattierte Bereich zeigt Ergebnisse von schlecht bis gut; die Linie zeigt den mittleren Pfad. Geld reicht bedeutet, dass der Plan die wesentlichen Ausgaben deckt und bis zum Planungshorizont noch Geld übrig ist. Im FIRE-Modus muss der Plan zudem zuerst die finanzielle Unabhängigkeit erreichen.",
+      "market_paths_desc": "Wir modellieren verschiedene Marktverläufe anhand Ihrer Annahmen. Die Schattierung zeigt das 10.–90. Perzentil je Alter; die Linie zeigt den Median aller Verläufe, keinen einzelnen Verlauf. Gezählt werden Verläufe, die notwendige Ausgaben decken und mit Restkapital enden; FIRE-Verläufe müssen auch finanzielle Unabhängigkeit erreichen.",
       "base_case_title": "Basisfall",
       "base_case_desc": "Zeigt denselben deterministischen Basisplan wie die Übersicht und verweist dann auf das größte Stresstest-Ergebnis, damit Sie sehen, was am wichtigsten ist.",
       "stress_tests_title": "Stresstests",
       "stress_tests_desc": "Feste Prüfungen zeigen, wie sich der Plan ändert, wenn die Renditen niedriger sind, die Inflation höher ist, die Ausgaben steigen, der Ruhestand früher beginnt, die Ersparnisse sinken oder ein Marktcrash kurz vor dem Ruhestand eintritt.",
       "what_moves_title": "Was beeinflusst den Plan?",
-      "what_moves_desc": "Entscheidungskarten vergleichen Ersparnisse, Renditen, Rentenalter und Ausgaben. Grüne Zellen lassen am Ende mehr Geld übrig. Rote Zellen lassen weiterhin eine Lücke oder werden knapp.",
+      "what_moves_desc": "Vergleichen Sie Sparen, Renditen, Rentenalter und Ausgaben. Grün bedeutet mehr Restkapital als im Basisplan, Gelb weniger. Rot zeigt eine Lücke oder kein Restkapital.",
       "crash_paths_title": "Pfade eines frühen Marktcrashs",
       "crash_paths_desc": "Vergleicht einige Crash-Zeitpunkt-Pfade kurz vor dem Ruhestand. Ein Crash im ersten Ruhestandsjahr kann mehr schaden als derselbe Crash später, da die Entnahmen erfolgen, während das Portfolio im Minus ist."
     },
@@ -508,25 +514,24 @@
       "yearly_spending_title": "Wie jährliche Ausgaben modelliert werden",
       "yearly_spending_desc": "Ihre Ausgaben bestimmen die Entnahme. Jedes Jahr finanziert der Planer den von Ihnen eingegebenen Ausgabenplan, zieht das Renteneinkommen ab und schätzt die Steuerlast auf Portfolio-Entnahmen.",
       "target_calc_title": "Wie das Ziel berechnet wird",
-      "target_calc_desc": "Der Planer berechnet den Barwert Ihres gesamten Ausgabenplans vom Ruhestand bis zu Ihrem Planungshorizont — unter Berücksichtigung der Inflationsrate jedes Ausgabentopfs, der Einkommensströme, die in unterschiedlichen Altersstufen beginnen, und der Steuerlast auf Entnahmen. Wenn Ihr Portfolio diesen Betrag erreicht, verfügt der Basisplan über genügend Kapital für den von Ihnen eingegebenen Plan. Das ist genauer als ein einfaches Vielfaches der Ausgaben, da es variable Ausgaben, aufgeschobene Renten und endliche Horizonte berücksichtigt.",
+      "target_calc_desc": "Der Planer schätzt das Startportfolio zur Finanzierung der Ruhestandsausgaben bis zum Planungshorizont. Er modelliert Ausgabeninflation, Einkommenszeitpunkte, Renditen, Gebühren und Entnahmesteuern. Das Ziel hängt von diesen Annahmen ab.",
       "inflation_title": "Inflationsrate",
-      "inflation_desc": "Alle Projektionen lassen Ausgaben und inflationsgebundenes Einkommen Jahr für Jahr mit dieser Rate wachsen. Der Standardwert von 2 % entspricht dem EZB-Ziel.",
-      "inflation_it_note": "Verwenden Sie 2,5–3 % für eine konservativere Annahme des italienischen VPI.",
+      "inflation_desc": "Die Inflationsannahme erhöht Ausgaben und inflationsgebundene Einnahmen im Zeitverlauf. Einzelne Posten können eigene Raten verwenden.",
       "returns_title": "Renditen, Gebühren und Volatilität",
       "returns_desc": "Die Rendite vor dem Ruhestand bestimmt die Ansparphase. Die Rendite während des Ruhestands bestimmt die Entnahmephase und das erforderliche Kapital. Jährliche Anlagegebühren werden von beiden abgezogen. Die Volatilität wird nur bei Marktpfad-Prüfungen verwendet — höhere Werte erzeugen eine breitere Spanne von Ergebnissen.",
       "horizon_title": "Alter des Planungshorizonts",
-      "horizon_desc": "Wie lange das Portfolio reichen muss. Das Rentenziel und die Was-wäre-wenn-Prüfungen laufen bis zu diesem Alter. Setzen Sie es auf 90–95, um die Langlebigkeit zu testen. Pfade eines frühen Marktcrashs und Geld reicht werden beide an diesem Horizont gemessen."
+      "horizon_desc": "Das Alter, bis zu dem Ruhestandsausgaben und Was-wäre-wenn-Ergebnisse modelliert werden. Eine Annahme über den Planungszeitraum, keine Vorhersage der Lebensdauer."
     },
     "italian": {
       "title": "Italienische Ruhestandseinrichtung (fondo pensione, TFR, INPS)",
       "portfolio_title": "Anlageportfolio (Golden Butterfly, All-Weather…)",
       "portfolio_desc": "Dies ist Ihr Hauptportfolio — der Wert, den Wealthfolio verfolgt. Legen Sie hier Ihre Renditeannahmen, die Gebührenlast und den monatlichen Beitrag fest. Es ist der primäre Ansparmotor Ihres Ruhestandsplans.",
       "fondo_title": "Fondo pensione integrativo (zusätzlicher Pensionsfonds)",
-      "fondo_desc": "Verwenden Sie Pensionsfonds hinzufügen. Geben Sie das aktuelle Fondsguthaben, den monatlichen Beitrag, die erwartete Fondsrendite und das Alter des Auszahlungsbeginns ein. Der Planer schätzt das künftige Guthaben und schätzt, falls Sie keine monatliche Auszahlung eingeben, die Auszahlung auf 3,5 %/Jahr dieses prognostizierten Guthabens ab dem Startalter.",
+      "fondo_desc": "Verwenden Sie Pensionsfonds hinzufügen. Geben Sie Guthaben, Beitrag, angenommene Rendite und Auszahlungsalter ein. Die Schätzung verwendet den eingestellten Auszahlungssatz, sofern kein Monatsbetrag eingegeben wird. Entnahmen enden bei Erschöpfung des Fonds; Rentenzahlungen werden bis zum Planungshorizont modelliert.",
       "inps_title": "Pensione INPS (staatliche Rente — previdenza obbligatoria)",
       "inps_desc": "Verwenden Sie Renteneinkommen hinzufügen. Geben Sie Ihre geschätzte monatliche Nettorente in heutigem Geld ein und legen Sie das Alter des Auszahlungsbeginns fest. Verwenden Sie Indexiert, wenn das Einkommen mit der Inflationsannahme des Plans steigen soll.",
       "tfr_title": "TFR (Trattamento di Fine Rapporto — Abfindungsansammlung)",
-      "tfr_desc": "Wenn Ihr TFR in einen Pensionsfonds fließt, berücksichtigen Sie es im monatlichen Fondsbeitrag. Wenn Sie es getrennt halten, modellieren Sie es als weiteren Pensionsfonds mit eigenem Guthaben, Beitrag, Rendite und Alter des Auszahlungsbeginns. Dieselbe Auszahlungsschätzung von 3,5 %/Jahr gilt, sofern Sie nicht selbst eine monatliche Auszahlung eingeben."
+      "tfr_desc": "Fließt die TFR in einen Pensionsfonds, berücksichtigen Sie sie im Beitrag. Ein separater Fonds kann getrennte TFR-Ersparnisse abbilden; seine modellierten Auszahlungen folgen dem eingestellten Satz oder Monatsbetrag."
     }
   },
   "type": {
@@ -774,7 +779,7 @@
       "retirement_gap": "Rentenlücke",
       "fi_moves_prefix": "FU verschiebt sich um",
       "fi_moves_suffix": "Jahre später",
-      "largest_risk": "{{label}} ist das größte Risiko",
+      "largest_risk": "{{label}} hat unter diesen Tests den größten Effekt",
       "and": "und",
       "none": "Keine",
       "surplus": "Überschuss",
@@ -797,7 +802,10 @@
       "money_lasts_summary_traditional": "bleibt bis zum Alter von {{horizonAge}} finanziert",
       "money_lasts_summary_fire": "FU erreicht + finanziert bis zum Alter von {{horizonAge}}",
       "money_lasts_prompt_traditional": "Führen Sie 10k Pfade aus, um zu sehen, wie oft der Plan bis zum Alter von {{horizonAge}} finanziert bleibt.",
-      "money_lasts_prompt_fire": "Führen Sie 10k Pfade aus, um zu sehen, wie oft der Plan FU erreicht und bis zum Alter von {{horizonAge}} finanziert bleibt."
+      "money_lasts_prompt_fire": "Führen Sie 10k Pfade aus, um zu sehen, wie oft der Plan FU erreicht und bis zum Alter von {{horizonAge}} finanziert bleibt.",
+      "of_simulated_paths": "der simulierten Verläufe",
+      "simulation_tooltip_traditional": "{{percent}} % der simulierten Verläufe decken notwendige Ausgaben und enden mit verbleibendem Kapital. Die Farben verwenden Referenzbereiche: unter 75 %, 75 % bis unter 90 % und mindestens 90 %. Dies sind Modellergebnisse, keine realen Wahrscheinlichkeiten.",
+      "simulation_tooltip_fire": "{{percent}} % der simulierten Verläufe decken notwendige Ausgaben und enden mit verbleibendem Kapital. Sie müssen auch finanzielle Unabhängigkeit erreichen. Die Farben verwenden Referenzbereiche: unter 75 %, 75 % bis unter 90 % und mindestens 90 %. Dies sind Modellergebnisse, keine realen Wahrscheinlichkeiten."
     },
     "stress": {
       "eyebrow_with_count": "Was könnte diesen Plan gefährden? · {{count}} Szenarien",
@@ -814,7 +822,7 @@
     "montecarlo": {
       "eyebrow": "Marktpfade",
       "heading": "Wie oft könnte das Geld reichen?",
-      "intro": "Wir testen denselben Plan über viele mögliche Marktpfade. Der schattierte Bereich zeigt Ergebnisse von schlecht bis gut; die Linie zeigt den mittleren Pfad.",
+      "intro": "Wir modellieren verschiedene Marktverläufe anhand Ihrer Annahmen. Die Schattierung zeigt das 10.–90. Perzentil je Alter; die Linie zeigt den Median aller Verläufe, keinen einzelnen Verlauf.",
       "run_10k": "10k Pfade ausführen",
       "run_100k": "100k Pfade ausführen",
       "running_short": "Wird ausgeführt…",
@@ -826,17 +834,17 @@
       "median_fi_age": "Median-FU-Alter",
       "withdrawals_start_detail": "Auszahlungen beginnen",
       "vs_goal": "vs. Ziel {{age}}",
-      "bad_path": "Schlechter Pfad",
-      "middle_path": "Mittlerer Pfad",
-      "good_path": "Guter Pfad"
+      "bad_path": "Unteres Ergebnis",
+      "middle_path": "Median",
+      "good_path": "Oberes Ergebnis"
     },
     "chart": {
       "age_label": "Alter {{age}}",
       "age_detail": "Alter {{age}}",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "Median-FU @{{age}}",
-      "bad_good_range": "Schlecht-gut-Bereich",
-      "median_path": "Mittlerer Pfad",
+      "bad_good_range": "10.–90. Perzentil",
+      "median_path": "Median",
       "retirement_age": "Renteneintrittsalter",
       "goal_age": "Zielalter",
       "median_fi_age": "Median-FU-Alter",
@@ -844,12 +852,13 @@
       "retire": "Rente",
       "goal": "Ziel",
       "market_paths_count_one": "{{count}} Marktpfad",
-      "market_paths_count_other": "{{count}} Marktpfade"
+      "market_paths_count_other": "{{count}} Marktpfade",
+      "percentile_at_age": "Perzentil {{percentile}} · Alter {{age}}"
     },
     "moves": {
       "eyebrow": "Was verändert den Plan am meisten?",
       "heading": "Was bewegt den Plan?",
-      "description": "Zeigt, wie Ersparnisse, Renditen, Renteneintrittsalter und Ausgaben das Ergebnis verändern. Grün = mehr verbleibendes Geld; Rot = Fehlbetrag oder wird knapp.",
+      "description": "Vergleichen Sie Sparen, Renditen, Rentenalter und Ausgaben. Grün bedeutet mehr Restkapital als im Basisplan, Gelb weniger. Rot zeigt eine Lücke oder kein Restkapital.",
       "empty_title": "Sehen Sie, welche Änderungen am meisten helfen würden.",
       "empty_description": "Vergleichen Sie mehr zu sparen, eine andere Rendite zu erzielen, weniger auszugeben oder in einem anderen Alter in Rente zu gehen.",
       "building": "Wird erstellt...",
@@ -878,6 +887,39 @@
       "unavailable_title": "Crash-Pfade nicht verfügbar.",
       "empty_description": "Führen Sie die fünf Pfade aus, um zu sehen, welche Abfolge den Plan zuerst unter Druck setzen würde.",
       "unavailable_description": "Diese Prüfung erfordert ein positives prognostiziertes Portfolio zu Beginn des Ruhestands."
+    },
+    "labels": {
+      "crash_year_1": "Crash im 1. Jahr (−30 %)",
+      "crash_year_5": "Crash im 5. Jahr (−30 %)",
+      "double_crash": "Zwei Crashs",
+      "lost_decade": "Verlorenes Jahrzehnt",
+      "after_fee_return": "Rendite nach Gebühren"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "Niedrigere Renditen",
+        "description": "Die Renditen vor und während des Ruhestands sind 2 Prozentpunkte niedriger."
+      },
+      "inflation-shock": {
+        "label": "Höhere Inflation",
+        "description": "Die allgemeine Inflation ist 1,5 Prozentpunkte höher."
+      },
+      "spending-shock": {
+        "label": "Höhere Ausgaben",
+        "description": "Alle Ruhestandsausgaben sind 10 % höher."
+      },
+      "retire-earlier": {
+        "label": "Ruhestand 2 Jahre früher",
+        "description": "Das Zielalter wird um zwei Jahre vorgezogen, begrenzt durch das aktuelle Alter im Plan."
+      },
+      "save-less": {
+        "label": "Niedrigere Beiträge",
+        "description": "Die monatlichen Beiträge sind 25 % niedriger."
+      },
+      "early-crash": {
+        "label": "Früher Markteinbruch",
+        "description": "Im ersten Ruhestandsjahr wird ein Marktrückgang von 30 % modelliert."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/en/goals.json
+++ b/apps/frontend/src/i18n/locales/en/goals.json
@@ -107,17 +107,17 @@
       "on_track": "On track",
       "fi_reached": "FI reached",
       "at_risk": "At risk",
-      "never_reaches_fi": "Never reaches FI",
+      "never_reaches_fi": "Not projected by age {{age}}",
       "years_late_one": "{{count}} yr late",
       "years_late_other": "{{count}} yrs late"
     },
     "verdict": {
       "age": "age {{age}}",
-      "spending_gap_prefix": "Spending gap starts at",
+      "spending_gap_prefix": "A spending gap is projected from",
       "spending_gap_suffix": "before the plan reaches age {{age}}.",
-      "short_prefix": "At age {{age}}, you're short",
+      "short_prefix": "At age {{age}}, your projected shortfall is",
       "short_suffix": "to fund retirement through age {{age}}.",
-      "depleted_prefix": "Portfolio runs short during",
+      "depleted_prefix": "The portfolio is projected to run short at",
       "depleted_suffix": "after retiring at {{age}}.",
       "surplus_prefix": "You're projected to retire at age {{age}} with",
       "surplus_suffix": "surplus.",
@@ -126,33 +126,23 @@
       "fi_reached_prefix": "You have reached",
       "financial_independence": "financial independence",
       "fi_reached_suffix": "— with the current assumptions.",
-      "fi_at_prefix": "You'll reach financial independence at",
-      "years_after_one": "{{count}} year after",
-      "years_after_other": "{{count}} years after",
-      "years_before_one": "{{count}} year before",
-      "years_before_other": "{{count}} years before",
-      "your_goal_of": "your goal of {{age}}.",
-      "right_on_goal": "right on your goal of {{age}}.",
-      "not_reachable_prefix": "Not reachable by",
-      "not_reachable_suffix": "with current assumptions."
+      "not_reachable_prefix": "Not projected by",
+      "not_reachable_suffix": "with current assumptions.",
+      "fi_projected": "You're projected to reach financial independence at <age>age {{age}}</age>."
     },
     "summary": {
-      "at_your_current_prefix": "At your current",
-      "contribution": "contribution,",
-      "capital_not_available": "the required capital target is not available with the current assumptions. Review spending, inflation, returns, and life expectancy.",
-      "projected_balance_is": "projected retirement balance is",
-      "vs_required_capital_of": "vs. required capital of",
       "at_age": "at age {{age}}.",
-      "the_plan_funds": "the plan funds",
-      "per_yr_expenses_to_age": "/yr of expenses to age {{age}}.",
-      "youre_short": "You're short"
+      "youre_short": "Your projected shortfall is",
+      "traditional": "Based on your current assumptions and <contribution>{{contribution}}</contribution> contribution, your projected balance at age {{age}} is <balance>{{balance}}</balance>, compared with required capital of <target>{{target}}</target>.",
+      "fire": "Based on your current assumptions and <contribution>{{contribution}}</contribution> contribution, the plan includes <budget>{{budget}}</budget>/yr of spending through age {{age}}.",
+      "unavailable": "With your current assumptions and <contribution>{{contribution}}</contribution> contribution, the capital target cannot be estimated. Compare assumptions in What If."
     },
     "progress": {
       "portfolio_today": "Portfolio today",
       "required_at_age": "Required at age {{age}}",
       "target_at_age": "Target at age {{age}}",
-      "capital_needed_tip_traditional": "Capital needed at your retirement age after expenses, income, taxes, retirement returns, and fees. Shown in {{valueLabel}}.",
-      "capital_needed_tip_fire": "Capital needed at your desired retirement age after expenses, income, taxes, retirement returns, and fees. Shown in {{valueLabel}}.",
+      "capital_needed_tip_traditional": "Estimated capital needed at your target retirement age under the plan's spending, income, tax, return, and fee assumptions. Shown in {{valueLabel}}.",
+      "capital_needed_tip_fire": "Estimated capital needed at your target retirement age under the plan's spending, income, tax, return, and fee assumptions. Shown in {{valueLabel}}.",
       "not_available": "Not available",
       "funded_pct": "{{pct}}% funded"
     },
@@ -169,18 +159,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "Stop contributing, still retires on time",
-      "coast_tip_nominal": "Coast amount translated into nominal dollars at your desired retirement age.",
-      "coast_tip_real": "Capital you need today that — with zero further contributions — grows to full FI by your retirement age.",
+      "coast_hint": "Estimated capital needed today",
+      "coast_tip_nominal": "The estimated capital needed today, expressed in retirement-age dollars using assumed inflation. This is a value conversion, not projected investment growth.",
+      "coast_tip_real": "Estimated capital today, calculated by discounting the retirement target at the assumed pre-retirement return after fees. Pension assumptions remain unchanged.",
       "lean_fire": "Lean FIRE",
       "lean_hint": "70% of planned spending",
-      "lean_tip": "Retire on a frugal budget — roughly 70% of your planned spending. Feasible earlier but leaves little margin.",
+      "lean_tip": "Capital estimated for 70% of your planned spending, with other assumptions unchanged. This is the planner's Lean FIRE scenario.",
       "fi": "FI",
       "fi_hint": "Full planned spending",
       "fi_tip": "Capital that funds your planned retirement spending through the full retirement horizon.",
       "fat_fire": "Fat FIRE",
       "fat_hint": "150% of planned spending",
-      "fat_tip": "Retire with ~50% more spending than planned — room for travel, gifts, volatility, and lifestyle upgrades.",
+      "fat_tip": "Capital estimated for 150% of your planned spending, with other assumptions unchanged. This is the planner's Fat FIRE scenario.",
       "more_info_about": "More info about {{label}}",
       "done": "DONE"
     },
@@ -217,11 +207,26 @@
       "unfunded": "Unfunded",
       "planned_spending_legend": "Planned spending",
       "showing": "Showing {{valueLabel}}",
-      "projection_unavailable": "Coverage projection is unavailable for this plan."
+      "projection_unavailable": "Coverage projection is unavailable for this plan.",
+      "age_range": "Age {{start}} → {{end}}",
+      "starts_at": "Starts at {{age}}",
+      "ended_at": "Ended at {{age}}",
+      "not_active": "Not active"
     },
     "disclaimer": {
       "title": "One thing to keep in mind",
-      "body": "This is not financial advice. Treat these numbers as a sketch, not a forecast. Everything here is a simulation built on the inputs you entered: returns, inflation, contributions, taxes, and how long you expect to live. Real markets don't move in straight lines, tax rules shift, and government programs get rewritten. Use this to stress-test ideas and spot gaps, then talk to a qualified professional before making decisions that are hard to undo."
+      "body": "Projections depend on your assumptions. Actual results may differ. Not financial advice."
+    },
+    "guidance": {
+      "unavailable": "The target cannot be estimated with the current assumptions. Compare assumptions in What If.",
+      "depleted": "The portfolio is projected to run short at age {{age}}. Compare assumptions in What If.",
+      "gap": "A spending gap is projected to start at age {{age}}. Compare assumptions in What If.",
+      "fund": "{{label}} is projected to be depleted at age {{age}}; modeled payments then stop. Compare payout and income assumptions.",
+      "shortfall": "A shortfall is projected at retirement. Compare assumptions in What If.",
+      "reached": "The current portfolio meets the estimated financial independence target under your assumptions.",
+      "not_reached": "Financial independence is not projected by age {{age}}. Compare assumptions in What If.",
+      "late_one": "Financial independence is projected {{count}} year after your desired age. Compare assumptions in What If.",
+      "late_other": "Financial independence is projected {{count}} years after your desired age. Compare assumptions in What If."
     }
   },
   "sidebar": {
@@ -231,7 +236,8 @@
       "high_inflation": "High inflation assumption. Long-range spending needs become more sensitive at this rate.",
       "high_fee": "High fee assumption. Fee drag materially reduces long-term returns.",
       "high_volatility": "High volatility assumption. Outcome ranges can become very wide.",
-      "high_contribution_growth": "High contribution growth assumption. This assumes sustained large savings increases."
+      "high_contribution_growth": "High contribution growth assumption. This assumes sustained large savings increases.",
+      "high_return": "High return assumption. Projected balances are sensitive to this rate."
     },
     "plan": {
       "kicker": "Plan",
@@ -252,14 +258,14 @@
       "desired_retirement_age_hint": "Age you want to become financially independent.",
       "retirement_age_hint": "Age you want to retire.",
       "horizon_age_fire": "Plan through age",
-      "horizon_age_traditional": "Life expectancy",
+      "horizon_age_traditional": "Plan through age",
       "horizon_hint": "Age the plan should cover through.",
       "monthly_contribution": "Monthly contribution",
       "monthly_contribution_hint": "How much you add each month until retirement.",
-      "return_before_hint": "Expected yearly return while you are saving.",
-      "return_during_hint": "Expected yearly return after withdrawals begin.",
+      "return_before_hint": "Assumed annual return while saving, before investment fees.",
+      "return_during_hint": "Assumed annual return after withdrawals begin, before investment fees.",
       "annual_fee_hint": "Estimated yearly portfolio fees.",
-      "inflation_hint": "Expected yearly increase in prices."
+      "inflation_hint": "Assumed annual increase in prices."
     },
     "spending": {
       "kicker": "Spending",
@@ -320,13 +326,13 @@
       "fund_return_before_payout": "Fund return before payout",
       "fund_payout_rate": "Payout rate",
       "fund_payout_mode": "Payout mode",
-      "fund_payout_mode_help": "An annuity pays for life; a drawdown draws on the fund until it runs out.",
+      "fund_payout_mode_help": "Annuity models ongoing payments through the plan horizon; drawdown uses the fund balance until it is depleted.",
       "annuity": "Annuity",
       "drawdown": "Drawdown",
       "fund_return_during_payout": "Fund return during payout",
-      "drawdown_note": "Drawdown takes {{pct}}%/yr of the balance at the start age, then follows the growth setting below until the fund is empty.",
+      "drawdown_note": "Drawdown estimates payments at {{pct}}%/yr of the fund balance. For payments already started, an entered monthly payout takes precedence. Payments then follow the growth setting until the fund is depleted.",
       "monthly_payout_after_tax": "Monthly payout after tax",
-      "payout_estimate_note": "Estimated payout uses {{pct}}%/yr of the projected fund balance unless you enter a monthly payout.",
+      "payout_estimate_note": "Estimated payout uses {{pct}}%/yr of the fund balance. For payments already started, an entered monthly payout takes precedence.",
       "start_age": "Start age",
       "income_growth": "Income growth",
       "income_growth_help": "Choose whether this income rises with plan inflation or stays fixed.",
@@ -465,15 +471,15 @@
     "quick_start": {
       "title": "Quick start — 5 steps",
       "step1_title": "Set the plan basics",
-      "step1_desc": "In Plan inputs, choose the plan type, birth month, retirement age, life expectancy, and monthly contribution.",
+      "step1_desc": "In Plan inputs, set the plan type, birth month, retirement age, planning horizon, and monthly contribution.",
       "step2_title": "Enter retirement spending",
       "step2_desc": "In Retirement Spending, add the monthly spending lines you want the plan to fund. Use today's money; inflation is handled by the plan assumptions.",
       "step3_title": "Add retirement income",
-      "step3_desc": "In Retirement Income, add monthly income streams such as public pensions (e.g. CPP/OAS in Canada, Social Security in the US), workplace pensions, part-time work, or annuity income. Use Add pension fund only when the planner should estimate a payout from a fund balance at 3.5%/yr unless you enter a monthly payout yourself.",
+      "step3_desc": "Add retirement income such as pensions, part-time work, or annuity income. For a pension fund, the estimated monthly payout uses its projected balance and configured annual payout rate unless you enter a monthly payout.",
       "step4_title": "Check assumptions, taxes, and account shares",
       "step4_desc": "Review projected returns, fees, volatility, inflation, withdrawal tax rates, tax buckets, and which accounts fund the goal.",
       "step5_title": "Read Overview, then open What If",
-      "step5_desc": "Overview answers whether the base plan works and shows the trajectory, spending coverage, and plan inputs. What If tests the same plan across market paths, stress tests, decision maps, and advanced checks."
+      "step5_desc": "Overview shows the base projection, spending coverage, and inputs. What If compares modeled market paths, stress scenarios, and assumption changes."
     },
     "overview": {
       "title": "Understanding Overview",
@@ -493,13 +499,13 @@
     "what_if": {
       "title": "Understanding What If",
       "market_paths_title": "Market paths",
-      "market_paths_desc": "Tests the same plan across many possible market paths using your return, volatility, and inflation assumptions. The shaded range shows bad-to-good outcomes; the line shows the middle path. Money lasts means the plan covers essential spending and still has money left through the planning horizon. In FIRE mode, the plan also needs to reach financial independence first.",
+      "market_paths_desc": "We model different market paths using your assumptions. The shading shows the 10th–90th percentile range at each age; the line shows the median across paths, not an individual path. Money lasts counts paths that cover essential spending and finish with money remaining; FIRE paths must also reach financial independence.",
       "base_case_title": "Base case",
       "base_case_desc": "Shows the same deterministic base plan as Overview, then points to the largest stress result so you can see what matters most.",
       "stress_tests_title": "Stress tests",
       "stress_tests_desc": "Fixed checks show how the plan changes if returns are lower, inflation is higher, spending rises, retirement starts earlier, savings fall, or a market crash happens near retirement.",
       "what_moves_title": "What moves the plan?",
-      "what_moves_desc": "Decision maps compare savings, returns, retirement age, and spending. Green cells leave more money at the end. Red cells still leave a gap or run short.",
+      "what_moves_desc": "Compare savings, returns, retirement age, and spending. Green means more money left than the base plan; amber means less. Red indicates a gap or no money remaining.",
       "crash_paths_title": "Early market crash paths",
       "crash_paths_desc": "Compares a few crash-timing paths near retirement. A crash in the first retirement year can hurt more than the same crash later because withdrawals happen while the portfolio is down."
     },
@@ -508,25 +514,24 @@
       "yearly_spending_title": "How yearly spending is modeled",
       "yearly_spending_desc": "Your expenses drive the withdrawal. Each year the planner funds the spending plan you entered, subtracts retirement income, and estimates any tax drag on portfolio withdrawals.",
       "target_calc_title": "How the target is calculated",
-      "target_calc_desc": "The planner computes the present value of your full spending schedule from retirement through your planning horizon — accounting for each expense bucket's inflation rate, income streams that start at different ages, and tax drag on withdrawals. When your portfolio reaches this amount, the base plan has enough capital for the schedule you entered. This is more accurate than a simple multiple of expenses because it handles varying expenses, deferred pensions, and finite horizons.",
+      "target_calc_desc": "The planner estimates the starting portfolio needed to fund the retirement spending schedule through the planning horizon. It models expense inflation, income timing, investment returns, fees, and withdrawal taxes. The target depends on these assumptions.",
       "inflation_title": "Inflation rate",
-      "inflation_desc": "All projections grow expenses and inflation-linked income at this rate year over year. The default 2% matches the ECB target.",
-      "inflation_it_note": "Use 2.5–3% for a more conservative Italian CPI assumption.",
+      "inflation_desc": "The inflation assumption increases spending and inflation-linked income over time. Individual spending and income items can use their own rates.",
       "returns_title": "Returns, fees, and volatility",
       "returns_desc": "Return before retirement drives accumulation. Return during retirement drives the withdrawal phase and required capital. Annual investment fees are subtracted from both. Volatility is used only in market-path checks — higher values produce a wider fan of outcomes.",
       "horizon_title": "Planning horizon age",
-      "horizon_desc": "How long the portfolio must last. The retirement target and What If checks run to this age. Set it to 90–95 to stress-test longevity. Early market crash paths and Money lasts are both measured at this horizon."
+      "horizon_desc": "The age through which retirement spending and What If outcomes are modeled. This is an assumption about the planning period, not a prediction of lifespan."
     },
     "italian": {
       "title": "Italian retirement setup (fondo pensione, TFR, INPS)",
       "portfolio_title": "Investment portfolio (Golden Butterfly, All-Weather…)",
       "portfolio_desc": "This is your main portfolio — the value Wealthfolio tracks. Set your return assumptions, fee drag, and monthly contribution here. It is the primary accumulation engine of your retirement plan.",
       "fondo_title": "Fondo pensione integrativo (supplementary pension fund)",
-      "fondo_desc": "Use Add pension fund. Enter the current fund balance, monthly contribution, expected fund return, and payout start age. The planner estimates the future balance and, if you do not enter a monthly payout, estimates payout as 3.5%/yr of that projected balance from the start age.",
+      "fondo_desc": "Use Add pension fund. Enter its balance, contribution, assumed return, and payout start age. Estimated payout uses the configured payout rate unless you enter a monthly payout. Drawdown payments stop when the fund is depleted; annuity payments are modeled through the planning horizon.",
       "inps_title": "Pensione INPS (state pension — previdenza obbligatoria)",
       "inps_desc": "Use Add retirement income. Enter your estimated monthly net pension in today's money and set the payout start age. Use Indexed if you want the income to rise with the plan inflation assumption.",
       "tfr_title": "TFR (Trattamento di Fine Rapporto — severance accrual)",
-      "tfr_desc": "If your TFR goes into a pension fund, include it in the monthly fund contribution. If you keep it separate, model it as another pension fund with its own balance, contribution, return, and payout start age. The same 3.5%/yr payout estimate applies unless you enter a monthly payout yourself."
+      "tfr_desc": "If TFR is included in a pension fund, include it in the fund contribution. A separate fund can represent separate TFR savings; its modeled payout follows the configured payout rate or monthly payout."
     }
   },
   "type": {
@@ -774,7 +779,7 @@
       "retirement_gap": "Retirement gap",
       "fi_moves_prefix": "FI moves",
       "fi_moves_suffix": "years later",
-      "largest_risk": "{{label}} is the largest risk",
+      "largest_risk": "{{label}} has the largest effect among these tests",
       "and": "and",
       "none": "None",
       "surplus": "surplus",
@@ -797,7 +802,10 @@
       "money_lasts_summary_traditional": "stays funded through age {{horizonAge}}",
       "money_lasts_summary_fire": "FI reached + funded through age {{horizonAge}}",
       "money_lasts_prompt_traditional": "Run 10k paths to see how often the plan stays funded through age {{horizonAge}}.",
-      "money_lasts_prompt_fire": "Run 10k paths to see how often the plan reaches FI and stays funded through age {{horizonAge}}."
+      "money_lasts_prompt_fire": "Run 10k paths to see how often the plan reaches FI and stays funded through age {{horizonAge}}.",
+      "of_simulated_paths": "of simulated paths",
+      "simulation_tooltip_traditional": "{{percent}}% of simulated paths covered essential spending and finished with money remaining. Colors use reference bands: below 75%, 75% to below 90%, and 90% or above. These are modeled results, not real-world probabilities.",
+      "simulation_tooltip_fire": "{{percent}}% of simulated paths covered essential spending and finished with money remaining. Paths must also reach financial independence. Colors use reference bands: below 75%, 75% to below 90%, and 90% or above. These are modeled results, not real-world probabilities."
     },
     "stress": {
       "eyebrow_with_count": "What could break this plan? · {{count}} scenarios",
@@ -814,7 +822,7 @@
     "montecarlo": {
       "eyebrow": "Market paths",
       "heading": "How often could the money last?",
-      "intro": "We test the same plan across many possible market paths. The shaded range shows bad-to-good outcomes; the line shows the middle path.",
+      "intro": "We model different market paths using your assumptions. The shading shows the 10th–90th percentile range at each age; the line shows the median across paths, not an individual path.",
       "run_10k": "Run 10k paths",
       "run_100k": "Run 100k paths",
       "running_short": "Running…",
@@ -826,17 +834,17 @@
       "median_fi_age": "Median FI age",
       "withdrawals_start_detail": "withdrawals start",
       "vs_goal": "vs goal {{age}}",
-      "bad_path": "Bad path",
-      "middle_path": "Middle path",
-      "good_path": "Good path"
+      "bad_path": "Lower outcome",
+      "middle_path": "Median",
+      "good_path": "Upper outcome"
     },
     "chart": {
       "age_label": "Age {{age}}",
       "age_detail": "age {{age}}",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "median FI @{{age}}",
-      "bad_good_range": "Bad-good range",
-      "median_path": "Median path",
+      "bad_good_range": "10th–90th percentile range",
+      "median_path": "Median",
       "retirement_age": "Retirement age",
       "goal_age": "Goal age",
       "median_fi_age": "Median FI age",
@@ -844,12 +852,13 @@
       "retire": "retire",
       "goal": "goal",
       "market_paths_count_one": "{{count}} market path",
-      "market_paths_count_other": "{{count}} market paths"
+      "market_paths_count_other": "{{count}} market paths",
+      "percentile_at_age": "Percentile {{percentile}} · age {{age}}"
     },
     "moves": {
       "eyebrow": "What changes the plan most?",
       "heading": "What moves the plan?",
-      "description": "Shows how savings, returns, retirement age, and spending change the outcome. Green = more money left; red = shortfall or runs short.",
+      "description": "Compare savings, returns, retirement age, and spending. Green means more money left than the base plan; amber means less. Red indicates a gap or no money remaining.",
       "empty_title": "See which changes would help most.",
       "empty_description": "Compare saving more, earning a different return, spending less, or retiring at a different age.",
       "building": "Building...",
@@ -878,6 +887,39 @@
       "unavailable_title": "Crash paths unavailable.",
       "empty_description": "Run the five paths to see which sequence would put the plan under pressure first.",
       "unavailable_description": "This check needs a positive projected portfolio at retirement start."
+    },
+    "labels": {
+      "crash_year_1": "Crash in year 1 (−30%)",
+      "crash_year_5": "Crash in year 5 (−30%)",
+      "double_crash": "Two crashes",
+      "lost_decade": "Lost decade",
+      "after_fee_return": "Return after fees"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "Lower returns",
+        "description": "Pre-retirement and retirement returns are 2 percentage points lower."
+      },
+      "inflation-shock": {
+        "label": "Higher inflation",
+        "description": "General inflation is 1.5 percentage points higher."
+      },
+      "spending-shock": {
+        "label": "Higher spending",
+        "description": "All retirement spending amounts are 10% higher."
+      },
+      "retire-earlier": {
+        "label": "Retirement 2 years earlier",
+        "description": "The target retirement age is moved two years earlier, bounded by the plan's current age."
+      },
+      "save-less": {
+        "label": "Lower contributions",
+        "description": "Monthly contributions are 25% lower."
+      },
+      "early-crash": {
+        "label": "Early market crash",
+        "description": "A 30% market drop is modeled in the first retirement year."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/es/goals.json
+++ b/apps/frontend/src/i18n/locales/es/goals.json
@@ -110,18 +110,18 @@
       "on_track": "En camino",
       "fi_reached": "IF alcanzada",
       "at_risk": "En riesgo",
-      "never_reaches_fi": "Nunca alcanza la IF",
+      "never_reaches_fi": "No se proyecta antes de los {{age}}",
       "years_late_one": "{{count}} año tarde",
       "years_late_other": "{{count}} años tarde",
       "years_late_many": "{{count}} años tarde"
     },
     "verdict": {
       "age": "edad {{age}}",
-      "spending_gap_prefix": "El déficit de gasto comienza a los",
+      "spending_gap_prefix": "Se proyecta un déficit de gastos desde",
       "spending_gap_suffix": "antes de que el plan alcance la edad {{age}}.",
-      "short_prefix": "A la edad {{age}}, te faltan",
+      "short_prefix": "A los {{age}} años, tu déficit proyectado es de",
       "short_suffix": "para financiar la jubilación hasta la edad {{age}}.",
-      "depleted_prefix": "La cartera se queda corta durante",
+      "depleted_prefix": "Se proyecta que la cartera sea insuficiente a",
       "depleted_suffix": "tras jubilarte a los {{age}}.",
       "surplus_prefix": "Se prevé que te jubiles a la edad {{age}} con",
       "surplus_suffix": "de superávit.",
@@ -130,35 +130,25 @@
       "fi_reached_prefix": "Has alcanzado la",
       "financial_independence": "independencia financiera",
       "fi_reached_suffix": "— con las suposiciones actuales.",
-      "fi_at_prefix": "Alcanzarás la independencia financiera a los",
-      "years_after_one": "{{count}} año después de",
-      "years_after_other": "{{count}} años después de",
       "years_after_many": "{{count}} años después de",
-      "years_before_one": "{{count}} año antes de",
-      "years_before_other": "{{count}} años antes de",
       "years_before_many": "{{count}} años antes de",
-      "your_goal_of": "tu objetivo de {{age}}.",
-      "right_on_goal": "justo en tu objetivo de {{age}}.",
-      "not_reachable_prefix": "No alcanzable para los",
-      "not_reachable_suffix": "con las suposiciones actuales."
+      "not_reachable_prefix": "No se proyecta antes de",
+      "not_reachable_suffix": "con las suposiciones actuales.",
+      "fi_projected": "Se proyecta que alcanzarás la independencia financiera a los <age>{{age}} años</age>."
     },
     "summary": {
-      "at_your_current_prefix": "Con tu",
-      "contribution": "aportación actual,",
-      "capital_not_available": "el capital objetivo requerido no es alcanzable con las suposiciones actuales. Revisa el gasto, la inflación, la rentabilidad y la esperanza de vida.",
-      "projected_balance_is": "el saldo de jubilación proyectado es",
-      "vs_required_capital_of": "frente al capital requerido de",
       "at_age": "a la edad {{age}}.",
-      "the_plan_funds": "el plan financia",
-      "per_yr_expenses_to_age": "/año de gastos hasta la edad {{age}}.",
-      "youre_short": "Te faltan"
+      "youre_short": "Tu déficit proyectado es de",
+      "traditional": "Según tus supuestos actuales y una aportación de <contribution>{{contribution}}</contribution>, el saldo proyectado a los {{age}} años es de <balance>{{balance}}</balance>, frente a un capital requerido de <target>{{target}}</target>.",
+      "fire": "Según tus supuestos actuales y una aportación de <contribution>{{contribution}}</contribution>, el plan incluye <budget>{{budget}}</budget>/año de gastos hasta los {{age}} años.",
+      "unavailable": "Con tus supuestos actuales y una aportación de <contribution>{{contribution}}</contribution>, no se puede estimar el objetivo de capital. Compara supuestos en Qué pasaría si."
     },
     "progress": {
       "portfolio_today": "Cartera hoy",
       "required_at_age": "Requerido a la edad {{age}}",
       "target_at_age": "Objetivo a la edad {{age}}",
-      "capital_needed_tip_traditional": "Capital necesario a tu edad de jubilación después de gastos, ingresos, impuestos, rentabilidad de la jubilación y comisiones. Mostrado en {{valueLabel}}.",
-      "capital_needed_tip_fire": "Capital necesario a tu edad de jubilación deseada después de gastos, ingresos, impuestos, rentabilidad de la jubilación y comisiones. Mostrado en {{valueLabel}}.",
+      "capital_needed_tip_traditional": "Capital estimado necesario a la edad objetivo según los supuestos de gastos, ingresos, impuestos, rentabilidades y comisiones. Se muestra en {{valueLabel}}.",
+      "capital_needed_tip_fire": "Capital estimado necesario a la edad objetivo según los supuestos de gastos, ingresos, impuestos, rentabilidades y comisiones. Se muestra en {{valueLabel}}.",
       "not_available": "No disponible",
       "funded_pct": "{{pct}}% financiado"
     },
@@ -175,18 +165,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "Deja de aportar y aun así te jubilas a tiempo",
-      "coast_tip_nominal": "Importe Coast convertido a euros nominales a tu edad de jubilación deseada.",
-      "coast_tip_real": "Capital que necesitas hoy que, sin más aportaciones, crece hasta la IF completa para tu edad de jubilación.",
+      "coast_hint": "Capital estimado necesario hoy",
+      "coast_tip_nominal": "Capital estimado necesario hoy, expresado en dinero a la edad de jubilación según la inflación supuesta. Es una conversión de valor, no crecimiento proyectado de la inversión.",
+      "coast_tip_real": "Capital estimado hoy al descontar el objetivo de jubilación con la rentabilidad supuesta antes de jubilarte, después de comisiones. Los supuestos de pensiones no cambian.",
       "lean_fire": "Lean FIRE",
       "lean_hint": "70% del gasto planificado",
-      "lean_tip": "Jubílate con un presupuesto frugal, aproximadamente el 70% de tu gasto planificado. Factible antes, pero deja poco margen.",
+      "lean_tip": "Capital estimado para el 70% de tus gastos previstos, sin cambiar los demás supuestos. Es el escenario Lean FIRE del planificador.",
       "fi": "IF",
       "fi_hint": "Gasto planificado completo",
       "fi_tip": "Capital que financia tu gasto de jubilación planificado durante todo el horizonte de jubilación.",
       "fat_fire": "Fat FIRE",
       "fat_hint": "150% del gasto planificado",
-      "fat_tip": "Jubílate con ~50% más de gasto del planificado: margen para viajes, regalos, volatilidad y mejoras en el estilo de vida.",
+      "fat_tip": "Capital estimado para el 150% de tus gastos previstos, sin cambiar los demás supuestos. Es el escenario Fat FIRE del planificador.",
       "more_info_about": "Más información sobre {{label}}",
       "done": "HECHO"
     },
@@ -223,11 +213,26 @@
       "unfunded": "Sin financiar",
       "planned_spending_legend": "Gasto planificado",
       "showing": "Mostrando {{valueLabel}}",
-      "projection_unavailable": "La proyección de cobertura no está disponible para este plan."
+      "projection_unavailable": "La proyección de cobertura no está disponible para este plan.",
+      "age_range": "Edad {{start}} → {{end}}",
+      "starts_at": "Comienza a los {{age}}",
+      "ended_at": "Terminó a los {{age}}",
+      "not_active": "No activo"
     },
     "disclaimer": {
       "title": "Algo a tener en cuenta",
-      "body": "Esto no es asesoramiento financiero. Considera estas cifras como un esbozo, no como una previsión. Todo lo que aquí aparece es una simulación construida sobre los datos que introdujiste: rentabilidad, inflación, aportaciones, impuestos y cuánto tiempo esperas vivir. Los mercados reales no se mueven en línea recta, las normas fiscales cambian y los programas gubernamentales se reescriben. Usa esto para poner a prueba ideas y detectar carencias, y luego consulta con un profesional cualificado antes de tomar decisiones difíciles de deshacer."
+      "body": "Las proyecciones dependen de tus supuestos. Los resultados reales pueden variar. No es asesoramiento financiero."
+    },
+    "guidance": {
+      "unavailable": "No se puede estimar el objetivo con los supuestos actuales. Compara supuestos en Qué pasaría si.",
+      "depleted": "Se proyecta que la cartera no alcance a partir de los {{age}} años. Compara supuestos en Qué pasaría si.",
+      "gap": "Se proyecta un déficit de gastos a partir de los {{age}} años. Compara supuestos en Qué pasaría si.",
+      "fund": "Se proyecta que {{label}} se agote a los {{age}} años; los pagos modelados cesan entonces. Compara los supuestos de pagos e ingresos.",
+      "shortfall": "Se proyecta un déficit al jubilarte. Compara supuestos en Qué pasaría si.",
+      "reached": "La cartera actual alcanza el objetivo estimado de independencia financiera según tus supuestos.",
+      "not_reached": "No se proyecta alcanzar la independencia financiera antes de los {{age}} años. Compara supuestos en Qué pasaría si.",
+      "late_one": "Se proyecta alcanzar la independencia financiera {{count}} año después de la edad deseada. Compara supuestos en Qué pasaría si.",
+      "late_other": "Se proyecta alcanzar la independencia financiera {{count}} años después de la edad deseada. Compara supuestos en Qué pasaría si."
     }
   },
   "sidebar": {
@@ -237,7 +242,8 @@
       "high_inflation": "Suposición de inflación alta. Las necesidades de gasto a largo plazo se vuelven más sensibles a esta tasa.",
       "high_fee": "Suposición de comisiones altas. El lastre de las comisiones reduce notablemente la rentabilidad a largo plazo.",
       "high_volatility": "Suposición de volatilidad alta. Los rangos de resultados pueden volverse muy amplios.",
-      "high_contribution_growth": "Suposición de crecimiento de aportación alto. Esto supone aumentos de ahorro grandes y sostenidos."
+      "high_contribution_growth": "Suposición de crecimiento de aportación alto. Esto supone aumentos de ahorro grandes y sostenidos.",
+      "high_return": "Supuesto de rentabilidad alta. Los saldos proyectados son sensibles a esta tasa."
     },
     "plan": {
       "kicker": "Plan",
@@ -258,14 +264,14 @@
       "desired_retirement_age_hint": "Edad a la que quieres ser financieramente independiente.",
       "retirement_age_hint": "Edad a la que quieres jubilarte.",
       "horizon_age_fire": "Horizonte del plan",
-      "horizon_age_traditional": "Esperanza de vida",
+      "horizon_age_traditional": "Horizonte del plan",
       "horizon_hint": "Edad hasta la que debe cubrir el plan.",
       "monthly_contribution": "Aportación mensual",
       "monthly_contribution_hint": "Cuánto añades cada mes hasta la jubilación.",
-      "return_before_hint": "Rentabilidad anual esperada mientras ahorras.",
-      "return_during_hint": "Rentabilidad anual esperada tras comenzar las retiradas.",
+      "return_before_hint": "Rentabilidad anual supuesta durante el ahorro, antes de comisiones.",
+      "return_during_hint": "Rentabilidad anual supuesta tras comenzar los retiros, antes de comisiones.",
       "annual_fee_hint": "Comisiones anuales estimadas de la cartera.",
-      "inflation_hint": "Aumento anual esperado de los precios."
+      "inflation_hint": "Aumento anual supuesto de los precios."
     },
     "spending": {
       "kicker": "Gasto",
@@ -326,13 +332,13 @@
       "fund_return_before_payout": "Rentabilidad del fondo antes del pago",
       "fund_payout_rate": "Tasa de pago",
       "fund_payout_mode": "Modo de pago",
-      "fund_payout_mode_help": "Una anualidad paga de por vida; un retiro programado consume el fondo hasta agotarlo.",
+      "fund_payout_mode_help": "La renta vitalicia modela pagos hasta el horizonte del plan; los retiros usan el saldo del fondo hasta agotarlo.",
       "annuity": "Anualidad",
       "drawdown": "Retiro programado",
       "fund_return_during_payout": "Rentabilidad del fondo durante el pago",
-      "drawdown_note": "El retiro utiliza el {{pct}}%/año del saldo a la edad de inicio y luego sigue el ajuste de crecimiento de abajo hasta agotar el fondo.",
+      "drawdown_note": "Los retiros se estiman en el {{pct}}% anual del saldo del fondo. Si los pagos ya han comenzado, prevalece el importe mensual introducido. Después, los pagos siguen el ajuste de crecimiento hasta agotar el fondo.",
       "monthly_payout_after_tax": "Pago mensual después de impuestos",
-      "payout_estimate_note": "El pago estimado utiliza el {{pct}}%/año del saldo proyectado del fondo salvo que introduzcas un pago mensual.",
+      "payout_estimate_note": "El pago estimado utiliza el {{pct}}% anual del saldo del fondo. Si los pagos ya han comenzado, prevalece el importe mensual introducido.",
       "start_age": "Edad de inicio",
       "income_growth": "Crecimiento del ingreso",
       "income_growth_help": "Elige si este ingreso crece con la inflación del plan o se mantiene fijo.",
@@ -471,15 +477,15 @@
     "quick_start": {
       "title": "Inicio rápido — 5 pasos",
       "step1_title": "Define los datos básicos del plan",
-      "step1_desc": "En Datos del plan, elige el tipo de plan, el mes de nacimiento, la edad de jubilación, la esperanza de vida y la aportación mensual.",
+      "step1_desc": "En los datos del plan, define el tipo, mes de nacimiento, edad de jubilación, horizonte y aportación mensual.",
       "step2_title": "Introduce el gasto de jubilación",
       "step2_desc": "En Gasto de jubilación, añade las líneas de gasto mensual que quieres que el plan financie. Usa dinero de hoy; la inflación la gestionan las suposiciones del plan.",
       "step3_title": "Añade ingresos de jubilación",
-      "step3_desc": "En Ingresos de jubilación, añade flujos de ingresos mensuales como pensiones públicas (p. ej. CPP/OAS en Canadá, Seguridad Social en EE. UU.), pensiones de empresa, trabajo a tiempo parcial o rentas vitalicias. Usa Añadir fondo de pensiones solo cuando el planificador deba estimar un pago a partir del saldo de un fondo al 3,5%/año salvo que introduzcas tú mismo un pago mensual.",
+      "step3_desc": "Añade ingresos de jubilación como pensiones, trabajo a tiempo parcial o rentas vitalicias. En un fondo de pensiones, el pago mensual estimado usa el saldo proyectado y la tasa anual configurada, salvo que introduzcas un pago mensual.",
       "step4_title": "Revisa suposiciones, impuestos y participaciones de cuenta",
       "step4_desc": "Revisa las rentabilidades proyectadas, las comisiones, la volatilidad, la inflación, las tasas impositivas por retirada, los bloques fiscales y qué cuentas financian el objetivo.",
       "step5_title": "Lee Resumen y luego abre Qué pasaría si",
-      "step5_desc": "Resumen responde si el plan base funciona y muestra la trayectoria, la cobertura del gasto y los datos del plan. Qué pasaría si prueba el mismo plan en distintas trayectorias de mercado, pruebas de estrés, mapas de decisiones y comprobaciones avanzadas."
+      "step5_desc": "La vista general muestra la proyección base, cobertura de gastos y datos. Las simulaciones comparan trayectorias de mercado, escenarios de estrés y cambios de supuestos."
     },
     "overview": {
       "title": "Entender Resumen",
@@ -499,13 +505,13 @@
     "what_if": {
       "title": "Entender Qué pasaría si",
       "market_paths_title": "Trayectorias de mercado",
-      "market_paths_desc": "Prueba el mismo plan en muchas trayectorias de mercado posibles utilizando tus suposiciones de rentabilidad, volatilidad e inflación. El rango sombreado muestra los resultados de malo a bueno; la línea muestra la trayectoria intermedia. El dinero dura significa que el plan cubre el gasto esencial y aún queda dinero durante el horizonte de planificación. En modo FIRE, el plan también debe alcanzar primero la independencia financiera.",
+      "market_paths_desc": "Modelamos distintas trayectorias de mercado con tus supuestos. El sombreado muestra los percentiles 10–90 a cada edad; la línea muestra la mediana entre trayectorias, no una trayectoria individual. Se cuentan las trayectorias que cubren gastos esenciales y terminan con dinero restante; las de FIRE también deben alcanzar la independencia financiera.",
       "base_case_title": "Caso base",
       "base_case_desc": "Muestra el mismo plan base determinista que Resumen, y luego señala el mayor resultado de estrés para que veas lo que más importa.",
       "stress_tests_title": "Pruebas de estrés",
       "stress_tests_desc": "Comprobaciones fijas que muestran cómo cambia el plan si las rentabilidades son más bajas, la inflación es más alta, el gasto sube, la jubilación empieza antes, el ahorro cae o ocurre una caída de mercado cerca de la jubilación.",
       "what_moves_title": "¿Qué mueve el plan?",
-      "what_moves_desc": "Los mapas de decisiones comparan el ahorro, las rentabilidades, la edad de jubilación y el gasto. Las celdas verdes dejan más dinero al final. Las celdas rojas siguen dejando un déficit o se quedan cortas.",
+      "what_moves_desc": "Compara ahorro, rentabilidades, edad de jubilación y gastos. Verde indica más dinero final que el plan base; ámbar, menos. Rojo indica un déficit o ningún dinero restante.",
       "crash_paths_title": "Trayectorias de caída temprana del mercado",
       "crash_paths_desc": "Compara varias trayectorias según el momento de la caída cerca de la jubilación. Una caída en el primer año de jubilación puede perjudicar más que la misma caída más tarde, porque las retiradas ocurren mientras la cartera está a la baja."
     },
@@ -514,25 +520,24 @@
       "yearly_spending_title": "Cómo se modela el gasto anual",
       "yearly_spending_desc": "Tus gastos impulsan la retirada. Cada año el planificador financia el plan de gasto que introdujiste, resta los ingresos de jubilación y estima cualquier lastre fiscal sobre las retiradas de la cartera.",
       "target_calc_title": "Cómo se calcula el objetivo",
-      "target_calc_desc": "El planificador calcula el valor presente de todo tu calendario de gastos desde la jubilación hasta tu horizonte de planificación, teniendo en cuenta la tasa de inflación de cada bloque de gasto, los flujos de ingresos que comienzan a distintas edades y el lastre fiscal sobre las retiradas. Cuando tu cartera alcanza este importe, el plan base tiene suficiente capital para el calendario que introdujiste. Esto es más preciso que un simple múltiplo de los gastos porque gestiona gastos variables, pensiones diferidas y horizontes finitos.",
+      "target_calc_desc": "El planificador estima la cartera inicial necesaria para financiar los gastos de jubilación hasta el horizonte del plan. Modela inflación de gastos, fechas de ingresos, rentabilidades, comisiones e impuestos sobre retiros. El objetivo depende de estos supuestos.",
       "inflation_title": "Tasa de inflación",
-      "inflation_desc": "Todas las proyecciones aumentan los gastos y los ingresos ligados a la inflación a esta tasa año tras año. El valor predeterminado del 2% coincide con el objetivo del BCE.",
-      "inflation_it_note": "Usa 2,5–3% para una suposición de IPC italiano más conservadora.",
+      "inflation_desc": "El supuesto de inflación aumenta los gastos y los ingresos indexados con el tiempo. Cada partida puede usar su propia tasa.",
       "returns_title": "Rentabilidades, comisiones y volatilidad",
       "returns_desc": "La rentabilidad antes de la jubilación impulsa la acumulación. La rentabilidad durante la jubilación impulsa la fase de retirada y el capital requerido. Las comisiones de inversión anuales se restan de ambas. La volatilidad solo se usa en las comprobaciones de trayectorias de mercado: valores más altos producen un abanico de resultados más amplio.",
       "horizon_title": "Edad del horizonte de planificación",
-      "horizon_desc": "Cuánto tiempo debe durar la cartera. El objetivo de jubilación y las comprobaciones de Qué pasaría si llegan hasta esta edad. Ponla en 90–95 para poner a prueba la longevidad. Las trayectorias de caída temprana del mercado y El dinero dura se miden ambas en este horizonte."
+      "horizon_desc": "Edad hasta la que se modelan los gastos de jubilación y los resultados de Qué pasaría si. Es un supuesto del periodo de planificación, no una predicción de longevidad."
     },
     "italian": {
       "title": "Configuración de jubilación italiana (fondo pensione, TFR, INPS)",
       "portfolio_title": "Cartera de inversión (Golden Butterfly, All-Weather…)",
       "portfolio_desc": "Esta es tu cartera principal, el valor que Wealthfolio sigue. Define aquí tus suposiciones de rentabilidad, el lastre de comisiones y la aportación mensual. Es el principal motor de acumulación de tu plan de jubilación.",
       "fondo_title": "Fondo pensione integrativo (fondo de pensiones complementario)",
-      "fondo_desc": "Usa Añadir fondo de pensiones. Introduce el saldo actual del fondo, la aportación mensual, la rentabilidad esperada del fondo y la edad de inicio del pago. El planificador estima el saldo futuro y, si no introduces un pago mensual, estima el pago como el 3,5%/año de ese saldo proyectado desde la edad de inicio.",
+      "fondo_desc": "Usa Añadir fondo de pensiones. Introduce saldo, aportación, rentabilidad supuesta y edad de inicio de pagos. La estimación usa la tasa de pago configurada salvo que indiques un importe mensual. Los retiros cesan al agotarse el fondo; las rentas vitalicias se modelan hasta el horizonte del plan.",
       "inps_title": "Pensione INPS (pensión estatal — previdenza obbligatoria)",
       "inps_desc": "Usa Añadir ingreso de jubilación. Introduce tu pensión neta mensual estimada en dinero de hoy y define la edad de inicio del pago. Usa Indexado si quieres que el ingreso aumente con la suposición de inflación del plan.",
       "tfr_title": "TFR (Trattamento di Fine Rapporto — indemnización acumulada)",
-      "tfr_desc": "Si tu TFR va a un fondo de pensiones, inclúyelo en la aportación mensual al fondo. Si lo mantienes por separado, modélalo como otro fondo de pensiones con su propio saldo, aportación, rentabilidad y edad de inicio del pago. Se aplica la misma estimación de pago del 3,5%/año salvo que introduzcas tú mismo un pago mensual."
+      "tfr_desc": "Si el TFR se destina a un fondo de pensiones, inclúyelo en la aportación. Un fondo separado puede representar el ahorro TFR independiente; sus pagos modelados siguen la tasa o el importe mensual configurado."
     }
   },
   "type": {
@@ -783,7 +788,7 @@
       "retirement_gap": "Déficit de jubilación",
       "fi_moves_prefix": "La IF se mueve",
       "fi_moves_suffix": "años más tarde",
-      "largest_risk": "{{label}} es el mayor riesgo",
+      "largest_risk": "{{label}} tiene el mayor efecto entre estas pruebas",
       "and": "y",
       "none": "Ninguno",
       "surplus": "superávit",
@@ -807,7 +812,10 @@
       "money_lasts_summary_traditional": "se mantiene financiado hasta la edad {{horizonAge}}",
       "money_lasts_summary_fire": "IF alcanzada + financiado hasta la edad {{horizonAge}}",
       "money_lasts_prompt_traditional": "Ejecuta 10k trayectorias para ver con qué frecuencia el plan se mantiene financiado hasta la edad {{horizonAge}}.",
-      "money_lasts_prompt_fire": "Ejecuta 10k trayectorias para ver con qué frecuencia el plan alcanza la IF y se mantiene financiado hasta la edad {{horizonAge}}."
+      "money_lasts_prompt_fire": "Ejecuta 10k trayectorias para ver con qué frecuencia el plan alcanza la IF y se mantiene financiado hasta la edad {{horizonAge}}.",
+      "of_simulated_paths": "de las trayectorias simuladas",
+      "simulation_tooltip_traditional": "El {{percent}}% de las trayectorias simuladas cubre los gastos esenciales y termina con dinero restante. Los colores usan bandas de referencia: menos del 75%, del 75% a menos del 90%, y 90% o más. Son resultados modelados, no probabilidades del mundo real.",
+      "simulation_tooltip_fire": "El {{percent}}% de las trayectorias simuladas cubre los gastos esenciales y termina con dinero restante. Las trayectorias también deben alcanzar la independencia financiera. Los colores usan bandas de referencia: menos del 75%, del 75% a menos del 90%, y 90% o más. Son resultados modelados, no probabilidades del mundo real."
     },
     "stress": {
       "eyebrow_with_count": "¿Qué podría romper este plan? · {{count}} escenarios",
@@ -825,7 +833,7 @@
     "montecarlo": {
       "eyebrow": "Trayectorias de mercado",
       "heading": "¿Con qué frecuencia podría durar el dinero?",
-      "intro": "Probamos el mismo plan en muchas trayectorias de mercado posibles. El rango sombreado muestra los resultados de malo a bueno; la línea muestra la trayectoria intermedia.",
+      "intro": "Modelamos distintas trayectorias de mercado con tus supuestos. El sombreado muestra los percentiles 10–90 a cada edad; la línea muestra la mediana entre trayectorias, no una trayectoria individual.",
       "run_10k": "Ejecutar 10k trayectorias",
       "run_100k": "Ejecutar 100k trayectorias",
       "running_short": "Ejecutando…",
@@ -837,17 +845,17 @@
       "median_fi_age": "Edad mediana de IF",
       "withdrawals_start_detail": "comienzan las retiradas",
       "vs_goal": "frente al objetivo {{age}}",
-      "bad_path": "Trayectoria mala",
-      "middle_path": "Trayectoria intermedia",
-      "good_path": "Trayectoria buena"
+      "bad_path": "Resultado inferior",
+      "middle_path": "Mediana",
+      "good_path": "Resultado superior"
     },
     "chart": {
       "age_label": "Edad {{age}}",
       "age_detail": "edad {{age}}",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "IF mediana @{{age}}",
-      "bad_good_range": "Rango malo-bueno",
-      "median_path": "Trayectoria mediana",
+      "bad_good_range": "Rango de percentiles 10–90",
+      "median_path": "Mediana",
       "retirement_age": "Edad de jubilación",
       "goal_age": "Edad objetivo",
       "median_fi_age": "Edad mediana de IF",
@@ -856,12 +864,13 @@
       "goal": "objetivo",
       "market_paths_count_one": "{{count}} trayectoria de mercado",
       "market_paths_count_other": "{{count}} trayectorias de mercado",
-      "market_paths_count_many": "{{count}} trayectorias de mercado"
+      "market_paths_count_many": "{{count}} trayectorias de mercado",
+      "percentile_at_age": "Percentil {{percentile}} · edad {{age}}"
     },
     "moves": {
       "eyebrow": "¿Qué cambia más el plan?",
       "heading": "¿Qué mueve el plan?",
-      "description": "Muestra cómo el ahorro, las rentabilidades, la edad de jubilación y el gasto cambian el resultado. Verde = más dinero restante; rojo = déficit o se queda corto.",
+      "description": "Compara ahorro, rentabilidades, edad de jubilación y gastos. Verde indica más dinero final que el plan base; ámbar, menos. Rojo indica un déficit o ningún dinero restante.",
       "empty_title": "Descubre qué cambios ayudarían más.",
       "empty_description": "Compara ahorrar más, obtener una rentabilidad diferente, gastar menos o jubilarte a una edad distinta.",
       "building": "Construyendo...",
@@ -890,6 +899,39 @@
       "unavailable_title": "Trayectorias de caída no disponibles.",
       "empty_description": "Ejecuta las cinco trayectorias para ver qué secuencia pondría el plan bajo presión antes.",
       "unavailable_description": "Esta comprobación necesita una cartera proyectada positiva al inicio de la jubilación."
+    },
+    "labels": {
+      "crash_year_1": "Caída en el año 1 (−30%)",
+      "crash_year_5": "Caída en el año 5 (−30%)",
+      "double_crash": "Dos caídas",
+      "lost_decade": "Década perdida",
+      "after_fee_return": "Rentabilidad tras comisiones"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "Menores rentabilidades",
+        "description": "Las rentabilidades antes y durante la jubilación son 2 puntos porcentuales menores."
+      },
+      "inflation-shock": {
+        "label": "Mayor inflación",
+        "description": "La inflación general es 1,5 puntos porcentuales mayor."
+      },
+      "spending-shock": {
+        "label": "Mayores gastos",
+        "description": "Todos los importes de gastos de jubilación son un 10% mayores."
+      },
+      "retire-earlier": {
+        "label": "Jubilación 2 años antes",
+        "description": "La edad objetivo se adelanta dos años, limitada por la edad actual del plan."
+      },
+      "save-less": {
+        "label": "Menores aportaciones",
+        "description": "Las aportaciones mensuales son un 25% menores."
+      },
+      "early-crash": {
+        "label": "Caída temprana del mercado",
+        "description": "Se modela una caída del mercado del 30% en el primer año de jubilación."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/es/goals.json
+++ b/apps/frontend/src/i18n/locales/es/goals.json
@@ -130,8 +130,6 @@
       "fi_reached_prefix": "Has alcanzado la",
       "financial_independence": "independencia financiera",
       "fi_reached_suffix": "— con las suposiciones actuales.",
-      "years_after_many": "{{count}} años después de",
-      "years_before_many": "{{count}} años antes de",
       "not_reachable_prefix": "No se proyecta antes de",
       "not_reachable_suffix": "con las suposiciones actuales.",
       "fi_projected": "Se proyecta que alcanzarás la independencia financiera a los <age>{{age}} años</age>."
@@ -232,7 +230,8 @@
       "reached": "La cartera actual alcanza el objetivo estimado de independencia financiera según tus supuestos.",
       "not_reached": "No se proyecta alcanzar la independencia financiera antes de los {{age}} años. Compara supuestos en Qué pasaría si.",
       "late_one": "Se proyecta alcanzar la independencia financiera {{count}} año después de la edad deseada. Compara supuestos en Qué pasaría si.",
-      "late_other": "Se proyecta alcanzar la independencia financiera {{count}} años después de la edad deseada. Compara supuestos en Qué pasaría si."
+      "late_other": "Se proyecta alcanzar la independencia financiera {{count}} años después de la edad deseada. Compara supuestos en Qué pasaría si.",
+      "late_many": "Se proyecta alcanzar la independencia financiera {{count}} años después de la edad deseada. Compara supuestos en Qué pasaría si."
     }
   },
   "sidebar": {

--- a/apps/frontend/src/i18n/locales/fr/goals.json
+++ b/apps/frontend/src/i18n/locales/fr/goals.json
@@ -130,8 +130,6 @@
       "fi_reached_prefix": "Vous avez atteint",
       "financial_independence": "l’indépendance financière",
       "fi_reached_suffix": "— avec les hypothèses actuelles.",
-      "years_after_many": "{{count}} ans après",
-      "years_before_many": "{{count}} ans avant",
       "not_reachable_prefix": "Non projetée avant",
       "not_reachable_suffix": "avec les hypothèses actuelles.",
       "fi_projected": "Selon les projections, vous atteindrez l’indépendance financière à <age>{{age}} ans</age>."
@@ -232,7 +230,8 @@
       "reached": "Le portefeuille actuel atteint la cible estimée d’indépendance financière selon vos hypothèses.",
       "not_reached": "L’indépendance financière n’est pas projetée avant {{age}} ans. Comparez les hypothèses dans Simulation.",
       "late_one": "L’indépendance financière est projetée {{count}} an après l’âge souhaité. Comparez les hypothèses dans Simulation.",
-      "late_other": "L’indépendance financière est projetée {{count}} ans après l’âge souhaité. Comparez les hypothèses dans Simulation."
+      "late_other": "L’indépendance financière est projetée {{count}} ans après l’âge souhaité. Comparez les hypothèses dans Simulation.",
+      "late_many": "L’indépendance financière est projetée {{count}} ans après l’âge souhaité. Comparez les hypothèses dans Simulation."
     }
   },
   "sidebar": {

--- a/apps/frontend/src/i18n/locales/fr/goals.json
+++ b/apps/frontend/src/i18n/locales/fr/goals.json
@@ -110,18 +110,18 @@
       "on_track": "Sur la bonne voie",
       "fi_reached": "IF atteinte",
       "at_risk": "À risque",
-      "never_reaches_fi": "N’atteint jamais l’IF",
+      "never_reaches_fi": "Non projetée avant {{age}} ans",
       "years_late_one": "{{count}} an de retard",
       "years_late_other": "{{count}} ans de retard",
       "years_late_many": "{{count}} ans de retard"
     },
     "verdict": {
       "age": "âge {{age}}",
-      "spending_gap_prefix": "L’écart de dépenses commence à",
+      "spending_gap_prefix": "Un déficit de dépenses est projeté à partir de",
       "spending_gap_suffix": "avant que le plan n’atteigne l’âge de {{age}} ans.",
-      "short_prefix": "À {{age}} ans, il vous manque",
+      "short_prefix": "À {{age}} ans, votre déficit projeté est de",
       "short_suffix": "pour financer la retraite jusqu’à {{age}} ans.",
-      "depleted_prefix": "Le portefeuille s’épuise vers",
+      "depleted_prefix": "Le portefeuille devrait manquer de fonds à",
       "depleted_suffix": "après un départ à la retraite à {{age}} ans.",
       "surplus_prefix": "Vous devriez partir à la retraite à {{age}} ans avec",
       "surplus_suffix": "d’excédent.",
@@ -130,35 +130,25 @@
       "fi_reached_prefix": "Vous avez atteint",
       "financial_independence": "l’indépendance financière",
       "fi_reached_suffix": "— avec les hypothèses actuelles.",
-      "fi_at_prefix": "Vous atteindrez l’indépendance financière à",
-      "years_after_one": "{{count}} an après",
-      "years_after_other": "{{count}} ans après",
       "years_after_many": "{{count}} ans après",
-      "years_before_one": "{{count}} an avant",
-      "years_before_other": "{{count}} ans avant",
       "years_before_many": "{{count}} ans avant",
-      "your_goal_of": "votre objectif de {{age}} ans.",
-      "right_on_goal": "pile sur votre objectif de {{age}} ans.",
-      "not_reachable_prefix": "Inatteignable avant",
-      "not_reachable_suffix": "avec les hypothèses actuelles."
+      "not_reachable_prefix": "Non projetée avant",
+      "not_reachable_suffix": "avec les hypothèses actuelles.",
+      "fi_projected": "Selon les projections, vous atteindrez l’indépendance financière à <age>{{age}} ans</age>."
     },
     "summary": {
-      "at_your_current_prefix": "À votre",
-      "contribution": "de cotisation actuelle,",
-      "capital_not_available": "l’objectif de capital requis n’est pas atteignable avec les hypothèses actuelles. Révisez les dépenses, l’inflation, les rendements et l’espérance de vie.",
-      "projected_balance_is": "le solde de retraite projeté est de",
-      "vs_required_capital_of": "contre un capital requis de",
       "at_age": "à {{age}} ans.",
-      "the_plan_funds": "le plan finance",
-      "per_yr_expenses_to_age": "/an de dépenses jusqu’à {{age}} ans.",
-      "youre_short": "Il vous manque"
+      "youre_short": "Votre déficit projeté est de",
+      "traditional": "Selon vos hypothèses actuelles et une cotisation de <contribution>{{contribution}}</contribution>, votre solde projeté à {{age}} ans est de <balance>{{balance}}</balance>, contre un capital requis de <target>{{target}}</target>.",
+      "fire": "Selon vos hypothèses actuelles et une cotisation de <contribution>{{contribution}}</contribution>, le plan prévoit <budget>{{budget}}</budget>/an de dépenses jusqu’à {{age}} ans.",
+      "unavailable": "Avec vos hypothèses actuelles et une cotisation de <contribution>{{contribution}}</contribution>, la cible de capital ne peut pas être estimée. Comparez les hypothèses dans Simulation."
     },
     "progress": {
       "portfolio_today": "Portefeuille aujourd’hui",
       "required_at_age": "Requis à {{age}} ans",
       "target_at_age": "Cible à {{age}} ans",
-      "capital_needed_tip_traditional": "Capital nécessaire à votre âge de départ à la retraite, après dépenses, revenus, impôts, rendements de retraite et frais. Affiché en {{valueLabel}}.",
-      "capital_needed_tip_fire": "Capital nécessaire à votre âge de retraite souhaité, après dépenses, revenus, impôts, rendements de retraite et frais. Affiché en {{valueLabel}}.",
+      "capital_needed_tip_traditional": "Capital estimé nécessaire à l’âge de retraite cible selon les hypothèses de dépenses, revenus, impôts, rendements et frais du plan. Affiché en {{valueLabel}}.",
+      "capital_needed_tip_fire": "Capital estimé nécessaire à l’âge de retraite cible selon les hypothèses de dépenses, revenus, impôts, rendements et frais du plan. Affiché en {{valueLabel}}.",
       "not_available": "Non disponible",
       "funded_pct": "{{pct}} % financé"
     },
@@ -175,18 +165,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "Arrêtez de cotiser, partez quand même à temps",
-      "coast_tip_nominal": "Montant Coast converti en dollars nominaux à votre âge de retraite souhaité.",
-      "coast_tip_real": "Capital nécessaire aujourd’hui qui — sans aucune cotisation supplémentaire — croît jusqu’à l’IF complète à votre âge de retraite.",
+      "coast_hint": "Capital estimé nécessaire aujourd’hui",
+      "coast_tip_nominal": "Capital estimé nécessaire aujourd’hui, exprimé en monnaie à l’âge de la retraite selon l’inflation supposée. Il s’agit d’une conversion de valeur, pas d’une croissance projetée des placements.",
+      "coast_tip_real": "Capital estimé aujourd’hui en actualisant la cible de retraite au rendement supposé avant la retraite, après frais. Les hypothèses de pension restent inchangées.",
       "lean_fire": "Lean FIRE",
       "lean_hint": "70 % des dépenses prévues",
-      "lean_tip": "Partir à la retraite avec un budget frugal — environ 70 % de vos dépenses prévues. Réalisable plus tôt mais laisse peu de marge.",
+      "lean_tip": "Capital estimé pour 70 % de vos dépenses prévues, les autres hypothèses restant inchangées. Il s’agit du scénario Lean FIRE du planificateur.",
       "fi": "IF",
       "fi_hint": "Dépenses prévues complètes",
       "fi_tip": "Capital qui finance vos dépenses de retraite prévues sur tout l’horizon de retraite.",
       "fat_fire": "Fat FIRE",
       "fat_hint": "150 % des dépenses prévues",
-      "fat_tip": "Partir à la retraite avec environ 50 % de dépenses de plus que prévu — de la marge pour les voyages, les cadeaux, la volatilité et l’amélioration du niveau de vie.",
+      "fat_tip": "Capital estimé pour 150 % de vos dépenses prévues, les autres hypothèses restant inchangées. Il s’agit du scénario Fat FIRE du planificateur.",
       "more_info_about": "Plus d’infos sur {{label}}",
       "done": "ATTEINT"
     },
@@ -223,11 +213,26 @@
       "unfunded": "Non financé",
       "planned_spending_legend": "Dépenses prévues",
       "showing": "Affichage en {{valueLabel}}",
-      "projection_unavailable": "La projection de couverture n’est pas disponible pour ce plan."
+      "projection_unavailable": "La projection de couverture n’est pas disponible pour ce plan.",
+      "age_range": "Âge {{start}} → {{end}}",
+      "starts_at": "Débute à {{age}} ans",
+      "ended_at": "Terminé à {{age}} ans",
+      "not_active": "Inactif"
     },
     "disclaimer": {
       "title": "Une chose à garder à l’esprit",
-      "body": "Ceci n’est pas un conseil financier. Considérez ces chiffres comme une esquisse, pas une prévision. Tout ici est une simulation fondée sur les données que vous avez saisies : rendements, inflation, cotisations, impôts et durée de vie estimée. Les marchés réels n’évoluent pas en ligne droite, les règles fiscales changent et les programmes publics sont réécrits. Utilisez ceci pour tester des idées et repérer des lacunes, puis parlez à un professionnel qualifié avant de prendre des décisions difficiles à annuler."
+      "body": "Les projections dépendent de vos hypothèses. Les résultats réels peuvent différer. Ceci ne constitue pas un conseil financier."
+    },
+    "guidance": {
+      "unavailable": "La cible ne peut pas être estimée avec les hypothèses actuelles. Comparez les hypothèses dans Simulation.",
+      "depleted": "Le portefeuille devrait manquer de fonds à {{age}} ans selon les projections. Comparez les hypothèses dans Simulation.",
+      "gap": "Un déficit de financement des dépenses est projeté à partir de {{age}} ans. Comparez les hypothèses dans Simulation.",
+      "fund": "{{label}} devrait être épuisé à {{age}} ans ; les versements modélisés cessent alors. Comparez les hypothèses de versement et de revenu.",
+      "shortfall": "Un déficit est projeté à la retraite. Comparez les hypothèses dans Simulation.",
+      "reached": "Le portefeuille actuel atteint la cible estimée d’indépendance financière selon vos hypothèses.",
+      "not_reached": "L’indépendance financière n’est pas projetée avant {{age}} ans. Comparez les hypothèses dans Simulation.",
+      "late_one": "L’indépendance financière est projetée {{count}} an après l’âge souhaité. Comparez les hypothèses dans Simulation.",
+      "late_other": "L’indépendance financière est projetée {{count}} ans après l’âge souhaité. Comparez les hypothèses dans Simulation."
     }
   },
   "sidebar": {
@@ -237,7 +242,8 @@
       "high_inflation": "Hypothèse d’inflation élevée. Les besoins de dépenses à long terme deviennent plus sensibles à ce taux.",
       "high_fee": "Hypothèse de frais élevés. Les frais réduisent sensiblement les rendements à long terme.",
       "high_volatility": "Hypothèse de volatilité élevée. Les plages de résultats peuvent devenir très larges.",
-      "high_contribution_growth": "Hypothèse de forte croissance des cotisations. Cela suppose des hausses d’épargne importantes et soutenues."
+      "high_contribution_growth": "Hypothèse de forte croissance des cotisations. Cela suppose des hausses d’épargne importantes et soutenues.",
+      "high_return": "Hypothèse de rendement élevé. Les soldes projetés sont sensibles à ce taux."
     },
     "plan": {
       "kicker": "Plan",
@@ -258,14 +264,14 @@
       "desired_retirement_age_hint": "Âge auquel vous voulez devenir financièrement indépendant.",
       "retirement_age_hint": "Âge auquel vous voulez prendre votre retraite.",
       "horizon_age_fire": "Horizon du plan",
-      "horizon_age_traditional": "Espérance de vie",
+      "horizon_age_traditional": "Horizon du plan",
       "horizon_hint": "Âge que le plan doit couvrir.",
       "monthly_contribution": "Cotisation mensuelle",
       "monthly_contribution_hint": "Combien vous ajoutez chaque mois jusqu’à la retraite.",
-      "return_before_hint": "Rendement annuel attendu pendant que vous épargnez.",
-      "return_during_hint": "Rendement annuel attendu après le début des retraits.",
+      "return_before_hint": "Rendement annuel supposé pendant l’épargne, avant frais de placement.",
+      "return_during_hint": "Rendement annuel supposé après le début des retraits, avant frais de placement.",
       "annual_fee_hint": "Frais annuels estimés du portefeuille.",
-      "inflation_hint": "Augmentation annuelle attendue des prix."
+      "inflation_hint": "Hausse annuelle supposée des prix."
     },
     "spending": {
       "kicker": "Dépenses",
@@ -326,13 +332,13 @@
       "fund_return_before_payout": "Rendement du fonds avant versement",
       "fund_payout_rate": "Taux de versement",
       "fund_payout_mode": "Mode de versement",
-      "fund_payout_mode_help": "Une rente verse à vie ; un retrait progressif puise dans le fonds jusqu'à épuisement.",
+      "fund_payout_mode_help": "La rente modélise des versements jusqu’à la fin du plan ; les retraits utilisent le solde du fonds jusqu’à son épuisement.",
       "annuity": "Rente",
       "drawdown": "Retrait progressif",
       "fund_return_during_payout": "Rendement du fonds pendant le versement",
-      "drawdown_note": "Le retrait utilise {{pct}} %/an du solde à l'âge de départ, puis suit le paramètre de croissance ci-dessous jusqu'à épuisement du fonds.",
+      "drawdown_note": "Les retraits sont estimés à {{pct}} % par an du capital du fonds. Pour les versements déjà commencés, le montant mensuel saisi est prioritaire. Les versements suivent ensuite le taux de croissance défini jusqu’à épuisement du capital.",
       "monthly_payout_after_tax": "Versement mensuel après impôt",
-      "payout_estimate_note": "Le versement estimé utilise {{pct}} %/an du solde projeté du fonds, sauf si vous saisissez un versement mensuel.",
+      "payout_estimate_note": "Les versements sont estimés à {{pct}} % par an du capital du fonds. Pour les versements déjà commencés, le montant mensuel saisi est prioritaire.",
       "start_age": "Âge de début",
       "income_growth": "Croissance du revenu",
       "income_growth_help": "Choisissez si ce revenu augmente avec l’inflation du plan ou reste fixe.",
@@ -471,15 +477,15 @@
     "quick_start": {
       "title": "Démarrage rapide — 5 étapes",
       "step1_title": "Définir les bases du plan",
-      "step1_desc": "Dans Paramètres du plan, choisissez le type de plan, le mois de naissance, l'âge de la retraite, l'espérance de vie et la cotisation mensuelle.",
+      "step1_desc": "Dans les paramètres du plan, définissez le type, le mois de naissance, l’âge de retraite, l’horizon du plan et la cotisation mensuelle.",
       "step2_title": "Saisir les dépenses de retraite",
       "step2_desc": "Dans Dépenses de retraite, ajoutez les lignes de dépenses mensuelles que le plan doit financer. Utilisez la monnaie d'aujourd'hui ; l'inflation est gérée par les hypothèses du plan.",
       "step3_title": "Ajouter des revenus de retraite",
-      "step3_desc": "Dans Revenus de retraite, ajoutez des flux de revenus mensuels tels que les pensions publiques (par ex. RPC/SV au Canada, Sécurité sociale aux États-Unis), les régimes d'entreprise, le travail à temps partiel ou les rentes. Utilisez Ajouter un fonds de pension uniquement lorsque le planificateur doit estimer un versement à partir d'un solde de fonds à 3,5 %/an, sauf si vous saisissez vous-même un versement mensuel.",
+      "step3_desc": "Ajoutez des revenus de retraite : pensions, travail à temps partiel ou rentes. Pour un fonds de pension, le versement mensuel estimé utilise le solde projeté et le taux annuel configuré, sauf si vous saisissez un versement mensuel.",
       "step4_title": "Vérifier les hypothèses, les impôts et les parts de comptes",
       "step4_desc": "Passez en revue les rendements projetés, les frais, la volatilité, l'inflation, les taux d'imposition sur les retraits, les enveloppes fiscales et les comptes qui financent l'objectif.",
       "step5_title": "Lire l'Aperçu, puis ouvrir Simulations",
-      "step5_desc": "L'Aperçu indique si le plan de base fonctionne et affiche la trajectoire, la couverture des dépenses et les paramètres du plan. Simulations teste le même plan à travers des trajectoires de marché, des tests de résistance, des cartes de décision et des vérifications avancées."
+      "step5_desc": "L’Aperçu montre la projection de base, la couverture des dépenses et les paramètres. Les simulations comparent des trajectoires de marché, des scénarios de résistance et des changements d’hypothèses."
     },
     "overview": {
       "title": "Comprendre l'Aperçu",
@@ -499,13 +505,13 @@
     "what_if": {
       "title": "Comprendre Simulations",
       "market_paths_title": "Trajectoires de marché",
-      "market_paths_desc": "Teste le même plan à travers de nombreuses trajectoires de marché possibles en utilisant vos hypothèses de rendement, de volatilité et d'inflation. La plage ombrée montre les résultats du pire au meilleur ; la ligne montre la trajectoire médiane. L'argent dure signifie que le plan couvre les dépenses essentielles et qu'il reste encore de l'argent jusqu'à l'horizon de planification. En mode FIRE, le plan doit aussi d'abord atteindre l'indépendance financière.",
+      "market_paths_desc": "Nous modélisons différentes trajectoires de marché selon vos hypothèses. La zone ombrée représente les 10e à 90e percentiles à chaque âge ; la ligne montre la médiane des trajectoires, pas une trajectoire individuelle. La durée des fonds compte les trajectoires qui couvrent les dépenses essentielles et se terminent avec un capital positif ; les trajectoires FIRE doivent aussi atteindre l’indépendance financière.",
       "base_case_title": "Cas de base",
       "base_case_desc": "Affiche le même plan de base déterministe que l'Aperçu, puis met en évidence le plus grand résultat de test de résistance afin que vous puissiez voir ce qui compte le plus.",
       "stress_tests_title": "Tests de résistance",
       "stress_tests_desc": "Des vérifications fixes montrent comment le plan change si les rendements sont plus faibles, l'inflation plus élevée, les dépenses augmentent, la retraite commence plus tôt, l'épargne diminue ou un krach boursier survient près de la retraite.",
       "what_moves_title": "Qu'est-ce qui influence le plan ?",
-      "what_moves_desc": "Les cartes de décision comparent l'épargne, les rendements, l'âge de la retraite et les dépenses. Les cellules vertes laissent plus d'argent à la fin. Les cellules rouges laissent encore un écart ou manquent de fonds.",
+      "what_moves_desc": "Comparez épargne, rendements, âge de retraite et dépenses. Le vert indique plus de capital final que le plan de base ; l’ambre, moins. Le rouge indique un déficit ou aucun capital restant.",
       "crash_paths_title": "Trajectoires de krach précoce",
       "crash_paths_desc": "Compare quelques trajectoires de timing de krach près de la retraite. Un krach au cours de la première année de retraite peut faire plus de mal que le même krach plus tard, car les retraits ont lieu pendant que le portefeuille est en baisse."
     },
@@ -514,25 +520,24 @@
       "yearly_spending_title": "Comment les dépenses annuelles sont modélisées",
       "yearly_spending_desc": "Vos dépenses déterminent le retrait. Chaque année, le planificateur finance le plan de dépenses que vous avez saisi, soustrait le revenu de retraite et estime la charge fiscale sur les retraits du portefeuille.",
       "target_calc_title": "Comment l'objectif est calculé",
-      "target_calc_desc": "Le planificateur calcule la valeur actuelle de l'ensemble de votre calendrier de dépenses, de la retraite jusqu'à votre horizon de planification — en tenant compte du taux d'inflation de chaque poste de dépenses, des flux de revenus qui commencent à différents âges et de la charge fiscale sur les retraits. Lorsque votre portefeuille atteint ce montant, le plan de base dispose de suffisamment de capital pour le calendrier que vous avez saisi. C'est plus précis qu'un simple multiple des dépenses car cela gère des dépenses variables, des pensions différées et des horizons finis.",
+      "target_calc_desc": "Le planificateur estime le portefeuille initial nécessaire pour financer les dépenses de retraite jusqu’à la fin du plan. Il modélise l’inflation des dépenses, le calendrier des revenus, les rendements, les frais et les impôts sur les retraits. La cible dépend de ces hypothèses.",
       "inflation_title": "Taux d'inflation",
-      "inflation_desc": "Toutes les projections font croître les dépenses et les revenus indexés sur l'inflation à ce taux d'une année sur l'autre. La valeur par défaut de 2 % correspond à la cible de la BCE.",
-      "inflation_it_note": "Utilisez 2,5–3 % pour une hypothèse d'IPC italien plus prudente.",
+      "inflation_desc": "L’hypothèse d’inflation fait augmenter les dépenses et les revenus indexés au fil du temps. Chaque poste peut utiliser son propre taux.",
       "returns_title": "Rendements, frais et volatilité",
       "returns_desc": "Le rendement avant la retraite détermine l'accumulation. Le rendement pendant la retraite détermine la phase de retrait et le capital requis. Les frais d'investissement annuels sont soustraits des deux. La volatilité n'est utilisée que dans les vérifications de trajectoires de marché — des valeurs plus élevées produisent un éventail de résultats plus large.",
       "horizon_title": "Âge de l'horizon de planification",
-      "horizon_desc": "Combien de temps le portefeuille doit durer. L'objectif de retraite et les vérifications Simulations s'exécutent jusqu'à cet âge. Réglez-le sur 90–95 pour tester la longévité. Les trajectoires de krach précoce et L'argent dure sont toutes deux mesurées à cet horizon."
+      "horizon_desc": "L’âge jusqu’auquel les dépenses de retraite et les résultats Simulation sont modélisés. Il s’agit d’une hypothèse de durée du plan, pas d’une prévision de longévité."
     },
     "italian": {
       "title": "Configuration retraite italienne (fondo pensione, TFR, INPS)",
       "portfolio_title": "Portefeuille d'investissement (Golden Butterfly, All-Weather…)",
       "portfolio_desc": "Il s'agit de votre portefeuille principal — la valeur suivie par Wealthfolio. Définissez ici vos hypothèses de rendement, la charge des frais et la cotisation mensuelle. C'est le principal moteur d'accumulation de votre plan de retraite.",
       "fondo_title": "Fondo pensione integrativo (fonds de pension complémentaire)",
-      "fondo_desc": "Utilisez Ajouter un fonds de pension. Saisissez le solde actuel du fonds, la cotisation mensuelle, le rendement attendu du fonds et l'âge de début des versements. Le planificateur estime le solde futur et, si vous ne saisissez pas de versement mensuel, estime le versement à 3,5 %/an de ce solde projeté à partir de l'âge de début.",
+      "fondo_desc": "Utilisez Ajouter un fonds de pension. Saisissez le solde, la cotisation, le rendement supposé et l’âge de début des versements. Le versement estimé utilise le taux configuré, sauf si vous saisissez un montant mensuel. Les retraits cessent à l’épuisement du fonds ; les rentes sont modélisées jusqu’à la fin du plan.",
       "inps_title": "Pensione INPS (pension d'État — previdenza obbligatoria)",
       "inps_desc": "Utilisez Ajouter un revenu de retraite. Saisissez votre pension nette mensuelle estimée en monnaie d'aujourd'hui et définissez l'âge de début des versements. Utilisez Indexé si vous souhaitez que le revenu augmente avec l'hypothèse d'inflation du plan.",
       "tfr_title": "TFR (Trattamento di Fine Rapporto — indemnité de fin de contrat)",
-      "tfr_desc": "Si votre TFR est versé dans un fonds de pension, incluez-le dans la cotisation mensuelle au fonds. Si vous le conservez séparément, modélisez-le comme un autre fonds de pension avec son propre solde, sa cotisation, son rendement et son âge de début des versements. La même estimation de versement de 3,5 %/an s'applique, sauf si vous saisissez vous-même un versement mensuel."
+      "tfr_desc": "Si le TFR est versé dans un fonds de pension, incluez-le dans la cotisation. Un fonds distinct peut représenter une épargne TFR séparée ; ses versements modélisés suivent le taux ou le montant mensuel configuré."
     }
   },
   "type": {
@@ -783,7 +788,7 @@
       "retirement_gap": "Écart de retraite",
       "fi_moves_prefix": "L'IF se déplace de",
       "fi_moves_suffix": "ans plus tard",
-      "largest_risk": "{{label}} est le plus grand risque",
+      "largest_risk": "{{label}} a l’effet le plus important parmi ces tests",
       "and": "et",
       "none": "Aucun",
       "surplus": "excédent",
@@ -807,7 +812,10 @@
       "money_lasts_summary_traditional": "reste financé jusqu'à l'âge de {{horizonAge}} ans",
       "money_lasts_summary_fire": "IF atteinte + financé jusqu'à l'âge de {{horizonAge}} ans",
       "money_lasts_prompt_traditional": "Exécutez 10 000 trajectoires pour voir à quelle fréquence le plan reste financé jusqu'à l'âge de {{horizonAge}} ans.",
-      "money_lasts_prompt_fire": "Exécutez 10 000 trajectoires pour voir à quelle fréquence le plan atteint l'IF et reste financé jusqu'à l'âge de {{horizonAge}} ans."
+      "money_lasts_prompt_fire": "Exécutez 10 000 trajectoires pour voir à quelle fréquence le plan atteint l'IF et reste financé jusqu'à l'âge de {{horizonAge}} ans.",
+      "of_simulated_paths": "des trajectoires simulées",
+      "simulation_tooltip_traditional": "{{percent}} % des trajectoires simulées couvrent les dépenses essentielles et se terminent avec un capital positif. Les couleurs utilisent des plages de référence : moins de 75 %, de 75 % à moins de 90 %, et 90 % ou plus. Ce sont des résultats modélisés, pas des probabilités réelles.",
+      "simulation_tooltip_fire": "{{percent}} % des trajectoires simulées couvrent les dépenses essentielles et se terminent avec un capital positif. Elles doivent aussi atteindre l’indépendance financière. Les couleurs utilisent des plages de référence : moins de 75 %, de 75 % à moins de 90 %, et 90 % ou plus. Ce sont des résultats modélisés, pas des probabilités réelles."
     },
     "stress": {
       "eyebrow_with_count": "Qu'est-ce qui pourrait compromettre ce plan ? · {{count}} scénarios",
@@ -824,8 +832,8 @@
     },
     "montecarlo": {
       "eyebrow": "Trajectoires de marché",
-      "heading": "Combien de temps l'argent pourrait-il durer ?",
-      "intro": "Nous testons le même plan sur de nombreuses trajectoires de marché possibles. La plage ombrée montre les résultats du pire au meilleur ; la ligne montre la trajectoire médiane.",
+      "heading": "Dans quelle proportion des simulations l’argent suffit-il ?",
+      "intro": "Nous modélisons différentes trajectoires de marché selon vos hypothèses. La zone ombrée représente les 10e à 90e percentiles à chaque âge ; la ligne montre la médiane des trajectoires, pas une trajectoire individuelle.",
       "run_10k": "Exécuter 10k trajectoires",
       "run_100k": "Exécuter 100k trajectoires",
       "running_short": "Exécution…",
@@ -837,17 +845,17 @@
       "median_fi_age": "Âge IF médian",
       "withdrawals_start_detail": "début des retraits",
       "vs_goal": "vs objectif {{age}}",
-      "bad_path": "Mauvaise trajectoire",
-      "middle_path": "Trajectoire médiane",
-      "good_path": "Bonne trajectoire"
+      "bad_path": "Résultat inférieur",
+      "middle_path": "Médiane",
+      "good_path": "Résultat supérieur"
     },
     "chart": {
       "age_label": "Âge {{age}}",
       "age_detail": "âge {{age}}",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "IF médiane @{{age}}",
-      "bad_good_range": "Plage pire-meilleur",
-      "median_path": "Trajectoire médiane",
+      "bad_good_range": "Plage du 10e au 90e percentile",
+      "median_path": "Médiane",
       "retirement_age": "Âge de la retraite",
       "goal_age": "Âge cible",
       "median_fi_age": "Âge IF médian",
@@ -856,12 +864,13 @@
       "goal": "objectif",
       "market_paths_count_one": "{{count}} trajectoire de marché",
       "market_paths_count_other": "{{count}} trajectoires de marché",
-      "market_paths_count_many": "{{count}} trajectoires de marché"
+      "market_paths_count_many": "{{count}} trajectoires de marché",
+      "percentile_at_age": "Percentile {{percentile}} · {{age}} ans"
     },
     "moves": {
       "eyebrow": "Qu'est-ce qui change le plus le plan ?",
       "heading": "Qu'est-ce qui influence le plan ?",
-      "description": "Montre comment l'épargne, les rendements, l'âge de la retraite et les dépenses modifient le résultat. Vert = plus d'argent restant ; rouge = déficit ou manque de fonds.",
+      "description": "Comparez épargne, rendements, âge de retraite et dépenses. Le vert indique plus de capital final que le plan de base ; l’ambre, moins. Le rouge indique un déficit ou aucun capital restant.",
       "empty_title": "Découvrez quels changements aideraient le plus.",
       "empty_description": "Comparez épargner davantage, obtenir un rendement différent, dépenser moins ou prendre sa retraite à un âge différent.",
       "building": "Création...",
@@ -890,6 +899,39 @@
       "unavailable_title": "Trajectoires de krach indisponibles.",
       "empty_description": "Exécutez les cinq trajectoires pour voir quelle séquence mettrait le plan sous pression en premier.",
       "unavailable_description": "Cette vérification nécessite un portefeuille projeté positif au début de la retraite."
+    },
+    "labels": {
+      "crash_year_1": "Krach en année 1 (−30 %)",
+      "crash_year_5": "Krach en année 5 (−30 %)",
+      "double_crash": "Deux krachs",
+      "lost_decade": "Décennie perdue",
+      "after_fee_return": "Rendement après frais"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "Rendements plus faibles",
+        "description": "Les rendements avant et pendant la retraite diminuent de 2 points de pourcentage."
+      },
+      "inflation-shock": {
+        "label": "Inflation plus élevée",
+        "description": "L’inflation générale augmente de 1,5 point de pourcentage."
+      },
+      "spending-shock": {
+        "label": "Dépenses plus élevées",
+        "description": "Tous les montants des dépenses de retraite augmentent de 10 %."
+      },
+      "retire-earlier": {
+        "label": "Retraite 2 ans plus tôt",
+        "description": "L’âge cible de retraite est avancé de deux ans, dans les limites de l’âge actuel du plan."
+      },
+      "save-less": {
+        "label": "Cotisations plus faibles",
+        "description": "Les cotisations mensuelles diminuent de 25 %."
+      },
+      "early-crash": {
+        "label": "Krach en début de retraite",
+        "description": "Une baisse de marché de 30 % est modélisée la première année de retraite."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/it/goals.json
+++ b/apps/frontend/src/i18n/locales/it/goals.json
@@ -130,8 +130,6 @@
       "fi_reached_prefix": "Hai raggiunto",
       "financial_independence": "l'indipendenza finanziaria",
       "fi_reached_suffix": "— con le ipotesi attuali.",
-      "years_after_many": "{{count}} anni dopo",
-      "years_before_many": "{{count}} anni prima",
       "not_reachable_prefix": "Non prevista entro",
       "not_reachable_suffix": "con le ipotesi attuali.",
       "fi_projected": "Secondo le proiezioni, raggiungerai l’indipendenza finanziaria a <age>{{age}} anni</age>."
@@ -232,7 +230,8 @@
       "reached": "Il portafoglio attuale raggiunge l’obiettivo stimato di indipendenza finanziaria secondo le tue ipotesi.",
       "not_reached": "L’indipendenza finanziaria non è prevista entro {{age}} anni. Confronta le ipotesi in Simulazioni.",
       "late_one": "L’indipendenza finanziaria è prevista {{count}} anno dopo l’età desiderata. Confronta le ipotesi in Simulazioni.",
-      "late_other": "L’indipendenza finanziaria è prevista {{count}} anni dopo l’età desiderata. Confronta le ipotesi in Simulazioni."
+      "late_other": "L’indipendenza finanziaria è prevista {{count}} anni dopo l’età desiderata. Confronta le ipotesi in Simulazioni.",
+      "late_many": "L’indipendenza finanziaria è prevista {{count}} anni dopo l’età desiderata. Confronta le ipotesi in Simulazioni."
     }
   },
   "sidebar": {

--- a/apps/frontend/src/i18n/locales/it/goals.json
+++ b/apps/frontend/src/i18n/locales/it/goals.json
@@ -110,18 +110,18 @@
       "on_track": "In linea",
       "fi_reached": "IF raggiunta",
       "at_risk": "A rischio",
-      "never_reaches_fi": "Non raggiunge mai l'IF",
+      "never_reaches_fi": "Non prevista entro {{age}} anni",
       "years_late_one": "{{count}} anno di ritardo",
       "years_late_many": "{{count}} anni di ritardo",
       "years_late_other": "{{count}} anni di ritardo"
     },
     "verdict": {
       "age": "età {{age}}",
-      "spending_gap_prefix": "Il deficit di spesa inizia a",
+      "spending_gap_prefix": "Un deficit di spesa è previsto da",
       "spending_gap_suffix": "prima che il piano raggiunga l'età {{age}}.",
-      "short_prefix": "All'età {{age}}, ti mancano",
+      "short_prefix": "A {{age}} anni, il deficit previsto è",
       "short_suffix": "per finanziare la pensione fino all'età {{age}}.",
-      "depleted_prefix": "Il portafoglio si esaurisce durante",
+      "depleted_prefix": "Il portafoglio sarà presumibilmente insufficiente a",
       "depleted_suffix": "dopo esserti ritirato a {{age}}.",
       "surplus_prefix": "Si prevede che tu vada in pensione all'età {{age}} con",
       "surplus_suffix": "di surplus.",
@@ -130,35 +130,25 @@
       "fi_reached_prefix": "Hai raggiunto",
       "financial_independence": "l'indipendenza finanziaria",
       "fi_reached_suffix": "— con le ipotesi attuali.",
-      "fi_at_prefix": "Raggiungerai l'indipendenza finanziaria a",
-      "years_after_one": "{{count}} anno dopo",
       "years_after_many": "{{count}} anni dopo",
-      "years_after_other": "{{count}} anni dopo",
-      "years_before_one": "{{count}} anno prima",
       "years_before_many": "{{count}} anni prima",
-      "years_before_other": "{{count}} anni prima",
-      "your_goal_of": "il tuo obiettivo di {{age}}.",
-      "right_on_goal": "esattamente al tuo obiettivo di {{age}}.",
-      "not_reachable_prefix": "Non raggiungibile entro",
-      "not_reachable_suffix": "con le ipotesi attuali."
+      "not_reachable_prefix": "Non prevista entro",
+      "not_reachable_suffix": "con le ipotesi attuali.",
+      "fi_projected": "Secondo le proiezioni, raggiungerai l’indipendenza finanziaria a <age>{{age}} anni</age>."
     },
     "summary": {
-      "at_your_current_prefix": "Con il tuo",
-      "contribution": "contributo attuale,",
-      "capital_not_available": "il capitale obiettivo richiesto non è raggiungibile con le ipotesi attuali. Rivedi spesa, inflazione, rendimenti e aspettativa di vita.",
-      "projected_balance_is": "il saldo pensionistico proiettato è",
-      "vs_required_capital_of": "rispetto al capitale richiesto di",
       "at_age": "all'età {{age}}.",
-      "the_plan_funds": "il piano finanzia",
-      "per_yr_expenses_to_age": "/anno di spese fino all'età {{age}}.",
-      "youre_short": "Ti mancano"
+      "youre_short": "Il deficit previsto è",
+      "traditional": "Con le ipotesi attuali e un contributo di <contribution>{{contribution}}</contribution>, il saldo previsto a {{age}} anni è <balance>{{balance}}</balance>, rispetto a un capitale richiesto di <target>{{target}}</target>.",
+      "fire": "Con le ipotesi attuali e un contributo di <contribution>{{contribution}}</contribution>, il piano include <budget>{{budget}}</budget>/anno di spese fino a {{age}} anni.",
+      "unavailable": "Con le ipotesi attuali e un contributo di <contribution>{{contribution}}</contribution>, l’obiettivo di capitale non è stimabile. Confronta le ipotesi in Simulazioni."
     },
     "progress": {
       "portfolio_today": "Portafoglio oggi",
       "required_at_age": "Richiesto all'età {{age}}",
       "target_at_age": "Obiettivo all'età {{age}}",
-      "capital_needed_tip_traditional": "Capitale necessario alla tua età di pensionamento dopo spese, entrate, imposte, rendimenti in pensione e commissioni. Mostrato in {{valueLabel}}.",
-      "capital_needed_tip_fire": "Capitale necessario alla tua età di pensionamento desiderata dopo spese, entrate, imposte, rendimenti in pensione e commissioni. Mostrato in {{valueLabel}}.",
+      "capital_needed_tip_traditional": "Capitale stimato necessario all’età pensionabile obiettivo secondo le ipotesi di spesa, reddito, imposte, rendimenti e commissioni. Mostrato in {{valueLabel}}.",
+      "capital_needed_tip_fire": "Capitale stimato necessario all’età pensionabile obiettivo secondo le ipotesi di spesa, reddito, imposte, rendimenti e commissioni. Mostrato in {{valueLabel}}.",
       "not_available": "Non disponibile",
       "funded_pct": "{{pct}}% finanziato"
     },
@@ -175,18 +165,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "Smetti di versare e vai comunque in pensione in tempo",
-      "coast_tip_nominal": "Importo Coast convertito in euro nominali alla tua età di pensionamento desiderata.",
-      "coast_tip_real": "Capitale di cui hai bisogno oggi che, senza ulteriori contributi, cresce fino alla piena IF entro la tua età di pensionamento.",
+      "coast_hint": "Capitale stimato necessario oggi",
+      "coast_tip_nominal": "Capitale stimato necessario oggi, espresso in denaro all’età pensionabile usando l’inflazione ipotizzata. È una conversione di valore, non una crescita prevista degli investimenti.",
+      "coast_tip_real": "Capitale stimato oggi attualizzando l’obiettivo pensionistico al rendimento ipotizzato prima del pensionamento, al netto delle commissioni. Le ipotesi pensionistiche restano invariate.",
       "lean_fire": "Lean FIRE",
       "lean_hint": "70% della spesa pianificata",
-      "lean_tip": "Vai in pensione con un budget frugale, circa il 70% della tua spesa pianificata. Fattibile prima, ma lascia poco margine.",
+      "lean_tip": "Capitale stimato per il 70% delle spese pianificate, con le altre ipotesi invariate. È lo scenario Lean FIRE del pianificatore.",
       "fi": "IF",
       "fi_hint": "Spesa pianificata completa",
       "fi_tip": "Capitale che finanzia la tua spesa pensionistica pianificata per l'intero orizzonte di pensionamento.",
       "fat_fire": "Fat FIRE",
       "fat_hint": "150% della spesa pianificata",
-      "fat_tip": "Vai in pensione con circa il 50% di spesa in più rispetto al previsto: margine per viaggi, regali, volatilità e miglioramenti dello stile di vita.",
+      "fat_tip": "Capitale stimato per il 150% delle spese pianificate, con le altre ipotesi invariate. È lo scenario Fat FIRE del pianificatore.",
       "more_info_about": "Maggiori informazioni su {{label}}",
       "done": "FATTO"
     },
@@ -223,11 +213,26 @@
       "unfunded": "Non finanziato",
       "planned_spending_legend": "Spesa pianificata",
       "showing": "Visualizzazione di {{valueLabel}}",
-      "projection_unavailable": "La proiezione di copertura non è disponibile per questo piano."
+      "projection_unavailable": "La proiezione di copertura non è disponibile per questo piano.",
+      "age_range": "Età {{start}} → {{end}}",
+      "starts_at": "Inizia a {{age}} anni",
+      "ended_at": "Terminato a {{age}} anni",
+      "not_active": "Non attivo"
     },
     "disclaimer": {
       "title": "Una cosa da tenere a mente",
-      "body": "Questo non è consulenza finanziaria. Considera questi numeri come uno schizzo, non una previsione. Tutto ciò che vedi qui è una simulazione costruita sui dati che hai inserito: rendimenti, inflazione, contributi, imposte e quanto a lungo prevedi di vivere. I mercati reali non si muovono in linea retta, le norme fiscali cambiano e i programmi governativi vengono riscritti. Usa questo strumento per mettere alla prova le tue idee e individuare eventuali lacune, poi parla con un professionista qualificato prima di prendere decisioni difficili da annullare."
+      "body": "Le proiezioni dipendono dalle tue ipotesi. I risultati reali possono differire. Non è consulenza finanziaria."
+    },
+    "guidance": {
+      "unavailable": "L’obiettivo non è stimabile con le ipotesi attuali. Confronta le ipotesi in Simulazioni.",
+      "depleted": "Si prevede che il portafoglio non basti a partire da {{age}} anni. Confronta le ipotesi in Simulazioni.",
+      "gap": "Si prevede un deficit di spesa a partire da {{age}} anni. Confronta le ipotesi in Simulazioni.",
+      "fund": "Si prevede che {{label}} si esaurisca a {{age}} anni; i pagamenti modellati cessano da quel momento. Confronta le ipotesi sui pagamenti e sul reddito.",
+      "shortfall": "Si prevede un deficit al pensionamento. Confronta le ipotesi in Simulazioni.",
+      "reached": "Il portafoglio attuale raggiunge l’obiettivo stimato di indipendenza finanziaria secondo le tue ipotesi.",
+      "not_reached": "L’indipendenza finanziaria non è prevista entro {{age}} anni. Confronta le ipotesi in Simulazioni.",
+      "late_one": "L’indipendenza finanziaria è prevista {{count}} anno dopo l’età desiderata. Confronta le ipotesi in Simulazioni.",
+      "late_other": "L’indipendenza finanziaria è prevista {{count}} anni dopo l’età desiderata. Confronta le ipotesi in Simulazioni."
     }
   },
   "sidebar": {
@@ -237,7 +242,8 @@
       "high_inflation": "Ipotesi di inflazione elevata. Le esigenze di spesa a lungo termine diventano più sensibili a questo tasso.",
       "high_fee": "Ipotesi di commissioni elevate. Il costo delle commissioni riduce sensibilmente i rendimenti a lungo termine.",
       "high_volatility": "Ipotesi di volatilità elevata. Gli intervalli di risultato possono diventare molto ampi.",
-      "high_contribution_growth": "Ipotesi di crescita del contributo elevata. Questo presuppone aumenti di risparmio ampi e costanti nel tempo."
+      "high_contribution_growth": "Ipotesi di crescita del contributo elevata. Questo presuppone aumenti di risparmio ampi e costanti nel tempo.",
+      "high_return": "Ipotesi di rendimento elevato. I saldi previsti sono sensibili a questo tasso."
     },
     "plan": {
       "kicker": "Piano",
@@ -258,14 +264,14 @@
       "desired_retirement_age_hint": "Età in cui vuoi diventare finanziariamente indipendente.",
       "retirement_age_hint": "Età in cui vuoi andare in pensione.",
       "horizon_age_fire": "Orizzonte del piano",
-      "horizon_age_traditional": "Aspettativa di vita",
+      "horizon_age_traditional": "Orizzonte del piano",
       "horizon_hint": "Età fino alla quale il piano deve coprire.",
       "monthly_contribution": "Contributo mensile",
       "monthly_contribution_hint": "Quanto aggiungi ogni mese fino alla pensione.",
-      "return_before_hint": "Rendimento annuo atteso durante il periodo di risparmio.",
-      "return_during_hint": "Rendimento annuo atteso dopo l'inizio dei prelievi.",
+      "return_before_hint": "Rendimento annuo ipotizzato durante il risparmio, prima delle commissioni.",
+      "return_during_hint": "Rendimento annuo ipotizzato dopo l’inizio dei prelievi, prima delle commissioni.",
       "annual_fee_hint": "Commissioni annue stimate del portafoglio.",
-      "inflation_hint": "Aumento annuo atteso dei prezzi."
+      "inflation_hint": "Aumento annuo ipotizzato dei prezzi."
     },
     "spending": {
       "kicker": "Spesa",
@@ -326,13 +332,13 @@
       "fund_return_before_payout": "Rendimento del fondo prima dell'erogazione",
       "fund_payout_rate": "Tasso di erogazione",
       "fund_payout_mode": "Modalità di erogazione",
-      "fund_payout_mode_help": "La rendita paga a vita; il prelievo programmato attinge al fondo fino a esaurirlo.",
+      "fund_payout_mode_help": "La rendita modella pagamenti fino all’orizzonte del piano; i prelievi utilizzano il saldo del fondo fino all’esaurimento.",
       "annuity": "Rendita",
       "drawdown": "Prelievo programmato",
       "fund_return_during_payout": "Rendimento del fondo durante l'erogazione",
-      "drawdown_note": "Il prelievo programmato preleva il {{pct}}%/anno del saldo all'età di inizio, poi segue l'impostazione di crescita qui sotto fino a esaurire il fondo.",
+      "drawdown_note": "I prelievi sono stimati al {{pct}}% annuo del saldo del fondo. Per i pagamenti già iniziati, prevale l’importo mensile inserito. I pagamenti seguono poi il tasso di crescita impostato fino all’esaurimento del fondo.",
       "monthly_payout_after_tax": "Erogazione mensile netta",
-      "payout_estimate_note": "L'erogazione stimata utilizza il {{pct}}%/anno del saldo proiettato del fondo, salvo che tu inserisca un'erogazione mensile.",
+      "payout_estimate_note": "Il pagamento stimato è pari al {{pct}}% annuo del saldo del fondo. Per i pagamenti già iniziati, prevale l’importo mensile inserito.",
       "start_age": "Età di inizio",
       "income_growth": "Crescita dell'entrata",
       "income_growth_help": "Scegli se questa entrata cresce con l'inflazione del piano o resta fissa.",
@@ -471,15 +477,15 @@
     "quick_start": {
       "title": "Avvio rapido — 5 passaggi",
       "step1_title": "Imposta le basi del piano",
-      "step1_desc": "In Dati del piano, scegli il tipo di piano, il mese di nascita, l'età di pensionamento, l'aspettativa di vita e il contributo mensile.",
+      "step1_desc": "Nei dati del piano, imposta tipo, mese di nascita, età pensionabile, orizzonte e contributo mensile.",
       "step2_title": "Inserisci la spesa pensionistica",
       "step2_desc": "In Spesa pensionistica, aggiungi le voci di spesa mensile che vuoi che il piano finanzi. Usa il valore di oggi; l'inflazione è gestita dalle ipotesi del piano.",
       "step3_title": "Aggiungi entrate pensionistiche",
-      "step3_desc": "In Entrate pensionistiche, aggiungi flussi di entrate mensili come pensioni pubbliche (es. INPS in Italia, CPP/OAS in Canada, Social Security negli USA), pensioni aziendali, lavoro part-time o rendite. Usa Aggiungi fondo pensione solo quando il pianificatore deve stimare un'erogazione dal saldo di un fondo al 3,5%/anno, a meno che tu non inserisca tu stesso un'erogazione mensile.",
+      "step3_desc": "Aggiungi redditi pensionistici, lavoro part-time o rendite. Per un fondo pensione, il pagamento mensile stimato usa il saldo previsto e il tasso annuo configurato, salvo inserimento di un importo mensile.",
       "step4_title": "Verifica ipotesi, imposte e quote dei conti",
       "step4_desc": "Rivedi i rendimenti proiettati, le commissioni, la volatilità, l'inflazione, le aliquote fiscali sul prelievo, le categorie fiscali e quali conti finanziano l'obiettivo.",
       "step5_title": "Leggi Panoramica, poi apri Simulazioni",
-      "step5_desc": "Panoramica risponde se il piano base funziona e mostra la traiettoria, la copertura della spesa e i dati del piano. Simulazioni testa lo stesso piano su diverse traiettorie di mercato, stress test, mappe decisionali e verifiche avanzate."
+      "step5_desc": "La panoramica mostra proiezione base, copertura delle spese e dati. Le simulazioni confrontano percorsi di mercato, scenari di stress e modifiche delle ipotesi."
     },
     "overview": {
       "title": "Capire Panoramica",
@@ -499,13 +505,13 @@
     "what_if": {
       "title": "Capire Simulazioni",
       "market_paths_title": "Traiettorie di mercato",
-      "market_paths_desc": "Testa lo stesso piano su molte possibili traiettorie di mercato usando le tue ipotesi di rendimento, volatilità e inflazione. L'intervallo ombreggiato mostra i risultati da cattivo a buono; la linea mostra la traiettoria mediana. Il capitale dura significa che il piano copre la spesa essenziale e rimangono ancora soldi per tutto l'orizzonte di pianificazione. In modalità FIRE, il piano deve anche raggiungere prima l'indipendenza finanziaria.",
+      "market_paths_desc": "Modelliamo diversi percorsi di mercato con le tue ipotesi. L’area ombreggiata mostra il 10°–90° percentile a ogni età; la linea mostra la mediana tra i percorsi, non un percorso individuale. Si contano i percorsi che coprono le spese essenziali e terminano con capitale residuo; quelli FIRE devono anche raggiungere l’indipendenza finanziaria.",
       "base_case_title": "Caso base",
       "base_case_desc": "Mostra lo stesso piano base deterministico di Panoramica, poi indica il risultato di stress più rilevante così puoi vedere cosa conta di più.",
       "stress_tests_title": "Stress test",
       "stress_tests_desc": "Verifiche fisse mostrano come cambia il piano se i rendimenti sono più bassi, l'inflazione è più alta, la spesa aumenta, la pensione inizia prima, il risparmio diminuisce o si verifica un crollo di mercato vicino alla pensione.",
       "what_moves_title": "Cosa muove il piano?",
-      "what_moves_desc": "Le mappe decisionali confrontano risparmio, rendimenti, età di pensionamento e spesa. Le celle verdi lasciano più soldi alla fine. Le celle rosse lasciano comunque un deficit o si esauriscono.",
+      "what_moves_desc": "Confronta risparmio, rendimenti, età pensionabile e spese. Verde indica più capitale finale del piano base; ambra, meno. Rosso indica un deficit o nessun capitale residuo.",
       "crash_paths_title": "Traiettorie di crollo di mercato anticipato",
       "crash_paths_desc": "Confronta alcune traiettorie in base al momento del crollo vicino alla pensione. Un crollo nel primo anno di pensione può danneggiare più della stessa caduta più avanti, perché i prelievi avvengono mentre il portafoglio è in ribasso."
     },
@@ -514,25 +520,24 @@
       "yearly_spending_title": "Come viene modellata la spesa annuale",
       "yearly_spending_desc": "Le tue spese determinano il prelievo. Ogni anno il pianificatore finanzia il piano di spesa che hai inserito, sottrae le entrate pensionistiche e stima eventuali costi fiscali sui prelievi dal portafoglio.",
       "target_calc_title": "Come viene calcolato l'obiettivo",
-      "target_calc_desc": "Il pianificatore calcola il valore attuale dell'intero calendario di spesa dalla pensione fino al tuo orizzonte di pianificazione, tenendo conto del tasso di inflazione di ciascuna categoria di spesa, dei flussi di entrate che iniziano a età diverse e del costo fiscale sui prelievi. Quando il tuo portafoglio raggiunge questo importo, il piano base ha capitale sufficiente per il calendario che hai inserito. Questo è più accurato di un semplice multiplo delle spese perché gestisce spese variabili, pensioni differite e orizzonti finiti.",
+      "target_calc_desc": "Il pianificatore stima il portafoglio iniziale necessario a finanziare le spese pensionistiche fino all’orizzonte del piano. Modella inflazione delle spese, tempistiche dei redditi, rendimenti, commissioni e imposte sui prelievi. L’obiettivo dipende da queste ipotesi.",
       "inflation_title": "Tasso di inflazione",
-      "inflation_desc": "Tutte le proiezioni fanno crescere le spese e le entrate legate all'inflazione a questo tasso, anno dopo anno. Il valore predefinito del 2% corrisponde all'obiettivo della BCE.",
-      "inflation_it_note": "Usa il 2,5–3% per un'ipotesi più prudente basata sull'IPC italiano.",
+      "inflation_desc": "L’ipotesi di inflazione aumenta nel tempo spese e redditi indicizzati. Le singole voci possono usare tassi propri.",
       "returns_title": "Rendimenti, commissioni e volatilità",
       "returns_desc": "Il rendimento prima della pensione guida l'accumulo. Il rendimento durante la pensione guida la fase di prelievo e il capitale richiesto. Le commissioni di investimento annue vengono sottratte da entrambi. La volatilità viene usata solo nelle verifiche sulle traiettorie di mercato: valori più alti producono un ventaglio di risultati più ampio.",
       "horizon_title": "Età dell'orizzonte di pianificazione",
-      "horizon_desc": "Per quanto tempo deve durare il portafoglio. L'obiettivo pensionistico e le verifiche di Simulazioni arrivano fino a questa età. Impostala a 90–95 per mettere alla prova la longevità. Sia le traiettorie di crollo di mercato anticipato sia Il capitale dura vengono misurate su questo orizzonte."
+      "horizon_desc": "L’età fino alla quale vengono modellati spese pensionistiche e risultati Simulazioni. È un’ipotesi sul periodo di pianificazione, non una previsione della durata della vita."
     },
     "italian": {
       "title": "Impostazione pensionistica italiana (fondo pensione, TFR, INPS)",
       "portfolio_title": "Portafoglio di investimento (Golden Butterfly, All-Weather…)",
       "portfolio_desc": "Questo è il tuo portafoglio principale, il valore che Wealthfolio traccia. Imposta qui le tue ipotesi di rendimento, il costo delle commissioni e il contributo mensile. È il motore principale di accumulo del tuo piano pensionistico.",
       "fondo_title": "Fondo pensione integrativo",
-      "fondo_desc": "Usa Aggiungi fondo pensione. Inserisci il saldo attuale del fondo, il contributo mensile, il rendimento atteso del fondo e l'età di inizio erogazione. Il pianificatore stima il saldo futuro e, se non inserisci un'erogazione mensile, stima l'erogazione come il 3,5%/anno di quel saldo proiettato a partire dall'età di inizio.",
+      "fondo_desc": "Usa Aggiungi fondo pensione. Inserisci saldo, contributo, rendimento ipotizzato ed età di erogazione. La stima usa il tasso di erogazione configurato, salvo inserimento di un importo mensile. I prelievi cessano all’esaurimento del fondo; le rendite sono modellate fino all’orizzonte del piano.",
       "inps_title": "Pensione INPS (previdenza obbligatoria)",
       "inps_desc": "Usa Aggiungi entrata pensionistica. Inserisci la tua pensione netta mensile stimata in valore di oggi e imposta l'età di inizio erogazione. Usa Indicizzata se vuoi che l'entrata cresca secondo l'ipotesi di inflazione del piano.",
       "tfr_title": "TFR (Trattamento di Fine Rapporto)",
-      "tfr_desc": "Se il tuo TFR confluisce in un fondo pensione, includilo nel contributo mensile al fondo. Se lo mantieni separato, modellalo come un altro fondo pensione con proprio saldo, contributo, rendimento ed età di inizio erogazione. Si applica la stessa stima di erogazione del 3,5%/anno, a meno che tu non inserisca tu stesso un'erogazione mensile."
+      "tfr_desc": "Se il TFR confluisce in un fondo pensione, includilo nel contributo. Un fondo separato può rappresentare il TFR accantonato a parte; i pagamenti modellati seguono il tasso o l’importo mensile configurato."
     }
   },
   "type": {
@@ -783,7 +788,7 @@
       "retirement_gap": "Deficit pensionistico",
       "fi_moves_prefix": "L'IF si sposta",
       "fi_moves_suffix": "anni più tardi",
-      "largest_risk": "{{label}} è il rischio maggiore",
+      "largest_risk": "{{label}} ha l’effetto maggiore tra questi test",
       "and": "e",
       "none": "Nessuno",
       "surplus": "surplus",
@@ -807,7 +812,10 @@
       "money_lasts_summary_traditional": "resta finanziato fino all'età {{horizonAge}}",
       "money_lasts_summary_fire": "IF raggiunta + finanziato fino all'età {{horizonAge}}",
       "money_lasts_prompt_traditional": "Esegui 10k traiettorie per vedere con quale frequenza il piano resta finanziato fino all'età {{horizonAge}}.",
-      "money_lasts_prompt_fire": "Esegui 10k traiettorie per vedere con quale frequenza il piano raggiunge l'IF e resta finanziato fino all'età {{horizonAge}}."
+      "money_lasts_prompt_fire": "Esegui 10k traiettorie per vedere con quale frequenza il piano raggiunge l'IF e resta finanziato fino all'età {{horizonAge}}.",
+      "of_simulated_paths": "dei percorsi simulati",
+      "simulation_tooltip_traditional": "Il {{percent}}% dei percorsi simulati copre le spese essenziali e termina con capitale residuo. I colori usano fasce di riferimento: meno del 75%, dal 75% a meno del 90% e almeno il 90%. Sono risultati modellati, non probabilità reali.",
+      "simulation_tooltip_fire": "Il {{percent}}% dei percorsi simulati copre le spese essenziali e termina con capitale residuo. I percorsi devono anche raggiungere l’indipendenza finanziaria. I colori usano fasce di riferimento: meno del 75%, dal 75% a meno del 90% e almeno il 90%. Sono risultati modellati, non probabilità reali."
     },
     "stress": {
       "eyebrow_with_count": "Cosa potrebbe compromettere questo piano? · {{count}} scenari",
@@ -825,7 +833,7 @@
     "montecarlo": {
       "eyebrow": "Traiettorie di mercato",
       "heading": "Con quale frequenza potrebbe durare il capitale?",
-      "intro": "Testiamo lo stesso piano su molte possibili traiettorie di mercato. L'intervallo ombreggiato mostra i risultati da cattivo a buono; la linea mostra la traiettoria mediana.",
+      "intro": "Modelliamo diversi percorsi di mercato con le tue ipotesi. L’area ombreggiata mostra il 10°–90° percentile a ogni età; la linea mostra la mediana tra i percorsi, non un percorso individuale.",
       "run_10k": "Esegui 10k traiettorie",
       "run_100k": "Esegui 100k traiettorie",
       "running_short": "Esecuzione…",
@@ -837,17 +845,17 @@
       "median_fi_age": "Età mediana IF",
       "withdrawals_start_detail": "inizio dei prelievi",
       "vs_goal": "rispetto all'obiettivo {{age}}",
-      "bad_path": "Traiettoria negativa",
-      "middle_path": "Traiettoria mediana",
-      "good_path": "Traiettoria positiva"
+      "bad_path": "Esito inferiore",
+      "middle_path": "Mediana",
+      "good_path": "Esito superiore"
     },
     "chart": {
       "age_label": "Età {{age}}",
       "age_detail": "età {{age}}",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "IF mediana @{{age}}",
-      "bad_good_range": "Intervallo negativo-positivo",
-      "median_path": "Traiettoria mediana",
+      "bad_good_range": "Intervallo 10°–90° percentile",
+      "median_path": "Mediana",
       "retirement_age": "Età di pensionamento",
       "goal_age": "Età obiettivo",
       "median_fi_age": "Età mediana IF",
@@ -856,12 +864,13 @@
       "goal": "obiettivo",
       "market_paths_count_one": "{{count}} traiettoria di mercato",
       "market_paths_count_many": "{{count}} traiettorie di mercato",
-      "market_paths_count_other": "{{count}} traiettorie di mercato"
+      "market_paths_count_other": "{{count}} traiettorie di mercato",
+      "percentile_at_age": "Percentile {{percentile}} · età {{age}}"
     },
     "moves": {
       "eyebrow": "Cosa cambia di più il piano?",
       "heading": "Cosa muove il piano?",
-      "description": "Mostra come risparmio, rendimenti, età di pensionamento e spesa cambiano il risultato. Verde = più capitale residuo; rosso = deficit o esaurimento.",
+      "description": "Confronta risparmio, rendimenti, età pensionabile e spese. Verde indica più capitale finale del piano base; ambra, meno. Rosso indica un deficit o nessun capitale residuo.",
       "empty_title": "Scopri quali modifiche aiuterebbero di più.",
       "empty_description": "Confronta il risparmiare di più, ottenere un rendimento diverso, spendere meno o andare in pensione a un'età diversa.",
       "building": "Elaborazione...",
@@ -890,6 +899,39 @@
       "unavailable_title": "Traiettorie di crollo non disponibili.",
       "empty_description": "Esegui le cinque traiettorie per vedere quale sequenza metterebbe per prima il piano sotto pressione.",
       "unavailable_description": "Questa verifica richiede un portafoglio proiettato positivo all'inizio della pensione."
+    },
+    "labels": {
+      "crash_year_1": "Crollo nell’anno 1 (−30%)",
+      "crash_year_5": "Crollo nell’anno 5 (−30%)",
+      "double_crash": "Due crolli",
+      "lost_decade": "Decennio perduto",
+      "after_fee_return": "Rendimento netto delle commissioni"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "Rendimenti inferiori",
+        "description": "I rendimenti prima e durante il pensionamento sono inferiori di 2 punti percentuali."
+      },
+      "inflation-shock": {
+        "label": "Inflazione superiore",
+        "description": "L’inflazione generale è superiore di 1,5 punti percentuali."
+      },
+      "spending-shock": {
+        "label": "Spese superiori",
+        "description": "Tutti gli importi delle spese pensionistiche sono superiori del 10%."
+      },
+      "retire-earlier": {
+        "label": "Pensionamento 2 anni prima",
+        "description": "L’età obiettivo viene anticipata di due anni, entro i limiti dell’età attuale del piano."
+      },
+      "save-less": {
+        "label": "Contributi inferiori",
+        "description": "I contributi mensili sono inferiori del 25%."
+      },
+      "early-crash": {
+        "label": "Crollo iniziale del mercato",
+        "description": "Si modella un calo del mercato del 30% nel primo anno di pensionamento."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/ja/goals.json
+++ b/apps/frontend/src/i18n/locales/ja/goals.json
@@ -107,18 +107,18 @@
       "on_track": "順調",
       "fi_reached": "FI達成",
       "at_risk": "要注意",
-      "never_reaches_fi": "FI未達",
+      "never_reaches_fi": "{{age}}歳までの到達は予測されません",
       "years_late_one": "{{count}}年遅れ",
       "years_late_other": "{{count}}年遅れ"
     },
     "verdict": {
       "age": "{{age}}歳",
-      "spending_gap_prefix": "支出ギャップが",
-      "spending_gap_suffix": "から始まり、プランは{{age}}歳に達する前に資金不足になります。",
-      "short_prefix": "{{age}}歳時点で、",
-      "short_suffix": "が不足し、{{age}}歳までの老後資金を賄えません。",
-      "depleted_prefix": "ポートフォリオは",
-      "depleted_suffix": "中に資金不足になります({{age}}歳で退職した場合)。",
+      "spending_gap_prefix": "支出不足が予測される開始年齢：",
+      "spending_gap_suffix": "（計画期間は{{age}}歳まで）。",
+      "short_prefix": "{{age}}歳時点の予測不足額は",
+      "short_suffix": "です（{{age}}歳までの老後資金）。",
+      "depleted_prefix": "資金不足が予測される年齢：",
+      "depleted_suffix": "（{{age}}歳で退職した場合）。",
       "surplus_prefix": "{{age}}歳での退職が見込まれ、",
       "surplus_suffix": "の余剰が出る見通しです。",
       "on_track_prefix": "退職見込みは",
@@ -126,33 +126,23 @@
       "fi_reached_prefix": "あなたは",
       "financial_independence": "経済的自立",
       "fi_reached_suffix": "を達成しています — 現在の前提条件においてです。",
-      "fi_at_prefix": "経済的自立の達成見込みは",
-      "years_after_one": "、目標より{{count}}年遅れて",
-      "years_after_other": "、目標より{{count}}年遅れて",
-      "years_before_one": "、目標より{{count}}年早く",
-      "years_before_other": "、目標より{{count}}年早く",
-      "your_goal_of": "達成します(目標: {{age}}歳)。",
-      "right_on_goal": "目標の{{age}}歳ちょうどです。",
-      "not_reachable_prefix": "現在の前提条件では",
-      "not_reachable_suffix": "までに達成できません。"
+      "not_reachable_prefix": "現在の前提では、経済的自立は",
+      "not_reachable_suffix": "までに達成する見込みがありません。",
+      "fi_projected": "<age>{{age}}歳</age>で経済的自立に到達すると予測されます。"
     },
     "summary": {
-      "at_your_current_prefix": "現在の",
-      "contribution": "の積立では、",
-      "capital_not_available": "現在の前提条件では必要資本の目標を算出できません。支出、インフレ率、リターン、想定寿命を見直してください。",
-      "projected_balance_is": "退職時の予想残高は",
-      "vs_required_capital_of": "、対して必要資本は",
       "at_age": "({{age}}歳時点)。",
-      "the_plan_funds": "このプランで賄えるのは",
-      "per_yr_expenses_to_age": "/年の支出({{age}}歳まで)です。",
-      "youre_short": "不足額は"
+      "youre_short": "予測不足額は",
+      "traditional": "現在の前提条件と<contribution>{{contribution}}</contribution>の積立に基づく{{age}}歳時点の予測残高は<balance>{{balance}}</balance>で、必要資金は<target>{{target}}</target>です。",
+      "fire": "現在の前提条件と<contribution>{{contribution}}</contribution>の積立に基づき、計画には{{age}}歳まで年間<budget>{{budget}}</budget>の支出が含まれます。",
+      "unavailable": "現在の前提条件と<contribution>{{contribution}}</contribution>の積立では、目標資金を推計できません。「シミュレーション」で前提条件を比較してください。"
     },
     "progress": {
       "portfolio_today": "現在のポートフォリオ",
       "required_at_age": "{{age}}歳時点の必要額",
       "target_at_age": "{{age}}歳時点の目標額",
-      "capital_needed_tip_traditional": "支出、収入、税金、退職後リターン、手数料を考慮した、退職年齢時点で必要な資本です。{{valueLabel}}で表示。",
-      "capital_needed_tip_fire": "支出、収入、税金、退職後リターン、手数料を考慮した、希望退職年齢時点で必要な資本です。{{valueLabel}}で表示。",
+      "capital_needed_tip_traditional": "支出、収入、税金、利回り、手数料の前提に基づく、目標退職年齢で必要な推計資金です。表示基準：{{valueLabel}}。",
+      "capital_needed_tip_fire": "支出、収入、税金、利回り、手数料の前提に基づく、目標退職年齢で必要な推計資金です。表示基準：{{valueLabel}}。",
       "not_available": "利用不可",
       "funded_pct": "{{pct}}%充足"
     },
@@ -169,18 +159,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "積立をやめても予定どおり退職できる",
-      "coast_tip_nominal": "Coast金額を希望退職年齢時点の名目額に換算したものです。",
-      "coast_tip_real": "今後一切積み立てなくても、退職年齢までに完全なFIに到達するために今日必要な資本です。",
+      "coast_hint": "現在必要な資金の推計",
+      "coast_tip_nominal": "現在必要な推計額を、想定インフレ率で退職年齢時点の金額に換算しています。価値の換算であり、運用による成長予測ではありません。",
+      "coast_tip_real": "退職時の目標額を、退職前の想定利回りから手数料を差し引いた率で割り引いた現在の推計額です。年金の前提条件は変わりません。",
       "lean_fire": "Lean FIRE",
       "lean_hint": "計画支出の70%",
-      "lean_tip": "質素な予算で退職 — 計画支出の約70%です。より早く実現できますが、余裕はほとんどありません。",
+      "lean_tip": "他の前提条件を変えず、計画支出の70%に対して推計した資金です。このプランナーのLean FIREシナリオです。",
       "fi": "FI",
       "fi_hint": "計画支出の全額",
       "fi_tip": "退職期間全体を通じて計画された老後の支出を賄う資本です。",
       "fat_fire": "Fat FIRE",
       "fat_hint": "計画支出の150%",
-      "fat_tip": "計画より約50%多い支出で退職 — 旅行、贈り物、相場変動、生活水準の向上に余裕を持てます。",
+      "fat_tip": "他の前提条件を変えず、計画支出の150%に対して推計した資金です。このプランナーのFat FIREシナリオです。",
       "more_info_about": "{{label}}の詳細",
       "done": "達成"
     },
@@ -217,11 +207,26 @@
       "unfunded": "未充当",
       "planned_spending_legend": "計画支出",
       "showing": "{{valueLabel}}で表示中",
-      "projection_unavailable": "このプランではカバレッジ予測を利用できません。"
+      "projection_unavailable": "このプランではカバレッジ予測を利用できません。",
+      "age_range": "{{start}}歳 → {{end}}歳",
+      "starts_at": "{{age}}歳から開始",
+      "ended_at": "{{age}}歳で終了",
+      "not_active": "対象期間外"
     },
     "disclaimer": {
       "title": "ご留意ください",
-      "body": "これは投資助言ではありません。これらの数値は予測ではなく、あくまで概算のスケッチとして扱ってください。ここに表示される内容はすべて、入力された前提(リターン、インフレ率、積立額、税金、想定寿命)に基づくシミュレーションです。実際の市場は一直線には動かず、税制は変わり、公的制度も改定されます。アイデアの検証やギャップの発見に活用し、取り返しのつかない意思決定の前には資格を持つ専門家に相談してください。"
+      "body": "予測は前提条件に基づきます。実際の結果は異なる場合があります。金融助言ではありません。"
+    },
+    "guidance": {
+      "unavailable": "現在の前提条件では目標額を推計できません。「シミュレーション」で前提条件を比較してください。",
+      "depleted": "{{age}}歳でポートフォリオの資金不足が予測されます。「シミュレーション」で前提条件を比較してください。",
+      "gap": "{{age}}歳から支出を賄えない見込みです。「シミュレーション」で前提条件を比較してください。",
+      "fund": "{{label}}は{{age}}歳で枯渇し、モデル上の支払いが終了する見込みです。支払額と収入の前提条件を比較してください。",
+      "shortfall": "退職時の資金不足が予測されます。「シミュレーション」で前提条件を比較してください。",
+      "reached": "現在のポートフォリオは、設定した前提条件に基づく経済的自立の推計目標額に達しています。",
+      "not_reached": "{{age}}歳までの経済的自立は予測されません。「シミュレーション」で前提条件を比較してください。",
+      "late_one": "経済的自立は希望年齢の{{count}}年後と予測されます。「シミュレーション」で前提条件を比較してください。",
+      "late_other": "経済的自立は希望年齢の{{count}}年後と予測されます。「シミュレーション」で前提条件を比較してください。"
     }
   },
   "sidebar": {
@@ -231,7 +236,8 @@
       "high_inflation": "インフレ率の前提が高めです。この水準では長期の支出必要額の感応度が高くなります。",
       "high_fee": "手数料の前提が高めです。手数料負担は長期リターンを大きく押し下げます。",
       "high_volatility": "ボラティリティの前提が高めです。結果の範囲が非常に広くなる可能性があります。",
-      "high_contribution_growth": "積立増加率の前提が高めです。大幅な貯蓄増加が継続する想定になっています。"
+      "high_contribution_growth": "積立増加率の前提が高めです。大幅な貯蓄増加が継続する想定になっています。",
+      "high_return": "高い利回りの前提です。予測残高はこの率に大きく左右されます。"
     },
     "plan": {
       "kicker": "プラン",
@@ -252,14 +258,14 @@
       "desired_retirement_age_hint": "経済的自立を達成したい年齢です。",
       "retirement_age_hint": "退職したい年齢です。",
       "horizon_age_fire": "プラン終了年齢",
-      "horizon_age_traditional": "平均寿命",
+      "horizon_age_traditional": "プラン終了年齢",
       "horizon_hint": "プランがカバーする最終年齢です。",
       "monthly_contribution": "毎月の積立額",
       "monthly_contribution_hint": "退職まで毎月積み立てる金額です。",
-      "return_before_hint": "積立期間中の期待年間リターンです。",
-      "return_during_hint": "取り崩し開始後の期待年間リターンです。",
+      "return_before_hint": "積立期間中の想定年間利回り。運用手数料控除前です。",
+      "return_during_hint": "取り崩し開始後の想定年間利回り。運用手数料控除前です。",
       "annual_fee_hint": "推定の年間ポートフォリオ手数料です。",
-      "inflation_hint": "予想される年間の物価上昇率です。"
+      "inflation_hint": "想定される年間の物価上昇率。"
     },
     "spending": {
       "kicker": "支出",
@@ -320,13 +326,13 @@
       "fund_return_before_payout": "受取開始前のファンドリターン",
       "fund_payout_rate": "受取率",
       "fund_payout_mode": "受取方法",
-      "fund_payout_mode_help": "年金は終身で支払われ、取り崩しは資金がなくなるまで引き出します。",
+      "fund_payout_mode_help": "年金方式は計画期間の終了まで継続する支払いをモデル化し、取り崩し方式は残高がなくなるまで基金を使います。",
       "annuity": "年金",
       "drawdown": "取り崩し",
       "fund_return_during_payout": "受取期間中のファンドリターン",
-      "drawdown_note": "取り崩しは受取開始年齢時点の残高の{{pct}}%/年を引き出し、その後は下の成長設定に従って資金がなくなるまで続きます。",
+      "drawdown_note": "取り崩し額は基金残高の年{{pct}}%で見積もります。受取開始済みの場合は、入力した月額が優先されます。その後は設定した増加率に従い、残高がなくなるまで支払いが続きます。",
       "monthly_payout_after_tax": "税引後の毎月の受取額",
-      "payout_estimate_note": "毎月の受取額を入力しない場合、予想ファンド残高の{{pct}}%/年を推定受取額として使用します。",
+      "payout_estimate_note": "受取額は基金残高の年{{pct}}%で見積もります。受取開始済みの場合は、入力した月額が優先されます。",
       "start_age": "開始年齢",
       "income_growth": "収入の増加",
       "income_growth_help": "この収入をプランのインフレ率に連動させるか、固定にするかを選択します。",
@@ -461,19 +467,19 @@
   },
   "guide": {
     "title": "リタイアメントガイド",
-    "subtitle": "概要とWhat Ifの仕組み。",
+    "subtitle": "概要とシミュレーションの仕組み。",
     "quick_start": {
       "title": "クイックスタート — 5ステップ",
       "step1_title": "プランの基本を設定",
-      "step1_desc": "「プラン入力」で、プランタイプ、生まれ月、退職年齢、想定寿命、毎月の積立額を選択します。",
+      "step1_desc": "プラン入力で種類、誕生月、退職年齢、計画期間の終了年齢、毎月の積立額を設定します。",
       "step2_title": "老後の支出を入力",
       "step2_desc": "「老後の支出」で、プランで賄いたい毎月の支出項目を追加します。現在の貨幣価値で入力してください。インフレはプランの前提条件で処理されます。",
       "step3_title": "老後の収入を追加",
-      "step3_desc": "「老後の収入」で、公的年金(例: カナダのCPP/OAS、米国のSocial Security)、企業年金、パートタイム収入、年金保険などの毎月の収入を追加します。「年金基金を追加」は、毎月の受取額を自分で入力しない限りファンド残高から3.5%/年で受取額を推定させたい場合にのみ使用してください。",
+      "step3_desc": "年金、パート収入、終身年金などの退職後収入を追加します。年金基金の月額推計は、月額を直接入力しない限り、予測残高と設定した年間支払率に基づきます。",
       "step4_title": "前提条件・税金・口座配分を確認",
       "step4_desc": "予想リターン、手数料、ボラティリティ、インフレ率、取り崩し税率、税区分、目標の資金に充てる口座を確認します。",
-      "step5_title": "概要を読み、What Ifを開く",
-      "step5_desc": "概要は基本プランが機能するかに答え、推移、支出カバレッジ、プラン入力を表示します。What Ifは同じプランを市場パス、ストレステスト、意思決定マップ、高度なチェックでテストします。"
+      "step5_title": "概要を読み、シミュレーションを開く",
+      "step5_desc": "概要では基本予測、支出の充足状況、入力値を確認できます。シナリオでは市場経路、ストレス条件、前提条件の変更を比較します。"
     },
     "overview": {
       "title": "概要の見方",
@@ -491,15 +497,15 @@
       "snapshot_desc": "表には、年齢ごとの期末ポートフォリオ、年間積立額、老後の収入、計画支出、ポートフォリオ取り崩し額が表示されます。"
     },
     "what_if": {
-      "title": "What Ifの見方",
+      "title": "シミュレーションの見方",
       "market_paths_title": "市場パス",
-      "market_paths_desc": "リターン、ボラティリティ、インフレの前提を使い、同じプランを多数の市場パスでテストします。帯は悪い〜良い結果の範囲を、線は中央のパスを示します。「資金持続」とは、計画期間の終わりまで必須支出を賄い、なお資金が残ることを意味します。FIREモードでは、まず経済的自立に到達する必要もあります。",
+      "market_paths_desc": "設定した前提条件で異なる市場経路をモデル化します。塗りつぶしは各年齢の第10～第90パーセンタイル、線は経路全体の中央値を表し、個別の経路ではありません。 必須支出を賄い資金を残して終了する経路を数えます。FIREの経路は経済的自立への到達も必要です。",
       "base_case_title": "基本ケース",
       "base_case_desc": "概要と同じ決定論的な基本プランを表示し、最も影響の大きいストレス結果を示して、何が最も重要かを確認できます。",
       "stress_tests_title": "ストレステスト",
       "stress_tests_desc": "リターン低下、インフレ上昇、支出増加、早期退職、貯蓄減少、退職直前の市場暴落が起きた場合にプランがどう変わるかを、固定のチェックで示します。",
       "what_moves_title": "プランを動かすものは?",
-      "what_moves_desc": "意思決定マップは貯蓄、リターン、退職年齢、支出を比較します。緑のセルは最終的に残る資金が多く、赤のセルはギャップが残るか資金不足になります。",
+      "what_moves_desc": "積立、利回り、退職年齢、支出を比較します。緑は基本計画より期末資金が多く、黄は少ないことを示します。赤は不足または残高なしを示します。",
       "crash_paths_title": "早期市場暴落パス",
       "crash_paths_desc": "退職前後の暴落タイミングのパスをいくつか比較します。退職1年目の暴落は、ポートフォリオが下落している間に取り崩しが発生するため、同じ暴落が後で起きる場合より打撃が大きくなることがあります。"
     },
@@ -508,25 +514,24 @@
       "yearly_spending_title": "年間支出のモデル化",
       "yearly_spending_desc": "支出が取り崩しを決めます。プランナーは毎年、入力された支出プランを賄い、老後の収入を差し引き、ポートフォリオ取り崩しにかかる税負担を推定します。",
       "target_calc_title": "目標額の計算方法",
-      "target_calc_desc": "プランナーは、退職から計画期間の終わりまでの支出スケジュール全体の現在価値を計算します。各支出項目のインフレ率、開始年齢の異なる収入、取り崩しの税負担が考慮されます。ポートフォリオがこの金額に達すれば、基本プランは入力されたスケジュールを賄う資本を確保できたことになります。支出の変動、開始の遅い年金、有限の期間を扱えるため、単純な支出倍率よりも正確です。",
+      "target_calc_desc": "退職後の支出を計画期間の終了まで賄うための初期ポートフォリオを推計します。支出のインフレ、収入の時期、利回り、手数料、引出税をモデル化します。目標額はこれらの前提条件によって変わります。",
       "inflation_title": "インフレ率",
-      "inflation_desc": "すべての予測で、支出とインフレ連動の収入がこの率で毎年増加します。デフォルトの2%はECBの目標に一致します。",
-      "inflation_it_note": "イタリアのCPIをより保守的に見積もる場合は2.5〜3%を使用してください。",
+      "inflation_desc": "インフレの前提により、支出と物価連動収入が経年で増加します。個々の項目には独自の率を設定できます。",
       "returns_title": "リターン・手数料・ボラティリティ",
       "returns_desc": "退職前リターンは資産形成を左右します。退職後リターンは取り崩し期と必要資本を左右します。年間投資手数料は両方から差し引かれます。ボラティリティは市場パスのチェックでのみ使用され、値が大きいほど結果の幅が広がります。",
       "horizon_title": "計画終了年齢",
-      "horizon_desc": "ポートフォリオが持続すべき期間です。退職目標とWhat Ifのチェックはこの年齢まで実行されます。長寿リスクをストレステストするには90〜95歳に設定してください。早期市場暴落パスと「資金持続」もこの年齢で測定されます。"
+      "horizon_desc": "退職後の支出とシミュレーションの結果をモデル化する上限年齢です。計画期間の前提であり、寿命の予測ではありません。"
     },
     "italian": {
       "title": "イタリアの退職設定(fondo pensione、TFR、INPS)",
       "portfolio_title": "投資ポートフォリオ(Golden Butterfly、All-Weatherなど)",
       "portfolio_desc": "これはWealthfolioが追跡するメインのポートフォリオです。リターンの前提、手数料負担、毎月の積立額をここで設定します。老後プランにおける主要な資産形成エンジンです。",
       "fondo_title": "Fondo pensione integrativo(補完的年金基金)",
-      "fondo_desc": "「年金基金を追加」を使用します。現在のファンド残高、毎月の拠出額、期待ファンドリターン、受取開始年齢を入力します。プランナーは将来残高を推定し、毎月の受取額を入力しない場合は、受取開始年齢から予想残高の3.5%/年を受取額として推定します。",
+      "fondo_desc": "「年金基金を追加」で残高、積立額、想定利回り、支払開始年齢を入力します。月額を指定しない場合、設定した支払率で推計します。取り崩しは基金の枯渇時に終了し、終身年金は計画期間の終了までモデル化されます。",
       "inps_title": "Pensione INPS(公的年金 — previdenza obbligatoria)",
       "inps_desc": "「老後の収入を追加」を使用します。現在の貨幣価値での推定月額手取り年金を入力し、受取開始年齢を設定します。プランのインフレ率の前提に合わせて増やしたい場合は「連動」を選択してください。",
       "tfr_title": "TFR(Trattamento di Fine Rapporto — 退職金積立)",
-      "tfr_desc": "TFRが年金基金に拠出される場合は、毎月のファンド拠出額に含めてください。別で保有する場合は、残高・拠出額・リターン・受取開始年齢を持つ別の年金基金としてモデル化します。毎月の受取額を入力しない限り、同じ3.5%/年の受取額推定が適用されます。"
+      "tfr_desc": "TFRが年金基金に入る場合は積立額に含めます。別管理のTFRは別の基金で表せます。モデル上の支払いは設定した支払率または月額に従います。"
     }
   },
   "type": {
@@ -773,7 +778,7 @@
       "retirement_gap": "退職時ギャップ",
       "fi_moves_prefix": "FIが",
       "fi_moves_suffix": "年後ろ倒しになります",
-      "largest_risk": "{{label}}が最大のリスクです",
+      "largest_risk": "これらのテストで最も影響が大きいのは{{label}}です",
       "and": "と",
       "none": "なし",
       "surplus": "余剰",
@@ -796,7 +801,10 @@
       "money_lasts_summary_traditional": "{{horizonAge}}歳まで資金が持続",
       "money_lasts_summary_fire": "FI達成+{{horizonAge}}歳まで資金が持続",
       "money_lasts_prompt_traditional": "1万パスを実行して、{{horizonAge}}歳まで資金が持続する頻度を確認します。",
-      "money_lasts_prompt_fire": "1万パスを実行して、FIに到達し{{horizonAge}}歳まで資金が持続する頻度を確認します。"
+      "money_lasts_prompt_fire": "1万パスを実行して、FIに到達し{{horizonAge}}歳まで資金が持続する頻度を確認します。",
+      "of_simulated_paths": "シミュレーション経路の割合",
+      "simulation_tooltip_traditional": "シミュレーション経路の{{percent}}%が必須支出を賄い、資金を残して終了しました。色の参考区分は75%未満、75%以上90%未満、90%以上です。モデル上の結果であり、現実の確率ではありません。",
+      "simulation_tooltip_fire": "シミュレーション経路の{{percent}}%が必須支出を賄い、資金を残して終了しました。経済的自立への到達も条件です。色の参考区分は75%未満、75%以上90%未満、90%以上です。モデル上の結果であり、現実の確率ではありません。"
     },
     "stress": {
       "eyebrow_with_count": "このプランを崩すものは? · {{count}}シナリオ",
@@ -811,8 +819,8 @@
     },
     "montecarlo": {
       "eyebrow": "市場パス",
-      "heading": "資金はどのくらいの確率で持続する?",
-      "intro": "同じプランを多数の市場パスでテストします。帯は悪い〜良い結果の範囲を、線は中央のパスを示します。",
+      "heading": "資金が持続するシミュレーションの割合は？",
+      "intro": "設定した前提条件で異なる市場経路をモデル化します。塗りつぶしは各年齢の第10～第90パーセンタイル、線は経路全体の中央値を表し、個別の経路ではありません。",
       "run_10k": "1万パスを実行",
       "run_100k": "10万パスを実行",
       "running_short": "実行中…",
@@ -824,29 +832,30 @@
       "median_fi_age": "FI年齢の中央値",
       "withdrawals_start_detail": "取り崩し開始",
       "vs_goal": "目標{{age}}歳比",
-      "bad_path": "悪いパス",
-      "middle_path": "中央パス",
-      "good_path": "良いパス"
+      "bad_path": "下位の結果",
+      "middle_path": "中央値",
+      "good_path": "上位の結果"
     },
     "chart": {
       "age_label": "{{age}}歳",
       "age_detail": "{{age}}歳",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "FI中央値 @{{age}}",
-      "bad_good_range": "悪い〜良いの範囲",
-      "median_path": "中央値パス",
+      "bad_good_range": "第10～第90パーセンタイル",
+      "median_path": "中央値",
       "retirement_age": "退職年齢",
       "goal_age": "目標年齢",
       "median_fi_age": "FI年齢の中央値",
       "market_paths_count": "{{count}}本の市場パス",
       "retire": "退職",
       "goal": "目標",
-      "market_paths_count_other": "{{count}}本の市場パス"
+      "market_paths_count_other": "{{count}}本の市場パス",
+      "percentile_at_age": "第{{percentile}}パーセンタイル · {{age}}歳"
     },
     "moves": {
       "eyebrow": "プランを最も変えるものは?",
       "heading": "プランを動かすものは?",
-      "description": "貯蓄、リターン、退職年齢、支出が結果をどう変えるかを示します。緑=最終的に残る資金が多い、赤=不足または資金切れ。",
+      "description": "積立、利回り、退職年齢、支出を比較します。緑は基本計画より期末資金が多く、黄は少ないことを示します。赤は不足または残高なしを示します。",
       "empty_title": "どの変更が最も効果的かを確認しましょう。",
       "empty_description": "積立を増やす、異なるリターン、支出を減らす、退職年齢を変える、を比較します。",
       "building": "作成中...",
@@ -875,6 +884,39 @@
       "unavailable_title": "暴落パスを利用できません。",
       "empty_description": "5つのパスを実行して、どの順序がプランに最初に負荷をかけるかを確認します。",
       "unavailable_description": "このチェックには、退職開始時点でプラスの予想ポートフォリオが必要です。"
+    },
+    "labels": {
+      "crash_year_1": "1年目の急落（−30%）",
+      "crash_year_5": "5年目の急落（−30%）",
+      "double_crash": "2回の急落",
+      "lost_decade": "失われた10年",
+      "after_fee_return": "手数料控除後の利回り"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "利回り低下",
+        "description": "退職前と退職後の利回りが2パーセントポイント低下します。"
+      },
+      "inflation-shock": {
+        "label": "インフレ上昇",
+        "description": "全体のインフレ率が1.5パーセントポイント上昇します。"
+      },
+      "spending-shock": {
+        "label": "支出増加",
+        "description": "退職後のすべての支出額が10%増加します。"
+      },
+      "retire-earlier": {
+        "label": "退職を2年前倒し",
+        "description": "計画の現在年齢を下限として、目標退職年齢を2年前倒しします。"
+      },
+      "save-less": {
+        "label": "積立額減少",
+        "description": "毎月の積立額が25%減少します。"
+      },
+      "early-crash": {
+        "label": "退職初期の市場急落",
+        "description": "退職1年目に市場が30%下落するモデルです。"
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/ko/goals.json
+++ b/apps/frontend/src/i18n/locales/ko/goals.json
@@ -107,18 +107,18 @@
       "on_track": "정상 진행",
       "fi_reached": "경제적 자유 달성",
       "at_risk": "위험",
-      "never_reaches_fi": "경제적 자유 달성 불가",
+      "never_reaches_fi": "{{age}}세까지 도달이 예측되지 않음",
       "years_late_one": "{{count}}년 지연",
       "years_late_other": "{{count}}년 지연"
     },
     "verdict": {
       "age": "{{age}}세",
-      "spending_gap_prefix": "지출 격차가",
-      "spending_gap_suffix": "부터 발생해 {{age}}세에 도달하기 전 계획이 어려워집니다.",
-      "short_prefix": "{{age}}세 시점에",
-      "short_suffix": "이 부족해 {{age}}세까지 은퇴 생활을 지속할 수 없습니다.",
-      "depleted_prefix": "포트폴리오가",
-      "depleted_suffix": "에 {{age}}세 은퇴 이후 바닥납니다.",
+      "spending_gap_prefix": "지출 부족 시작 예상 나이:",
+      "spending_gap_suffix": "(계획 기간: {{age}}세까지).",
+      "short_prefix": "{{age}}세의 예상 부족액은",
+      "short_suffix": "입니다({{age}}세까지의 은퇴 생활 기준).",
+      "depleted_prefix": "포트폴리오 부족 예상 나이:",
+      "depleted_suffix": "({{age}}세 은퇴 기준).",
       "surplus_prefix": "{{age}}세에 은퇴할 것으로 예상되며, 예상 여유 자금은",
       "surplus_suffix": "입니다.",
       "on_track_prefix": "예상 은퇴 시점은",
@@ -126,33 +126,23 @@
       "fi_reached_prefix": "이미",
       "financial_independence": "경제적 자유",
       "fi_reached_suffix": "를 — 현재 가정 기준으로 — 달성했습니다.",
-      "fi_at_prefix": "경제적 자유 달성 예상 시점은",
-      "years_after_one": "{{count}}년 후",
-      "years_after_other": "{{count}}년 후",
-      "years_before_one": "{{count}}년 전",
-      "years_before_other": "{{count}}년 전",
-      "your_goal_of": "목표인 {{age}}세",
-      "right_on_goal": "목표인 {{age}}세에 정확히 맞습니다.",
-      "not_reachable_prefix": "현재 가정으로는",
-      "not_reachable_suffix": "까지 도달할 수 없습니다."
+      "not_reachable_prefix": "현재 가정에서 경제적 독립은",
+      "not_reachable_suffix": "까지 달성되지 않을 것으로 예상됩니다.",
+      "fi_projected": "<age>{{age}}세</age>에 경제적 독립에 도달할 것으로 예측됩니다."
     },
     "summary": {
-      "at_your_current_prefix": "현재",
-      "contribution": "납입액 기준으로,",
-      "capital_not_available": "현재 가정으로는 필요 자본 목표를 산출할 수 없습니다. 지출, 인플레이션, 수익률, 기대 수명을 다시 확인해 보세요.",
-      "projected_balance_is": "예상 은퇴 자산은",
-      "vs_required_capital_of": "이며, 필요 자본",
       "at_age": "({{age}}세 기준) 대비 비교됩니다.",
-      "the_plan_funds": "이 계획은 연간",
-      "per_yr_expenses_to_age": "의 지출을 {{age}}세까지 충당합니다.",
-      "youre_short": "부족한 금액은"
+      "youre_short": "예상 부족액은",
+      "traditional": "현재 가정과 <contribution>{{contribution}}</contribution> 납입을 기준으로 {{age}}세의 예상 잔액은 <balance>{{balance}}</balance>이며 필요 자금은 <target>{{target}}</target>입니다.",
+      "fire": "현재 가정과 <contribution>{{contribution}}</contribution> 납입을 기준으로 계획에는 {{age}}세까지 연간 <budget>{{budget}}</budget>의 지출이 포함됩니다.",
+      "unavailable": "현재 가정과 <contribution>{{contribution}}</contribution> 납입으로는 목표 자금을 추정할 수 없습니다. 만약에에서 가정을 비교하세요."
     },
     "progress": {
       "portfolio_today": "현재 포트폴리오",
       "required_at_age": "{{age}}세 시점 필요 금액",
       "target_at_age": "{{age}}세 시점 목표 금액",
-      "capital_needed_tip_traditional": "은퇴 연령 시점에 지출, 소득, 세금, 은퇴 후 수익률, 수수료를 반영해 필요한 자본입니다. {{valueLabel}} 기준으로 표시됩니다.",
-      "capital_needed_tip_fire": "희망 은퇴 연령 시점에 지출, 소득, 세금, 은퇴 후 수익률, 수수료를 반영해 필요한 자본입니다. {{valueLabel}} 기준으로 표시됩니다.",
+      "capital_needed_tip_traditional": "계획의 지출, 소득, 세금, 수익률과 수수료 가정에 따른 목표 은퇴 나이의 추정 필요 자금입니다. 표시 기준: {{valueLabel}}.",
+      "capital_needed_tip_fire": "계획의 지출, 소득, 세금, 수익률과 수수료 가정에 따른 목표 은퇴 나이의 추정 필요 자금입니다. 표시 기준: {{valueLabel}}.",
       "not_available": "확인 불가",
       "funded_pct": "{{pct}}% 충당됨"
     },
@@ -169,18 +159,18 @@
     },
     "milestone": {
       "coast_fire": "코스트 파이어(Coast FIRE)",
-      "coast_hint": "추가 납입 없이도 제때 은퇴 가능",
-      "coast_tip_nominal": "코스트 금액을 희망 은퇴 연령 시점의 명목 금액으로 환산한 값입니다.",
-      "coast_tip_real": "추가 납입 없이도 은퇴 연령까지 완전한 경제적 자유로 성장하는 데 필요한 현재 시점의 자본입니다.",
+      "coast_hint": "현재 필요한 추정 자금",
+      "coast_tip_nominal": "현재 필요한 추정 자금을 가정 인플레이션으로 은퇴 나이의 금액으로 환산합니다. 가치 환산이며 투자 성장 예측이 아닙니다.",
+      "coast_tip_real": "은퇴 목표액을 수수료 차감 후 은퇴 전 가정 수익률로 할인한 현재 추정 자금입니다. 연금 가정은 유지됩니다.",
       "lean_fire": "린 파이어(Lean FIRE)",
       "lean_hint": "계획 지출의 70%",
-      "lean_tip": "계획 지출의 약 70% 수준인 검소한 예산으로 은퇴합니다. 더 일찍 실현 가능하지만 여유는 적습니다.",
+      "lean_tip": "다른 가정은 유지하고 계획 지출의 70%에 대해 추정한 자금입니다. 이 플래너의 Lean FIRE 시나리오입니다.",
       "fi": "경제적 자유(FI)",
       "fi_hint": "전체 계획 지출",
       "fi_tip": "전체 은퇴 기간 동안 계획된 은퇴 지출을 충당하는 자본입니다.",
       "fat_fire": "팻 파이어(Fat FIRE)",
       "fat_hint": "계획 지출의 150%",
-      "fat_tip": "계획보다 약 50% 더 많은 지출로 은퇴합니다 — 여행, 선물, 변동성, 생활 수준 향상을 위한 여유가 있습니다.",
+      "fat_tip": "다른 가정은 유지하고 계획 지출의 150%에 대해 추정한 자금입니다. 이 플래너의 Fat FIRE 시나리오입니다.",
       "more_info_about": "{{label}}에 대한 자세한 정보",
       "done": "완료"
     },
@@ -217,11 +207,26 @@
       "unfunded": "미충당",
       "planned_spending_legend": "계획 지출",
       "showing": "{{valueLabel}} 표시 중",
-      "projection_unavailable": "이 계획에서는 자금 충당 예측을 사용할 수 없습니다."
+      "projection_unavailable": "이 계획에서는 자금 충당 예측을 사용할 수 없습니다.",
+      "age_range": "{{start}}세 → {{end}}세",
+      "starts_at": "{{age}}세부터 시작",
+      "ended_at": "{{age}}세에 종료",
+      "not_active": "비활성"
     },
     "disclaimer": {
       "title": "꼭 기억해야 할 사항",
-      "body": "이는 재무 자문이 아닙니다. 이 수치는 예측이 아니라 하나의 스케치로 봐 주세요. 여기에 표시된 모든 내용은 사용자가 입력한 값 — 수익률, 인플레이션, 납입액, 세금, 예상 수명 —을 기반으로 한 시뮬레이션입니다. 실제 시장은 일직선으로 움직이지 않고, 세법은 바뀌며, 정부 제도는 개편됩니다. 이를 활용해 아이디어를 검증하고 빈틈을 찾은 다음, 되돌리기 어려운 결정을 내리기 전에 반드시 전문가와 상담하세요."
+      "body": "예측은 가정에 따라 달라집니다. 실제 결과는 다를 수 있습니다. 금융 조언이 아닙니다."
+    },
+    "guidance": {
+      "unavailable": "현재 가정으로 목표를 추정할 수 없습니다. 만약에에서 가정을 비교하세요.",
+      "depleted": "{{age}}세에 포트폴리오 자금 부족이 예측됩니다. 만약에에서 가정을 비교하세요.",
+      "gap": "{{age}}세부터 지출 부족분이 발생할 것으로 예측됩니다. 만약에에서 가정을 비교하세요.",
+      "fund": "{{label}}은 {{age}}세에 소진될 것으로 예측되며 이후 모델상 지급이 중단됩니다. 지급 및 소득 가정을 비교하세요.",
+      "shortfall": "은퇴 시 부족분이 예측됩니다. 만약에에서 가정을 비교하세요.",
+      "reached": "현재 포트폴리오는 설정한 가정에 따른 추정 경제적 독립 목표에 도달했습니다.",
+      "not_reached": "{{age}}세까지 경제적 독립이 예측되지 않습니다. 만약에에서 가정을 비교하세요.",
+      "late_one": "경제적 독립은 희망 나이보다 {{count}}년 후로 예측됩니다. 만약에에서 가정을 비교하세요.",
+      "late_other": "경제적 독립은 희망 나이보다 {{count}}년 후로 예측됩니다. 만약에에서 가정을 비교하세요."
     }
   },
   "sidebar": {
@@ -231,7 +236,8 @@
       "high_inflation": "높은 인플레이션 가정입니다. 이 비율에서는 장기 지출 필요액이 더 민감하게 반응합니다.",
       "high_fee": "높은 수수료 가정입니다. 수수료 부담이 장기 수익률을 크게 낮춥니다.",
       "high_volatility": "높은 변동성 가정입니다. 결과 범위가 매우 넓어질 수 있습니다.",
-      "high_contribution_growth": "높은 납입 증가율 가정입니다. 이는 지속적으로 큰 폭의 저축 증가를 전제로 합니다."
+      "high_contribution_growth": "높은 납입 증가율 가정입니다. 이는 지속적으로 큰 폭의 저축 증가를 전제로 합니다.",
+      "high_return": "높은 수익률 가정입니다. 예상 잔액은 이 비율에 민감합니다."
     },
     "plan": {
       "kicker": "계획",
@@ -252,14 +258,14 @@
       "desired_retirement_age_hint": "경제적으로 자유로워지고 싶은 나이입니다.",
       "retirement_age_hint": "은퇴하고 싶은 나이입니다.",
       "horizon_age_fire": "계획 종료 연령",
-      "horizon_age_traditional": "기대 수명",
+      "horizon_age_traditional": "계획 종료 연령",
       "horizon_hint": "계획이 대상으로 하는 최대 연령입니다.",
       "monthly_contribution": "월 납입액",
       "monthly_contribution_hint": "은퇴 전까지 매달 추가로 납입할 금액입니다.",
-      "return_before_hint": "저축 기간 동안 예상되는 연간 수익률입니다.",
-      "return_during_hint": "인출 시작 이후 예상되는 연간 수익률입니다.",
+      "return_before_hint": "저축 기간의 연간 가정 수익률이며 투자 수수료 차감 전입니다.",
+      "return_during_hint": "인출 시작 후의 연간 가정 수익률이며 투자 수수료 차감 전입니다.",
       "annual_fee_hint": "예상 연간 포트폴리오 수수료입니다.",
-      "inflation_hint": "예상되는 연간 물가 상승률입니다."
+      "inflation_hint": "연간 가정 물가 상승률입니다."
     },
     "spending": {
       "kicker": "지출",
@@ -320,13 +326,13 @@
       "fund_return_before_payout": "지급 전 펀드 수익률",
       "fund_payout_rate": "지급률",
       "fund_payout_mode": "지급 방식",
-      "fund_payout_mode_help": "연금은 평생 지급되고, 인출은 자금이 소진될 때까지 꺼내 씁니다.",
+      "fund_payout_mode_help": "연금 방식은 계획 기간까지 지속적인 지급을 모델링하며 인출 방식은 펀드가 소진될 때까지 잔액을 사용합니다.",
       "annuity": "연금",
       "drawdown": "인출",
       "fund_return_during_payout": "지급 기간 중 펀드 수익률",
-      "drawdown_note": "인출은 지급 개시 연령의 잔액에서 연 {{pct}}%를 꺼내고, 이후에는 아래 증가 설정에 따라 자금이 소진될 때까지 이어집니다.",
+      "drawdown_note": "인출액은 펀드 잔액의 연 {{pct}}%로 추정합니다. 지급이 이미 시작된 경우 입력한 월 지급액이 우선합니다. 이후 지급액은 설정한 증가율에 따라 조정되며 자금이 소진되면 지급이 중단됩니다.",
       "monthly_payout_after_tax": "세후 월 지급액",
-      "payout_estimate_note": "월 지급액을 직접 입력하지 않으면 예상 지급액은 예측된 펀드 잔액의 연 {{pct}}%로 계산됩니다.",
+      "payout_estimate_note": "예상 지급액은 펀드 잔액의 연 {{pct}}%로 계산합니다. 지급이 이미 시작된 경우 입력한 월 지급액이 우선합니다.",
       "start_age": "시작 연령",
       "income_growth": "소득 증가율",
       "income_growth_help": "이 소득이 계획 인플레이션에 따라 증가할지, 고정된 상태로 유지될지 선택하세요.",
@@ -465,15 +471,15 @@
     "quick_start": {
       "title": "빠른 시작 — 5단계",
       "step1_title": "계획의 기본값 설정하기",
-      "step1_desc": "계획 입력값에서 계획 유형, 출생월, 은퇴 연령, 기대 수명, 월 납입액을 선택하세요.",
+      "step1_desc": "계획 입력에서 유형, 출생 월, 은퇴 나이, 계획 종료 나이, 월 납입액을 설정합니다.",
       "step2_title": "은퇴 후 지출 입력하기",
       "step2_desc": "은퇴 후 지출에서 계획이 충당해야 할 월 지출 항목을 추가하세요. 현재 화폐 가치로 입력하면 되며, 인플레이션은 계획 가정에서 자동으로 처리됩니다.",
       "step3_title": "은퇴 소득 추가하기",
-      "step3_desc": "은퇴 소득에서 공적 연금(예: 캐나다의 CPP/OAS, 미국의 Social Security), 직장 연금, 파트타임 근로, 연금 소득 등 월별 소득원을 추가하세요. 연금 펀드 추가는 월 지급액을 직접 입력하지 않고 플래너가 펀드 잔액 기준 연 3.5% 지급액을 추정하도록 할 때만 사용하세요.",
+      "step3_desc": "연금, 시간제 근로, 종신연금 등의 은퇴 소득을 추가합니다. 연금 펀드의 월 지급 추정액은 월 금액을 직접 입력하지 않는 한 예상 잔액과 설정한 연간 지급률을 사용합니다.",
       "step4_title": "가정, 세금, 계좌 비중 확인하기",
       "step4_desc": "예상 수익률, 수수료, 변동성, 인플레이션, 인출 세율, 세금 그룹, 그리고 어떤 계좌가 목표 자금을 충당하는지 검토하세요.",
       "step5_title": "개요를 읽고 만약에를 열어보기",
-      "step5_desc": "개요는 기본 계획이 성립하는지 알려주며, 자산 추이, 지출 충당 현황, 계획 입력값을 보여줍니다. 만약에는 같은 계획을 시장 경로, 스트레스 테스트, 의사 결정 맵, 고급 검증 기준으로 테스트합니다."
+      "step5_desc": "개요는 기본 예측, 지출 충당과 입력값을 보여줍니다. 시나리오는 시장 경로, 스트레스 조건과 가정 변경을 비교합니다."
     },
     "overview": {
       "title": "개요 이해하기",
@@ -493,13 +499,13 @@
     "what_if": {
       "title": "만약에 이해하기",
       "market_paths_title": "시장 경로",
-      "market_paths_desc": "수익률, 변동성, 인플레이션 가정을 사용해 같은 계획을 다양한 시장 경로에서 테스트합니다. 음영 처리된 범위는 나쁨부터 좋음까지의 결과를 보여주고, 선은 중간 경로를 보여줍니다. '자금이 유지됨'은 계획이 필수 지출을 충당하면서 계획 기간 끝까지 자금이 남아 있음을 의미합니다. 파이어(FIRE) 모드에서는 먼저 경제적 자유를 달성해야 합니다.",
+      "market_paths_desc": "설정한 가정으로 다양한 시장 경로를 모델링합니다. 음영은 각 나이의 10~90 백분위 범위이며 선은 개별 경로가 아닌 경로 전체의 중앙값입니다. 필수 지출을 충당하고 잔액을 남기고 종료한 경로를 집계합니다. FIRE 경로는 경제적 독립에도 도달해야 합니다.",
       "base_case_title": "기본 시나리오",
       "base_case_desc": "개요와 동일한 결정론적 기본 계획을 보여준 다음, 가장 큰 스트레스 테스트 결과를 가리켜 무엇이 가장 중요한지 알 수 있게 합니다.",
       "stress_tests_title": "스트레스 테스트",
       "stress_tests_desc": "고정된 검증 항목으로 수익률이 낮아지거나, 인플레이션이 높아지거나, 지출이 늘어나거나, 은퇴가 앞당겨지거나, 저축이 줄거나, 은퇴 직전 시장 폭락이 발생할 때 계획이 어떻게 바뀌는지 보여줍니다.",
       "what_moves_title": "계획에 가장 큰 영향을 주는 요인은?",
-      "what_moves_desc": "의사 결정 맵은 저축액, 수익률, 은퇴 연령, 지출을 비교합니다. 초록색 셀은 마지막에 더 많은 자금이 남는다는 뜻이고, 빨간색 셀은 여전히 격차가 있거나 자금이 부족하다는 뜻입니다.",
+      "what_moves_desc": "저축, 수익률, 은퇴 나이, 지출을 비교합니다. 녹색은 기본 계획보다 최종 잔액이 많고 황색은 적음을 뜻합니다. 빨간색은 부족분 또는 잔액 없음을 나타냅니다.",
       "crash_paths_title": "초기 시장 폭락 경로",
       "crash_paths_desc": "은퇴 직전의 여러 폭락 시점 경로를 비교합니다. 은퇴 첫해에 발생한 폭락은 포트폴리오가 하락한 상태에서 인출이 이루어지기 때문에 나중에 발생한 동일한 폭락보다 더 큰 타격을 줄 수 있습니다."
     },
@@ -508,25 +514,24 @@
       "yearly_spending_title": "연간 지출 모델링 방식",
       "yearly_spending_desc": "지출이 인출을 결정합니다. 매년 플래너는 입력한 지출 계획을 충당하고, 은퇴 소득을 차감하고, 포트폴리오 인출에 대한 세금 부담을 추정합니다.",
       "target_calc_title": "목표 계산 방식",
-      "target_calc_desc": "플래너는 은퇴 시점부터 계획 기간까지의 전체 지출 계획의 현재 가치를 계산합니다 — 각 지출 항목의 인플레이션율, 서로 다른 연령에 시작되는 소득원, 인출에 대한 세금 부담을 모두 고려합니다. 포트폴리오가 이 금액에 도달하면 기본 계획은 입력한 계획을 충당할 충분한 자본을 갖춘 것입니다. 이는 변동 지출, 이연 연금, 유한한 계획 기간을 모두 반영하기 때문에 단순히 지출의 배수를 사용하는 방식보다 정확합니다.",
+      "target_calc_desc": "플래너는 계획 기간까지 은퇴 지출을 충당하는 데 필요한 초기 포트폴리오를 추정합니다. 지출 인플레이션, 소득 시점, 수익률, 수수료, 인출세를 모델링합니다. 목표는 이러한 가정에 따라 달라집니다.",
       "inflation_title": "인플레이션율",
-      "inflation_desc": "모든 예측은 이 비율로 매년 지출과 물가 연동 소득을 늘려 나갑니다. 기본값 2%는 유럽중앙은행(ECB) 목표치와 일치합니다.",
-      "inflation_it_note": "이탈리아 소비자물가지수(CPI)를 더 보수적으로 가정하려면 2.5~3%를 사용하세요.",
+      "inflation_desc": "인플레이션 가정은 시간이 지남에 따라 지출과 물가 연동 소득을 증가시킵니다. 개별 항목은 별도의 비율을 사용할 수 있습니다.",
       "returns_title": "수익률, 수수료, 변동성",
       "returns_desc": "은퇴 전 수익률은 자산 축적을 좌우합니다. 은퇴 후 수익률은 인출 단계와 필요 자본을 좌우합니다. 연간 투자 수수료는 두 경우 모두에서 차감됩니다. 변동성은 시장 경로 검증에서만 사용되며, 값이 클수록 결과 범위가 넓어집니다.",
       "horizon_title": "계획 기간(연령)",
-      "horizon_desc": "포트폴리오가 얼마나 오래 유지되어야 하는지를 나타냅니다. 은퇴 목표와 만약에 검증은 이 연령까지 실행됩니다. 장수 리스크를 검증하려면 90~95세로 설정하세요. 초기 시장 폭락 경로와 자금 유지 여부는 모두 이 기간 기준으로 측정됩니다."
+      "horizon_desc": "은퇴 지출과 만약에 결과를 모델링하는 마지막 나이입니다. 계획 기간에 대한 가정이며 수명 예측이 아닙니다."
     },
     "italian": {
       "title": "이탈리아 은퇴 설정(fondo pensione, TFR, INPS)",
       "portfolio_title": "투자 포트폴리오(Golden Butterfly, All-Weather 등)",
       "portfolio_desc": "이는 Wealthfolio가 추적하는 값인 주요 포트폴리오입니다. 여기에서 수익률 가정, 수수료 부담, 월 납입액을 설정하세요. 은퇴 계획의 핵심적인 자산 축적 엔진입니다.",
       "fondo_title": "Fondo pensione integrativo(보충 연금 펀드)",
-      "fondo_desc": "연금 펀드 추가를 사용하세요. 현재 펀드 잔액, 월 납입액, 예상 펀드 수익률, 지급 시작 연령을 입력하세요. 월 지급액을 직접 입력하지 않으면 플래너는 미래 잔액을 추정하고, 시작 연령부터 예측 잔액의 연 3.5%를 지급액으로 추정합니다.",
+      "fondo_desc": "연금 펀드 추가에서 잔액, 납입액, 가정 수익률, 지급 시작 나이를 입력합니다. 월 금액을 입력하지 않으면 설정한 지급률로 추정합니다. 인출은 펀드 소진 시 중단되며 종신연금은 계획 기간까지 모델링됩니다.",
       "inps_title": "Pensione INPS(국가 연금 — previdenza obbligatoria)",
       "inps_desc": "은퇴 소득 추가를 사용하세요. 현재 화폐 가치 기준 예상 월 순연금을 입력하고 지급 시작 연령을 설정하세요. 소득이 계획 인플레이션 가정에 따라 오르길 원하면 물가 연동을 사용하세요.",
       "tfr_title": "TFR(Trattamento di Fine Rapporto — 퇴직금 적립)",
-      "tfr_desc": "TFR이 연금 펀드로 들어간다면 월 펀드 납입액에 포함하세요. 별도로 보관한다면 자체 잔액, 납입액, 수익률, 지급 시작 연령을 가진 또 다른 연금 펀드로 모델링하세요. 월 지급액을 직접 입력하지 않으면 동일하게 연 3.5% 지급액 추정치가 적용됩니다."
+      "tfr_desc": "TFR이 연금 펀드에 포함되면 납입액에 반영하세요. 별도 TFR 저축은 별도 펀드로 나타낼 수 있으며 모델상 지급은 설정한 지급률 또는 월 금액을 따릅니다."
     }
   },
   "type": {
@@ -773,7 +778,7 @@
       "retirement_gap": "은퇴 자금 격차",
       "fi_moves_prefix": "경제적 자유 달성 시점이",
       "fi_moves_suffix": "년 늦춰짐",
-      "largest_risk": "{{label}}이(가) 가장 큰 위험 요인입니다",
+      "largest_risk": "이 테스트 중 {{label}}의 영향이 가장 큽니다",
       "and": "그리고",
       "none": "없음",
       "surplus": "여유 자금",
@@ -796,7 +801,10 @@
       "money_lasts_summary_traditional": "{{horizonAge}}세까지 자금이 유지됨",
       "money_lasts_summary_fire": "경제적 자유 달성 + {{horizonAge}}세까지 자금 충당됨",
       "money_lasts_prompt_traditional": "1만 개 경로를 실행해 계획이 {{horizonAge}}세까지 얼마나 자주 유지되는지 확인하세요.",
-      "money_lasts_prompt_fire": "1만 개 경로를 실행해 계획이 경제적 자유를 달성하고 {{horizonAge}}세까지 얼마나 자주 유지되는지 확인하세요."
+      "money_lasts_prompt_fire": "1만 개 경로를 실행해 계획이 경제적 자유를 달성하고 {{horizonAge}}세까지 얼마나 자주 유지되는지 확인하세요.",
+      "of_simulated_paths": "시뮬레이션 경로 중",
+      "simulation_tooltip_traditional": "시뮬레이션 경로의 {{percent}}%가 필수 지출을 충당하고 잔액을 남긴 채 종료되었습니다. 색상 기준 구간은 75% 미만, 75% 이상 90% 미만, 90% 이상입니다. 모델 결과이며 실제 확률이 아닙니다.",
+      "simulation_tooltip_fire": "시뮬레이션 경로의 {{percent}}%가 필수 지출을 충당하고 잔액을 남긴 채 종료되었습니다. 경제적 독립에도 도달해야 합니다. 색상 기준 구간은 75% 미만, 75% 이상 90% 미만, 90% 이상입니다. 모델 결과이며 실제 확률이 아닙니다."
     },
     "stress": {
       "eyebrow_with_count": "이 계획을 무너뜨릴 수 있는 요인은? · 시나리오 {{count}}개",
@@ -812,7 +820,7 @@
     "montecarlo": {
       "eyebrow": "시장 경로",
       "heading": "자금이 얼마나 자주 유지될까요?",
-      "intro": "수익률, 변동성, 인플레이션 가정을 사용해 같은 계획을 다양한 시장 경로에서 테스트합니다. 음영 처리된 범위는 나쁨부터 좋음까지의 결과를 보여주고, 선은 중간 경로를 보여줍니다.",
+      "intro": "설정한 가정으로 다양한 시장 경로를 모델링합니다. 음영은 각 나이의 10~90 백분위 범위이며 선은 개별 경로가 아닌 경로 전체의 중앙값입니다.",
       "run_10k": "1만 개 경로 실행",
       "run_100k": "10만 개 경로 실행",
       "running_short": "실행 중…",
@@ -824,29 +832,30 @@
       "median_fi_age": "중앙값 경제적 자유 달성 연령",
       "withdrawals_start_detail": "인출 시작",
       "vs_goal": "목표 {{age}}세 대비",
-      "bad_path": "나쁜 경로",
-      "middle_path": "중간 경로",
-      "good_path": "좋은 경로"
+      "bad_path": "하위 결과",
+      "middle_path": "중앙값",
+      "good_path": "상위 결과"
     },
     "chart": {
       "age_label": "{{age}}세",
       "age_detail": "{{age}}세",
       "goal_at_age": "{{label}} @{{age}}세",
       "median_fi_at_age": "중앙값 경제적 자유 @{{age}}세",
-      "bad_good_range": "나쁨-좋음 범위",
-      "median_path": "중앙값 경로",
+      "bad_good_range": "10~90 백분위 범위",
+      "median_path": "중앙값",
       "retirement_age": "은퇴 연령",
       "goal_age": "목표 연령",
       "median_fi_age": "중앙값 경제적 자유 달성 연령",
       "market_paths_count": "시장 경로 {{count}}개",
       "retire": "은퇴",
       "goal": "목표",
-      "market_paths_count_other": "시장 경로 {{count}}개"
+      "market_paths_count_other": "시장 경로 {{count}}개",
+      "percentile_at_age": "{{percentile}} 백분위 · {{age}}세"
     },
     "moves": {
       "eyebrow": "계획에 가장 큰 영향을 주는 요인은?",
       "heading": "계획에 가장 큰 영향을 주는 요인은?",
-      "description": "저축액, 수익률, 은퇴 연령, 지출이 결과를 어떻게 바꾸는지 보여줍니다. 초록색 = 잔여 자금 증가, 빨간색 = 부족 또는 자금 소진.",
+      "description": "저축, 수익률, 은퇴 나이, 지출을 비교합니다. 녹색은 기본 계획보다 최종 잔액이 많고 황색은 적음을 뜻합니다. 빨간색은 부족분 또는 잔액 없음을 나타냅니다.",
       "empty_title": "어떤 변화가 가장 도움이 될지 확인하세요.",
       "empty_description": "저축을 늘리거나, 다른 수익률을 기대하거나, 지출을 줄이거나, 다른 연령에 은퇴하는 경우를 비교해 보세요.",
       "building": "생성 중...",
@@ -875,6 +884,39 @@
       "unavailable_title": "폭락 경로를 사용할 수 없습니다.",
       "empty_description": "다섯 가지 경로를 실행해 어떤 순서가 계획에 가장 먼저 압박을 줄지 확인하세요.",
       "unavailable_description": "이 검증에는 은퇴 시작 시점에 양(+)의 예측 포트폴리오 값이 필요합니다."
+    },
+    "labels": {
+      "crash_year_1": "1년 차 급락(−30%)",
+      "crash_year_5": "5년 차 급락(−30%)",
+      "double_crash": "두 번의 급락",
+      "lost_decade": "잃어버린 10년",
+      "after_fee_return": "수수료 차감 후 수익률"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "수익률 하락",
+        "description": "은퇴 전과 은퇴 중 수익률이 2%포인트 낮아집니다."
+      },
+      "inflation-shock": {
+        "label": "인플레이션 상승",
+        "description": "전체 인플레이션이 1.5%포인트 높아집니다."
+      },
+      "spending-shock": {
+        "label": "지출 증가",
+        "description": "모든 은퇴 지출 금액이 10% 높아집니다."
+      },
+      "retire-earlier": {
+        "label": "은퇴 2년 앞당김",
+        "description": "계획의 현재 나이를 기준으로 한도 내에서 목표 은퇴 나이를 2년 앞당깁니다."
+      },
+      "save-less": {
+        "label": "납입액 감소",
+        "description": "월 납입액이 25% 낮아집니다."
+      },
+      "early-crash": {
+        "label": "은퇴 초기 시장 급락",
+        "description": "은퇴 첫해에 시장이 30% 하락하는 것으로 모델링합니다."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/pt/goals.json
+++ b/apps/frontend/src/i18n/locales/pt/goals.json
@@ -130,8 +130,6 @@
       "fi_reached_prefix": "Você alcançou a",
       "financial_independence": "independência financeira",
       "fi_reached_suffix": "— com as premissas atuais.",
-      "years_after_many": "{{count}} anos depois de",
-      "years_before_many": "{{count}} anos antes de",
       "not_reachable_prefix": "Não projetada até",
       "not_reachable_suffix": "com as premissas atuais.",
       "fi_projected": "Pelas projeções, você alcançará a independência financeira aos <age>{{age}} anos</age>."
@@ -232,7 +230,8 @@
       "reached": "A carteira atual atinge a meta estimada de independência financeira segundo suas premissas.",
       "not_reached": "A independência financeira não é projetada até os {{age}} anos. Compare premissas em E se.",
       "late_one": "A independência financeira é projetada {{count}} ano após a idade desejada. Compare premissas em E se.",
-      "late_other": "A independência financeira é projetada {{count}} anos após a idade desejada. Compare premissas em E se."
+      "late_other": "A independência financeira é projetada {{count}} anos após a idade desejada. Compare premissas em E se.",
+      "late_many": "A independência financeira é projetada {{count}} anos após a idade desejada. Compare premissas em E se."
     }
   },
   "sidebar": {

--- a/apps/frontend/src/i18n/locales/pt/goals.json
+++ b/apps/frontend/src/i18n/locales/pt/goals.json
@@ -110,18 +110,18 @@
       "on_track": "No caminho certo",
       "fi_reached": "IF alcançada",
       "at_risk": "Em risco",
-      "never_reaches_fi": "Nunca alcança a IF",
+      "never_reaches_fi": "Não projetada até os {{age}}",
       "years_late_one": "{{count}} ano atrasado",
       "years_late_other": "{{count}} anos atrasado",
       "years_late_many": "{{count}} anos atrasado"
     },
     "verdict": {
       "age": "idade {{age}}",
-      "spending_gap_prefix": "O déficit de gastos começa aos",
+      "spending_gap_prefix": "Um déficit de gastos é projetado a partir de",
       "spending_gap_suffix": "antes de o plano alcançar a idade {{age}}.",
-      "short_prefix": "À idade {{age}}, faltam",
+      "short_prefix": "Aos {{age}} anos, seu déficit projetado é de",
       "short_suffix": "para financiar a aposentadoria até a idade {{age}}.",
-      "depleted_prefix": "A carteira fica a descoberto por",
+      "depleted_prefix": "A carteira será insuficiente, segundo a projeção, aos",
       "depleted_suffix": "após se aposentar aos {{age}}.",
       "surplus_prefix": "Prevê-se que você se aposente na idade {{age}} com",
       "surplus_suffix": "de superávit.",
@@ -130,35 +130,25 @@
       "fi_reached_prefix": "Você alcançou a",
       "financial_independence": "independência financeira",
       "fi_reached_suffix": "— com as premissas atuais.",
-      "fi_at_prefix": "Você alcançará a independência financeira aos",
-      "years_after_one": "{{count}} ano depois de",
-      "years_after_other": "{{count}} anos depois de",
       "years_after_many": "{{count}} anos depois de",
-      "years_before_one": "{{count}} ano antes de",
-      "years_before_other": "{{count}} anos antes de",
       "years_before_many": "{{count}} anos antes de",
-      "your_goal_of": "sua meta de {{age}}.",
-      "right_on_goal": "exatamente na sua meta de {{age}}.",
-      "not_reachable_prefix": "Não alcançável para os",
-      "not_reachable_suffix": "com as premissas atuais."
+      "not_reachable_prefix": "Não projetada até",
+      "not_reachable_suffix": "com as premissas atuais.",
+      "fi_projected": "Pelas projeções, você alcançará a independência financeira aos <age>{{age}} anos</age>."
     },
     "summary": {
-      "at_your_current_prefix": "Com seu",
-      "contribution": "aporte atual,",
-      "capital_not_available": "o capital alvo necessário não é alcançável com as premissas atuais. Revise os gastos, a inflação, o retorno e a expectativa de vida.",
-      "projected_balance_is": "o saldo de aposentadoria projetado é",
-      "vs_required_capital_of": "frente ao capital necessário de",
       "at_age": "na idade {{age}}.",
-      "the_plan_funds": "o plano financia",
-      "per_yr_expenses_to_age": "/ano de gastos até a idade {{age}}.",
-      "youre_short": "Faltam"
+      "youre_short": "Seu déficit projetado é de",
+      "traditional": "Com suas premissas atuais e uma contribuição de <contribution>{{contribution}}</contribution>, o saldo projetado aos {{age}} anos é <balance>{{balance}}</balance>, comparado ao capital necessário de <target>{{target}}</target>.",
+      "fire": "Com suas premissas atuais e uma contribuição de <contribution>{{contribution}}</contribution>, o plano inclui <budget>{{budget}}</budget>/ano de gastos até os {{age}} anos.",
+      "unavailable": "Com suas premissas atuais e uma contribuição de <contribution>{{contribution}}</contribution>, não é possível estimar a meta de capital. Compare premissas em E se."
     },
     "progress": {
       "portfolio_today": "Carteira hoje",
       "required_at_age": "Necessário na idade {{age}}",
       "target_at_age": "Alvo na idade {{age}}",
-      "capital_needed_tip_traditional": "Capital necessário na sua idade de aposentadoria após gastos, rendimentos, impostos, retorno da aposentadoria e taxas. Exibido em {{valueLabel}}.",
-      "capital_needed_tip_fire": "Capital necessário na sua idade de aposentadoria desejada após gastos, rendimentos, impostos, retorno da aposentadoria e taxas. Exibido em {{valueLabel}}.",
+      "capital_needed_tip_traditional": "Capital estimado necessário na idade-alvo segundo as premissas de gastos, renda, impostos, retornos e taxas do plano. Exibido em {{valueLabel}}.",
+      "capital_needed_tip_fire": "Capital estimado necessário na idade-alvo segundo as premissas de gastos, renda, impostos, retornos e taxas do plano. Exibido em {{valueLabel}}.",
       "not_available": "Não disponível",
       "funded_pct": "{{pct}}% financiado"
     },
@@ -175,18 +165,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "Pare de aportar e ainda se aposente no prazo",
-      "coast_tip_nominal": "Valor Coast convertido para valores nominais na sua idade de aposentadoria desejada.",
-      "coast_tip_real": "Capital que você precisa hoje que, sem mais aportes, cresce até a IF completa para a sua idade de aposentadoria.",
+      "coast_hint": "Capital estimado necessário hoje",
+      "coast_tip_nominal": "Capital estimado necessário hoje, expresso em dinheiro na idade de aposentadoria usando a inflação suposta. É uma conversão de valor, não crescimento projetado dos investimentos.",
+      "coast_tip_real": "Capital estimado hoje ao descontar a meta de aposentadoria pelo retorno suposto antes da aposentadoria, após taxas. As premissas de pensão permanecem iguais.",
       "lean_fire": "Lean FIRE",
       "lean_hint": "70% dos gastos planejados",
-      "lean_tip": "Aposente-se com um orçamento frugal, aproximadamente 70% dos seus gastos planejados. Viável antes, mas com pouca margem.",
+      "lean_tip": "Capital estimado para 70% dos gastos planejados, com as demais premissas iguais. Este é o cenário Lean FIRE do planejador.",
       "fi": "IF",
       "fi_hint": "Gastos planejados completos",
       "fi_tip": "Capital que financia seus gastos de aposentadoria planejados durante todo o horizonte de aposentadoria.",
       "fat_fire": "Fat FIRE",
       "fat_hint": "150% dos gastos planejados",
-      "fat_tip": "Aposente-se com ~50% a mais de gastos do que o planejado: margem para viagens, presentes, volatilidade e melhorias no estilo de vida.",
+      "fat_tip": "Capital estimado para 150% dos gastos planejados, com as demais premissas iguais. Este é o cenário Fat FIRE do planejador.",
       "more_info_about": "Mais informações sobre {{label}}",
       "done": "CONCLUÍDO"
     },
@@ -223,11 +213,26 @@
       "unfunded": "Sem financiamento",
       "planned_spending_legend": "Gastos planejados",
       "showing": "Exibindo {{valueLabel}}",
-      "projection_unavailable": "A projeção de cobertura não está disponível para este plano."
+      "projection_unavailable": "A projeção de cobertura não está disponível para este plano.",
+      "age_range": "Idade {{start}} → {{end}}",
+      "starts_at": "Começa aos {{age}}",
+      "ended_at": "Terminou aos {{age}}",
+      "not_active": "Não ativo"
     },
     "disclaimer": {
       "title": "Algo a considerar",
-      "body": "Isso não é consultoria financeira. Considere esses números como um esboço, não como uma previsão. Tudo aqui é uma simulação construída sobre os dados que você inseriu: retorno, inflação, aportes, impostos e quanto tempo você espera viver. Os mercados reais não se movem em linha reta, as regras fiscais mudam e os programas governamentais são reescritos. Use isso para testar ideias e identificar lacunas, e depois consulte um profissional qualificado antes de tomar decisões difíceis de desfazer."
+      "body": "As projeções dependem das suas premissas. Os resultados reais podem variar. Não é aconselhamento financeiro."
+    },
+    "guidance": {
+      "unavailable": "Não é possível estimar a meta com as premissas atuais. Compare premissas em E se.",
+      "depleted": "A projeção indica que a carteira será insuficiente aos {{age}} anos. Compare premissas em E se.",
+      "gap": "A projeção indica um déficit de gastos a partir dos {{age}} anos. Compare premissas em E se.",
+      "fund": "A projeção indica que {{label}} se esgotará aos {{age}} anos; os pagamentos modelados então cessam. Compare premissas de pagamento e renda.",
+      "shortfall": "Há um déficit projetado na aposentadoria. Compare premissas em E se.",
+      "reached": "A carteira atual atinge a meta estimada de independência financeira segundo suas premissas.",
+      "not_reached": "A independência financeira não é projetada até os {{age}} anos. Compare premissas em E se.",
+      "late_one": "A independência financeira é projetada {{count}} ano após a idade desejada. Compare premissas em E se.",
+      "late_other": "A independência financeira é projetada {{count}} anos após a idade desejada. Compare premissas em E se."
     }
   },
   "sidebar": {
@@ -237,7 +242,8 @@
       "high_inflation": "Premissa de inflação alta. As necessidades de gastos de longo prazo tornam-se mais sensíveis a esta taxa.",
       "high_fee": "Premissa de taxas altas. O peso das taxas reduz significativamente o retorno a longo prazo.",
       "high_volatility": "Premissa de volatilidade alta. Os intervalos de resultados podem se tornar muito amplos.",
-      "high_contribution_growth": "Premissa de alto crescimento de aporte. Isso pressupõe aumentos de poupança grandes e sustentados."
+      "high_contribution_growth": "Premissa de alto crescimento de aporte. Isso pressupõe aumentos de poupança grandes e sustentados.",
+      "high_return": "Premissa de retorno alto. Os saldos projetados são sensíveis a essa taxa."
     },
     "plan": {
       "kicker": "Plano",
@@ -258,14 +264,14 @@
       "desired_retirement_age_hint": "Idade na qual você quer ser financeiramente independente.",
       "retirement_age_hint": "Idade na qual você quer se aposentar.",
       "horizon_age_fire": "Horizonte do plano",
-      "horizon_age_traditional": "Expectativa de vida",
+      "horizon_age_traditional": "Horizonte do plano",
       "horizon_hint": "Idade até a qual o plano deve cobrir.",
       "monthly_contribution": "Aporte mensal",
       "monthly_contribution_hint": "Quanto você adiciona por mês até a aposentadoria.",
-      "return_before_hint": "Rentabilidade anual esperada enquanto você poupa.",
-      "return_during_hint": "Rentabilidade anual esperada após iniciar os saques.",
+      "return_before_hint": "Retorno anual suposto durante a acumulação, antes das taxas de investimento.",
+      "return_during_hint": "Retorno anual suposto após o início dos saques, antes das taxas de investimento.",
       "annual_fee_hint": "Taxas anuais estimadas da carteira.",
-      "inflation_hint": "Aumento anual esperado dos preços."
+      "inflation_hint": "Aumento anual suposto dos preços."
     },
     "spending": {
       "kicker": "Gastos",
@@ -326,13 +332,13 @@
       "fund_return_before_payout": "Rentabilidade do fundo antes do pagamento",
       "fund_payout_rate": "Taxa de pagamento",
       "fund_payout_mode": "Modo de pagamento",
-      "fund_payout_mode_help": "Uma anuidade paga de forma vitalícia; um resgate programado consome o fundo até esgotá-lo.",
+      "fund_payout_mode_help": "A anuidade modela pagamentos até o horizonte do plano; os saques usam o saldo do fundo até seu esgotamento.",
       "annuity": "Anuidade",
       "drawdown": "Resgate programado",
       "fund_return_during_payout": "Rentabilidade do fundo durante o pagamento",
-      "drawdown_note": "O resgate programado retira {{pct}}%/ano do saldo na idade inicial e depois segue a configuração de crescimento abaixo até o fundo se esgotar.",
+      "drawdown_note": "Os resgates são estimados em {{pct}}% ao ano do saldo do fundo. Para pagamentos já iniciados, prevalece o valor mensal informado. Depois, os pagamentos seguem a taxa de crescimento definida até o fundo se esgotar.",
       "monthly_payout_after_tax": "Pagamento mensal após impostos",
-      "payout_estimate_note": "O pagamento estimado usa {{pct}}%/ano do saldo projetado do fundo, salvo se você inserir um pagamento mensal.",
+      "payout_estimate_note": "O pagamento estimado usa {{pct}}% ao ano do saldo do fundo. Para pagamentos já iniciados, prevalece o valor mensal informado.",
       "start_age": "Idade de início",
       "income_growth": "Crescimento do rendimento",
       "income_growth_help": "Escolha se este rendimento cresce com a inflação do plano ou permanece fixo.",
@@ -471,15 +477,15 @@
     "quick_start": {
       "title": "Início rápido — 5 passos",
       "step1_title": "Defina os dados básicos do plano",
-      "step1_desc": "Em Dados do plano, escolha o tipo de plano, o mês de nascimento, a idade de aposentadoria, a expectativa de vida e o aporte mensal.",
+      "step1_desc": "Nos dados do plano, defina tipo, mês de nascimento, idade de aposentadoria, horizonte e contribuição mensal.",
       "step2_title": "Insira os gastos de aposentadoria",
       "step2_desc": "Em Gastos de aposentadoria, adicione as linhas de gasto mensal que você quer que o plano financie. Use dinheiro de hoje; a inflação é gerenciada pelas premissas do plano.",
       "step3_title": "Adicione rendimentos de aposentadoria",
-      "step3_desc": "Em Rendimentos de aposentadoria, adicione fluxos de rendimentos mensais como pensões públicas (ex.: CPP/OAS no Canadá, Seguridade Social nos EUA), pensões empresariais, trabalho de meio período ou anuidades. Use Adicionar fundo de previdência somente quando o planejador precisar estimar um pagamento a partir do saldo de um fundo a 3,5%/ano, salvo se você inserir um pagamento mensal.",
+      "step3_desc": "Adicione renda de aposentadoria, trabalho parcial ou anuidades. Para um fundo de pensão, o pagamento mensal estimado usa o saldo projetado e a taxa anual configurada, salvo se você informar um pagamento mensal.",
       "step4_title": "Revise premissas, impostos e participações de conta",
       "step4_desc": "Revise os retornos projetados, as taxas, a volatilidade, a inflação, as alíquotas de saque, os blocos fiscais e quais contas financiam a meta.",
       "step5_title": "Leia Resumo e depois abra E se",
-      "step5_desc": "Resumo responde se o plano base funciona e mostra a trajetória, a cobertura de gastos e os dados do plano. E se testa o mesmo plano em diferentes trajetórias de mercado, testes de estresse, mapas de decisão e verificações avançadas."
+      "step5_desc": "A visão geral mostra projeção base, cobertura de gastos e dados. As simulações comparam trajetórias de mercado, cenários de estresse e mudanças de premissas."
     },
     "overview": {
       "title": "Entendendo Resumo",
@@ -499,13 +505,13 @@
     "what_if": {
       "title": "Entendendo E se",
       "market_paths_title": "Trajetórias de mercado",
-      "market_paths_desc": "Teste o mesmo plano em muitas trajetórias de mercado possíveis usando suas premissas de retorno, volatilidade e inflação. O intervalo sombreado mostra os resultados de ruim a bom; a linha mostra a trajetória intermediária. O dinheiro dura significa que o plano cobre os gastos essenciais e ainda há dinheiro durante o horizonte de planejamento. No modo FIRE, o plano também deve primeiro alcançar a independência financeira.",
+      "market_paths_desc": "Modelamos diferentes trajetórias de mercado com suas premissas. A área sombreada mostra os percentis 10–90 em cada idade; a linha mostra a mediana entre trajetórias, não uma trajetória individual. São contadas as trajetórias que cobrem gastos essenciais e terminam com dinheiro restante; as de FIRE também precisam atingir a independência financeira.",
       "base_case_title": "Caso base",
       "base_case_desc": "Mostra o mesmo plano base determinístico que Resumo, e depois destaca o maior resultado de estresse para que você veja o que mais importa.",
       "stress_tests_title": "Testes de estresse",
       "stress_tests_desc": "Verificações fixas que mostram como o plano muda se os retornos são menores, a inflação é maior, os gastos sobem, a aposentadoria começa mais cedo, a poupança cai ou ocorre uma queda do mercado perto da aposentadoria.",
       "what_moves_title": "O que move o plano?",
-      "what_moves_desc": "Os mapas de decisão comparam poupança, retornos, idade de aposentadoria e gastos. Células verdes deixam mais dinheiro no final. Células vermelhas ainda deixam um déficit ou ficam a descoberto.",
+      "what_moves_desc": "Compare poupança, retornos, idade de aposentadoria e gastos. Verde indica mais dinheiro final que o plano base; âmbar, menos. Vermelho indica déficit ou nenhum dinheiro restante.",
       "crash_paths_title": "Trajetórias de queda antecipada do mercado",
       "crash_paths_desc": "Compara várias trajetórias de acordo com o momento da queda perto da aposentadoria. Uma queda no primeiro ano de aposentadoria pode prejudicar mais do que a mesma queda mais tarde, porque os saques ocorrem enquanto a carteira está em baixa."
     },
@@ -514,25 +520,24 @@
       "yearly_spending_title": "Como os gastos anuais são modelados",
       "yearly_spending_desc": "Seus gastos impulsionam o saque. A cada ano o planejador financia o calendário de gastos que você inseriu, subtrai os rendimentos de aposentadoria e estima qualquer peso fiscal sobre os saques da carteira.",
       "target_calc_title": "Como o alvo é calculado",
-      "target_calc_desc": "O planejador calcula o valor presente de todo o seu calendário de gastos desde a aposentadoria até o seu horizonte de planejamento, levando em conta a taxa de inflação de cada bloco de gastos, os fluxos de rendimentos que começam em idades diferentes e o peso fiscal sobre os saques. Quando sua carteira alcança esse valor, o plano base tem capital suficiente para o calendário que você inseriu. Isso é mais preciso do que um simples múltiplo de gastos porque gerencia gastos variáveis, pensões diferidas e horizontes finitos.",
+      "target_calc_desc": "O planejador estima a carteira inicial necessária para financiar os gastos de aposentadoria até o horizonte do plano. Modela inflação dos gastos, datas de renda, retornos, taxas e impostos sobre saques. A meta depende dessas premissas.",
       "inflation_title": "Taxa de inflação",
-      "inflation_desc": "Todas as projeções aumentam os gastos e os rendimentos ligados à inflação a esta taxa ano a ano. O valor padrão de 2% coincide com a meta do BCE.",
-      "inflation_it_note": "Use 2,5–3% para uma premissa de IPCA mais conservadora.",
+      "inflation_desc": "A premissa de inflação aumenta os gastos e a renda indexada ao longo do tempo. Cada item pode usar sua própria taxa.",
       "returns_title": "Retornos, taxas e volatilidade",
       "returns_desc": "O retorno antes da aposentadoria impulsiona o acúmulo. O retorno durante a aposentadoria impulsiona a fase de saque e o capital necessário. As taxas de investimento anuais são subtraídas de ambos. A volatilidade é usada apenas nas verificações de trajetórias de mercado: valores mais altos produzem um leque de resultados mais amplo.",
       "horizon_title": "Idade do horizonte de planejamento",
-      "horizon_desc": "Por quanto tempo a carteira deve durar. A meta de aposentadoria e as verificações de E se chegam até esta idade. Defina como 90–95 para testar a longevidade. As trajetórias de queda antecipada do mercado e O dinheiro dura são medidas neste horizonte."
+      "horizon_desc": "A idade até a qual são modelados os gastos de aposentadoria e os resultados de E se. É uma premissa do período de planejamento, não uma previsão de longevidade."
     },
     "italian": {
       "title": "Configuração de aposentadoria italiana (fondo pensione, TFR, INPS)",
       "portfolio_title": "Carteira de investimento (Golden Butterfly, All-Weather…)",
       "portfolio_desc": "Esta é sua carteira principal, o valor que o Wealthfolio acompanha. Defina aqui suas premissas de retorno, o peso das taxas e o aporte mensal. É o principal motor de acumulação do seu plano de aposentadoria.",
       "fondo_title": "Fondo pensione integrativo (fundo de previdência complementar)",
-      "fondo_desc": "Use Adicionar fundo de previdência. Insira o saldo atual do fundo, o aporte mensal, o retorno esperado do fundo e a idade de início do pagamento. O planejador estima o saldo futuro e, se você não inserir um pagamento mensal, estima o pagamento como 3,5%/ano desse saldo projetado a partir da idade de início.",
+      "fondo_desc": "Use Adicionar fundo de pensão. Informe saldo, contribuição, retorno suposto e idade de início dos pagamentos. A estimativa usa a taxa de pagamento configurada, salvo se informar um valor mensal. Os saques cessam quando o fundo se esgota; anuidades são modeladas até o horizonte do plano.",
       "inps_title": "Pensione INPS (pensão estatal — previdência obrigatória)",
       "inps_desc": "Use Adicionar rendimento de aposentadoria. Insira sua pensão mensal líquida estimada em dinheiro de hoje e defina a idade de início do pagamento. Use Indexado se quiser que o rendimento aumente com a premissa de inflação do plano.",
       "tfr_title": "TFR (Trattamento di Fine Rapporto — indenização acumulada)",
-      "tfr_desc": "Se o seu TFR vai para um fundo de previdência, inclua-o no aporte mensal do fundo. Se você o mantém separadamente, modele-o como outro fundo de previdência com seu próprio saldo, aporte, retorno e idade de início do pagamento. A mesma estimativa de pagamento de 3,5%/ano se aplica, salvo se você inserir um pagamento mensal."
+      "tfr_desc": "Se o TFR for destinado a um fundo de pensão, inclua-o na contribuição. Um fundo separado pode representar a poupança TFR independente; seus pagamentos modelados seguem a taxa ou o valor mensal configurado."
     }
   },
   "type": {
@@ -783,7 +788,7 @@
       "retirement_gap": "Déficit de aposentadoria",
       "fi_moves_prefix": "A IF se move",
       "fi_moves_suffix": "anos mais tarde",
-      "largest_risk": "{{label}} é o maior risco",
+      "largest_risk": "{{label}} tem o maior efeito entre estes testes",
       "and": "e",
       "none": "Nenhum",
       "surplus": "superávit",
@@ -807,7 +812,10 @@
       "money_lasts_summary_traditional": "permanece financiado até a idade {{horizonAge}}",
       "money_lasts_summary_fire": "IF alcançada + financiado até a idade {{horizonAge}}",
       "money_lasts_prompt_traditional": "Execute 10k trajetórias para ver com que frequência o plano permanece financiado até a idade {{horizonAge}}.",
-      "money_lasts_prompt_fire": "Execute 10k trajetórias para ver com que frequência o plano alcança a IF e permanece financiado até a idade {{horizonAge}}."
+      "money_lasts_prompt_fire": "Execute 10k trajetórias para ver com que frequência o plano alcança a IF e permanece financiado até a idade {{horizonAge}}.",
+      "of_simulated_paths": "das trajetórias simuladas",
+      "simulation_tooltip_traditional": "{{percent}}% das trajetórias simuladas cobriram os gastos essenciais e terminaram com dinheiro restante. As cores usam faixas de referência: abaixo de 75%, de 75% a menos de 90% e 90% ou mais. São resultados modelados, não probabilidades reais.",
+      "simulation_tooltip_fire": "{{percent}}% das trajetórias simuladas cobriram os gastos essenciais e terminaram com dinheiro restante. As trajetórias também precisam atingir a independência financeira. As cores usam faixas de referência: abaixo de 75%, de 75% a menos de 90% e 90% ou mais. São resultados modelados, não probabilidades reais."
     },
     "stress": {
       "eyebrow_with_count": "O que poderia romper este plano? · {{count}} cenários",
@@ -825,7 +833,7 @@
     "montecarlo": {
       "eyebrow": "Trajetórias de mercado",
       "heading": "Com que frequência o dinheiro poderia durar?",
-      "intro": "Testamos o mesmo plano em muitas trajetórias de mercado possíveis. O intervalo sombreado mostra os resultados de ruim a bom; a linha mostra a trajetória intermediária.",
+      "intro": "Modelamos diferentes trajetórias de mercado com suas premissas. A área sombreada mostra os percentis 10–90 em cada idade; a linha mostra a mediana entre trajetórias, não uma trajetória individual.",
       "run_10k": "Executar 10k trajetórias",
       "run_100k": "Executar 100k trajetórias",
       "running_short": "Executando…",
@@ -837,17 +845,17 @@
       "median_fi_age": "Idade mediana de IF",
       "withdrawals_start_detail": "os saques começam",
       "vs_goal": "frente à meta {{age}}",
-      "bad_path": "Trajetória ruim",
-      "middle_path": "Trajetória intermediária",
-      "good_path": "Trajetória boa"
+      "bad_path": "Resultado inferior",
+      "middle_path": "Mediana",
+      "good_path": "Resultado superior"
     },
     "chart": {
       "age_label": "Idade {{age}}",
       "age_detail": "idade {{age}}",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "IF mediana @{{age}}",
-      "bad_good_range": "Intervalo ruim-bom",
-      "median_path": "Trajetória mediana",
+      "bad_good_range": "Faixa do percentil 10 ao 90",
+      "median_path": "Mediana",
       "retirement_age": "Idade de aposentadoria",
       "goal_age": "Idade alvo",
       "median_fi_age": "Idade mediana de IF",
@@ -856,12 +864,13 @@
       "goal": "meta",
       "market_paths_count_one": "{{count}} trajetória de mercado",
       "market_paths_count_other": "{{count}} trajetórias de mercado",
-      "market_paths_count_many": "{{count}} trajetórias de mercado"
+      "market_paths_count_many": "{{count}} trajetórias de mercado",
+      "percentile_at_age": "Percentil {{percentile}} · idade {{age}}"
     },
     "moves": {
       "eyebrow": "O que mais muda o plano?",
       "heading": "O que move o plano?",
-      "description": "Mostra como poupança, retornos, idade de aposentadoria e gastos alteram o resultado. Verde = mais dinheiro restante; vermelho = déficit ou fica a descoberto.",
+      "description": "Compare poupança, retornos, idade de aposentadoria e gastos. Verde indica mais dinheiro final que o plano base; âmbar, menos. Vermelho indica déficit ou nenhum dinheiro restante.",
       "empty_title": "Descubra quais mudanças ajudariam mais.",
       "empty_description": "Compare poupar mais, obter um retorno diferente, gastar menos ou se aposentar em uma idade diferente.",
       "building": "Construindo...",
@@ -890,6 +899,39 @@
       "unavailable_title": "Trajetórias de queda não disponíveis.",
       "empty_description": "Execute as cinco trajetórias para ver qual sequência colocaria o plano sob pressão primeiro.",
       "unavailable_description": "Esta verificação precisa de uma carteira projetada positiva no início da aposentadoria."
+    },
+    "labels": {
+      "crash_year_1": "Queda no ano 1 (−30%)",
+      "crash_year_5": "Queda no ano 5 (−30%)",
+      "double_crash": "Duas quedas",
+      "lost_decade": "Década perdida",
+      "after_fee_return": "Retorno após taxas"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "Retornos menores",
+        "description": "Os retornos antes e durante a aposentadoria são 2 pontos percentuais menores."
+      },
+      "inflation-shock": {
+        "label": "Inflação maior",
+        "description": "A inflação geral é 1,5 ponto percentual maior."
+      },
+      "spending-shock": {
+        "label": "Gastos maiores",
+        "description": "Todos os valores de gastos de aposentadoria são 10% maiores."
+      },
+      "retire-earlier": {
+        "label": "Aposentadoria 2 anos antes",
+        "description": "A idade-alvo é antecipada em dois anos, limitada pela idade atual do plano."
+      },
+      "save-less": {
+        "label": "Contribuições menores",
+        "description": "As contribuições mensais são 25% menores."
+      },
+      "early-crash": {
+        "label": "Queda inicial do mercado",
+        "description": "Uma queda de mercado de 30% é modelada no primeiro ano de aposentadoria."
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/zh-Hant/goals.json
+++ b/apps/frontend/src/i18n/locales/zh-Hant/goals.json
@@ -107,17 +107,17 @@
       "on_track": "進度正常",
       "fi_reached": "已達財務獨立",
       "at_risk": "可能無法達成",
-      "never_reaches_fi": "無法達到財務獨立",
+      "never_reaches_fi": "預計{{age}}歲前無法達到",
       "years_late_one": "晚 {{count}} 年",
       "years_late_other": "晚 {{count}} 年"
     },
     "verdict": {
       "age": "{{age}} 歲",
-      "spending_gap_prefix": "支出缺口開始於",
+      "spending_gap_prefix": "預計支出缺口開始於",
       "spending_gap_suffix": "，早於計畫涵蓋的 {{age}} 歲。",
-      "short_prefix": "在 {{age}} 歲時，你還差",
+      "short_prefix": "{{age}}歲時預計缺口為",
       "short_suffix": "才能支撐退休生活至 {{age}} 歲。",
-      "depleted_prefix": "投資組合資金將在此期間耗盡：",
+      "depleted_prefix": "預計投資組合資金不足的年齡為",
       "depleted_suffix": "即在 {{age}} 歲退休之後。",
       "surplus_prefix": "預計你將在 {{age}} 歲退休，並有",
       "surplus_suffix": "盈餘。",
@@ -126,33 +126,23 @@
       "fi_reached_prefix": "你已實現",
       "financial_independence": "財務獨立",
       "fi_reached_suffix": "，以上依目前假設計算。",
-      "fi_at_prefix": "預計達成財務獨立的年齡：",
-      "years_after_one": "晚 {{count}} 年",
-      "years_after_other": "晚 {{count}} 年",
-      "years_before_one": "早 {{count}} 年",
-      "years_before_other": "早 {{count}} 年",
-      "your_goal_of": "你 {{age}} 歲的目標。",
-      "right_on_goal": "恰好符合你 {{age}} 歲的目標。",
-      "not_reachable_prefix": "無法達成於",
-      "not_reachable_suffix": "按目前假設計算。"
+      "not_reachable_prefix": "預計無法達到的年齡上限為",
+      "not_reachable_suffix": "按目前假設計算。",
+      "fi_projected": "預計您將在<age>{{age}}歲</age>達到財務獨立。"
     },
     "summary": {
-      "at_your_current_prefix": "依你目前的",
-      "contribution": "投入金額，",
-      "capital_not_available": "依目前假設，無法計算所需資本目標。請檢查支出、通膨、報酬率與預期壽命。",
-      "projected_balance_is": "預計退休餘額為",
-      "vs_required_capital_of": "相較於所需資本",
       "at_age": "在 {{age}} 歲時。",
-      "the_plan_funds": "該計畫可支撐",
-      "per_yr_expenses_to_age": "／年支出，直到 {{age}} 歲。",
-      "youre_short": "你還差"
+      "youre_short": "預計缺口為",
+      "traditional": "根據目前假設及<contribution>{{contribution}}</contribution>的提撥，{{age}}歲時的預計餘額為<balance>{{balance}}</balance>，所需資金為<target>{{target}}</target>。",
+      "fire": "根據目前假設及<contribution>{{contribution}}</contribution>的提撥，計畫包括直至{{age}}歲的每年<budget>{{budget}}</budget>支出。",
+      "unavailable": "根據目前假設及<contribution>{{contribution}}</contribution>的提撥，無法估算資金目標。請在假設分析中比較假設。"
     },
     "progress": {
       "portfolio_today": "目前投資組合",
       "required_at_age": "{{age}} 歲時所需",
       "target_at_age": "{{age}} 歲時目標",
-      "capital_needed_tip_traditional": "退休時所需資本，已計入支出、收入、稅款、退休後報酬率與費用。以 {{valueLabel}} 顯示。",
-      "capital_needed_tip_fire": "預定退休時所需資本，已計入支出、收入、稅款、退休後報酬率與費用。以 {{valueLabel}} 顯示。",
+      "capital_needed_tip_traditional": "根據計畫的支出、收入、稅收、報酬率和費用假設，估算目標退休年齡所需的資金。以{{valueLabel}}顯示。",
+      "capital_needed_tip_fire": "根據計畫的支出、收入、稅收、報酬率和費用假設，估算目標退休年齡所需的資金。以{{valueLabel}}顯示。",
       "not_available": "無法計算",
       "funded_pct": "已達標 {{pct}}%"
     },
@@ -169,18 +159,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "停止投入，仍可按時退休",
-      "coast_tip_nominal": "Coast FIRE 所需金額，換算為預定退休年齡時的名目金額。",
-      "coast_tip_real": "今天所需的資本；即使不再投入，仍可在退休年齡成長至完全財務獨立所需的金額。",
+      "coast_hint": "目前所需資金估算",
+      "coast_tip_nominal": "按假設通膨率，將目前所需資金估算換算為退休年齡時的金額。這是價值換算，並非投資成長預測。",
+      "coast_tip_real": "將退休目標按扣除費用後的退休前假設報酬率折現，估算目前所需資金。退休金假設維持不變。",
       "lean_fire": "Lean FIRE",
       "lean_hint": "計畫支出的 70%",
-      "lean_tip": "以約為計畫支出 70% 的精簡預算退休。可以較早達成，但緩衝空間較小。",
+      "lean_tip": "在其他假設不變的情況下，為計畫支出的70%估算所需資金。這是本規劃工具的Lean FIRE情境。",
       "fi": "FI",
       "fi_hint": "完整的計畫支出",
       "fi_tip": "在整個退休期內支撐你計畫退休支出的資本。",
       "fat_fire": "Fat FIRE",
       "fat_hint": "計畫支出的 150%",
-      "fat_tip": "以比計畫高約 50% 的支出退休，為旅遊、贈與、市場波動與生活品質提升保留空間。",
+      "fat_tip": "在其他假設不變的情況下，為計畫支出的150%估算所需資金。這是本規劃工具的Fat FIRE情境。",
       "more_info_about": "關於 {{label}} 的更多資訊",
       "done": "已完成"
     },
@@ -217,11 +207,26 @@
       "unfunded": "未支應",
       "planned_spending_legend": "計畫支出",
       "showing": "顯示 {{valueLabel}}",
-      "projection_unavailable": "此計畫無法產生資金涵蓋預測。"
+      "projection_unavailable": "此計畫無法產生資金涵蓋預測。",
+      "age_range": "{{start}}歲 → {{end}}歲",
+      "starts_at": "{{age}}歲開始",
+      "ended_at": "{{age}}歲結束",
+      "not_active": "未生效"
     },
     "disclaimer": {
       "title": "請留意",
-      "body": "這不是財務建議。請將這些數字視為概略試算，而不是預測結果。所有內容都是依你輸入的報酬率、通膨、投入金額、稅款與預期壽命進行模擬。實際市場不會直線變動，稅務規定與政府制度也可能改變。你可以用這些結果測試不同想法並找出缺口；在做出難以復原的決定前，請先諮詢合格的專業人士。"
+      "body": "預測取決於您的假設。實際結果可能不同。不構成財務建議。"
+    },
+    "guidance": {
+      "unavailable": "目前假設下無法估算目標。請在假設分析中比較假設。",
+      "depleted": "預計投資組合在{{age}}歲時出現資金不足。請在假設分析中比較假設。",
+      "gap": "預計從{{age}}歲起出現支出缺口。請在假設分析中比較假設。",
+      "fund": "預計{{label}}在{{age}}歲時耗盡，模型中的付款隨後停止。請比較付款及收入假設。",
+      "shortfall": "預計退休時出現缺口。請在假設分析中比較假設。",
+      "reached": "目前投資組合已達到您的假設下估算的財務獨立目標。",
+      "not_reached": "預計{{age}}歲前無法實現財務獨立。請在假設分析中比較假設。",
+      "late_one": "預計在期望年齡的{{count}}年後實現財務獨立。請在假設分析中比較假設。",
+      "late_other": "預計在期望年齡的{{count}}年後實現財務獨立。請在假設分析中比較假設。"
     }
   },
   "sidebar": {
@@ -231,7 +236,8 @@
       "high_inflation": "通膨假設偏高。這個比率會讓長期支出需求更敏感。",
       "high_fee": "費用假設偏高，會明顯拉低長期報酬。",
       "high_volatility": "波動率假設偏高。結果區間可能變得非常寬。",
-      "high_contribution_growth": "投入成長假設偏高，代表儲蓄金額需要持續大幅增加。"
+      "high_contribution_growth": "投入成長假設偏高，代表儲蓄金額需要持續大幅增加。",
+      "high_return": "報酬率假設較高。預計餘額對這一比率較為敏感。"
     },
     "plan": {
       "kicker": "計畫",
@@ -252,14 +258,14 @@
       "desired_retirement_age_hint": "你希望實現財務獨立的年齡。",
       "retirement_age_hint": "你希望退休的年齡。",
       "horizon_age_fire": "計畫涵蓋至",
-      "horizon_age_traditional": "預期壽命",
+      "horizon_age_traditional": "計畫涵蓋至",
       "horizon_hint": "計畫應涵蓋至此年齡。",
       "monthly_contribution": "每月投入",
       "monthly_contribution_hint": "退休前每月投入的金額。",
-      "return_before_hint": "儲蓄期間的預期年報酬率。",
-      "return_during_hint": "開始提領後的預期年報酬率。",
+      "return_before_hint": "儲蓄期間的假設年報酬率，未扣除投資費用。",
+      "return_during_hint": "開始提領後的假設年報酬率，未扣除投資費用。",
       "annual_fee_hint": "預估的年度投資費用。",
-      "inflation_hint": "預期的物價年度漲幅。"
+      "inflation_hint": "假設的年度物價漲幅。"
     },
     "spending": {
       "kicker": "支出",
@@ -320,13 +326,13 @@
       "fund_return_before_payout": "給付前基金報酬率",
       "fund_payout_rate": "基金給付率",
       "fund_payout_mode": "給付方式",
-      "fund_payout_mode_help": "年金會終身給付；基金提領會持續從基金餘額提領，直到餘額用完。",
+      "fund_payout_mode_help": "年金模式假設付款持續至規劃期末；提領模式使用基金餘額直至耗盡。",
       "annuity": "年金",
       "drawdown": "基金提領",
       "fund_return_during_payout": "給付期間基金報酬率",
-      "drawdown_note": "基金提領會從起始年齡當年的期初餘額提領 {{pct}}%／年，之後依下方的成長設定計算，直到基金餘額用完。",
+      "drawdown_note": "提領金額按基金餘額的每年 {{pct}}% 估算。若已開始領取，則優先使用輸入的每月領取金額。此後按設定的成長率調整，直至資金用完。",
       "monthly_payout_after_tax": "稅後每月給付",
-      "payout_estimate_note": "除非你輸入每月給付，否則會以預計基金餘額的 {{pct}}%/年估算給付。",
+      "payout_estimate_note": "預估領取金額按基金餘額的每年 {{pct}}% 估算。若已開始領取，則優先使用輸入的每月領取金額。",
       "start_age": "起始年齡",
       "income_growth": "收入成長",
       "income_growth_help": "選取此收入是隨計畫通膨上漲還是保持固定。",
@@ -465,15 +471,15 @@
     "quick_start": {
       "title": "快速入門：5 個步驟",
       "step1_title": "設定計畫基礎",
-      "step1_desc": "在「計畫輸入」中，選取計畫類型、出生月份、退休年齡、預期壽命與每月投入。",
+      "step1_desc": "在計畫輸入中設定類型、出生月份、退休年齡、規劃結束年齡和每月提撥。",
       "step2_title": "輸入退休支出",
       "step2_desc": "在「退休支出」中，新增你希望計畫支撐的每月支出項。使用今天的金額；通膨由計畫假設處理。",
       "step3_title": "新增退休收入",
-      "step3_desc": "在「退休收入」中，新增每月收入來源，例如公共退休金（如加拿大的 CPP/OAS、美國的 Social Security）、職場退休金、兼職工作或年金收入。只有希望規劃工具依基金餘額的 3.5%/年估算給付時，才使用「新增退休基金」；你也可以自行輸入每月給付。",
+      "step3_desc": "新增退休金、兼職或年金等退休收入。對於退休基金，除非輸入每月付款額，否則會使用預計餘額及設定的年度支付率估算月付款額。",
       "step4_title": "檢查假設、稅款與帳戶占比",
       "step4_desc": "查看預計報酬率、費用、波動率、通膨、提領稅率、稅務類別，以及哪些帳戶為目標提供資金。",
       "step5_title": "先閱讀「概覽」，再開啟「假設分析」",
-      "step5_desc": "「概覽」會說明基礎計畫是否可行，並顯示投資組合走勢、支出資金涵蓋與計畫資料。「假設分析」則以市場路徑、壓力測試、決策圖與進階檢查測試同一套計畫。"
+      "step5_desc": "概覽顯示基礎預測、支出涵蓋和輸入。情境分析比較市場路徑、壓力情境和假設變化。"
     },
     "overview": {
       "title": "理解「概覽」",
@@ -493,13 +499,13 @@
     "what_if": {
       "title": "理解「假設分析」",
       "market_paths_title": "市場路徑",
-      "market_paths_desc": "使用你的報酬率、波動率與通膨假設，在多種可能的市場路徑中測試同一計畫。陰影區間顯示較差至較佳的結果；線條顯示中間路徑。「資金充足」表示計畫能支應必要支出，並在整個規劃期限內仍有餘額。在 FIRE 模式下，計畫還需先達成財務獨立。",
+      "market_paths_desc": "我們根據您的假設模擬不同市場路徑。陰影顯示各年齡的第10至第90百分位區間；線條顯示各路徑的中位數，並非單一路徑。 統計涵蓋必要支出且期末仍有結餘的路徑；FIRE路徑還必須達到財務獨立。",
       "base_case_title": "基準情形",
       "base_case_desc": "顯示與「概覽」相同、採用固定假設的基礎計畫，再指出影響最大的壓力測試結果。",
       "stress_tests_title": "壓力測試",
       "stress_tests_desc": "固定檢查項顯示當報酬率降低、通膨升高、支出增加、退休提前、儲蓄減少或退休前後發生市場崩盤時，計畫將如何變化。",
       "what_moves_title": "哪些因素影響計畫？",
-      "what_moves_desc": "決策圖會比較儲蓄、報酬率、退休年齡與支出。綠色儲存格代表最後留下較多餘額；紅色儲存格則仍有缺口或資金不足。",
+      "what_moves_desc": "比較儲蓄、報酬率、退休年齡和支出。綠色表示期末資金比基礎計畫多，黃色表示更少。紅色表示存在缺口或沒有剩餘資金。",
       "crash_paths_title": "早期市場崩盤路徑",
       "crash_paths_desc": "比較退休前後幾種市場崩盤時點。退休第一年發生崩盤，可能比之後發生相同跌幅造成更大影響，因為你會在投資組合下跌時提領。"
     },
@@ -508,25 +514,24 @@
       "yearly_spending_title": "年度支出如何建模",
       "yearly_spending_desc": "支出會決定提領金額。規劃工具每年會支應你輸入的支出計畫、扣除退休收入，並估算投資組合提領產生的稅負影響。",
       "target_calc_title": "目標如何計算",
-      "target_calc_desc": "規劃工具會計算退休至規劃期限內完整支出計畫的現值，並納入各支出類別的通膨率、不同年齡開始的收入來源與提領稅負。當投資組合達到此金額，基礎計畫便有足夠資本支應你輸入的支出計畫。這比單純使用支出倍數更準確，因為它會處理變動支出、延後開始的退休金與有限的規劃期限。",
+      "target_calc_desc": "規劃工具估算涵蓋退休支出安排直至規劃期末所需的初始投資組合。模型考慮支出通膨、收入時間、報酬率、費用及提領稅。目標取決於這些假設。",
       "inflation_title": "通膨率",
-      "inflation_desc": "所有預測都會依此通膨率，逐年調整支出與隨通膨調整的收入。預設的 2% 與歐洲央行的目標一致。",
-      "inflation_it_note": "若要採用較保守的義大利 CPI 假設，請使用 2.5–3%。",
+      "inflation_desc": "通膨假設使支出及與通膨連動的收入隨時間增加。各個項目可以使用各自的成長率。",
       "returns_title": "報酬率、費用與波動率",
       "returns_desc": "退休前報酬率影響資產累積，退休期間報酬率則影響提領階段與所需資本。年度投資費用會從兩者扣除。波動率只用於市場路徑檢查；數值越高，結果分布越寬。",
       "horizon_title": "規劃期限年齡",
-      "horizon_desc": "投資組合必須維持的期間。退休目標與「假設分析」都會計算至此年齡。可設為 90–95 歲，以測試長壽風險。早期市場崩盤路徑與「資金充足」也都以此期限衡量。"
+      "horizon_desc": "退休支出及假設分析結果建模到的年齡。這是規劃期間的假設，不是壽命預測。"
     },
     "italian": {
       "title": "義大利退休設定（fondo pensione、TFR、INPS）",
       "portfolio_title": "投資組合（Golden Butterfly、All-Weather……）",
       "portfolio_desc": "這是 Wealthfolio 追蹤的主要投資組合。請在這裡設定報酬率假設、費用影響與每月投入；它是退休計畫累積資產的主要來源。",
       "fondo_title": "Fondo pensione integrativo（補充退休基金）",
-      "fondo_desc": "使用「新增退休基金」。輸入目前基金餘額、每月提撥、預期基金報酬率與開始給付年齡。規劃工具會估算未來餘額；如果沒有輸入每月給付，則會從起始年齡起，以預計餘額的 3.5%/年估算給付。",
+      "fondo_desc": "使用新增退休基金，輸入餘額、提撥、假設報酬率及付款起始年齡。未輸入月付款額時，使用設定支付率估算。提領在基金耗盡時停止；年金付款建模至規劃期末。",
       "inps_title": "Pensione INPS（國家退休金：強制性社會保險）",
       "inps_desc": "使用「新增退休收入」。以今天的金額輸入預估每月淨退休金，並設定開始給付年齡。如果希望收入隨計畫通膨假設調升，請選「隨通膨調整」。",
       "tfr_title": "TFR（Trattamento di Fine Rapporto：離職補償累積）",
-      "tfr_desc": "如果 TFR 存入退休基金，請計入每月基金提撥。若另外保留，請將它設定成另一個退休基金，並輸入各自的餘額、提撥、報酬率與開始給付年齡。除非你自行輸入每月給付，否則同樣會採用 3.5%/年的給付估算。"
+      "tfr_desc": "若TFR轉入退休基金，請將其計入提撥。單獨儲蓄的TFR可用另一基金表示；模型付款按設定支付率或月付款額計算。"
     }
   },
   "type": {
@@ -774,7 +779,7 @@
       "retirement_gap": "退休缺口",
       "fi_moves_prefix": "財務獨立推遲",
       "fi_moves_suffix": "年",
-      "largest_risk": "{{label}} 影響最大",
+      "largest_risk": "在這些測試中，{{label}}的影響最大",
       "and": "與",
       "none": "無",
       "surplus": "盈餘",
@@ -796,8 +801,11 @@
       "money_lasts_definition_fire": "「資金充足」表示計畫已達成財務獨立、能支應必要支出，並在 {{horizonAge}} 歲前仍有餘額。",
       "money_lasts_summary_traditional": "在 {{horizonAge}} 歲前保持資金充足",
       "money_lasts_summary_fire": "實現財務獨立 + 在 {{horizonAge}} 歲前資金充足",
-      "money_lasts_prompt_traditional": "執行 10k 條路徑，查看計畫在 {{horizonAge}} 歲前保持資金充足的機率。",
-      "money_lasts_prompt_fire": "執行 10k 條路徑，查看計畫達成財務獨立，並在 {{horizonAge}} 歲前保持資金充足的機率。"
+      "money_lasts_prompt_traditional": "執行 1 萬條模擬路徑，查看有多少比例的路徑能讓計畫維持資金充足至 {{horizonAge}} 歲。",
+      "money_lasts_prompt_fire": "執行 1 萬條模擬路徑，查看有多少比例的路徑能達成財務獨立，並維持資金充足至 {{horizonAge}} 歲。",
+      "of_simulated_paths": "模擬路徑占比",
+      "simulation_tooltip_traditional": "{{percent}}%的模擬路徑涵蓋了必要支出，並在結束時仍有資金結餘。顏色採用參考區間：低於75%、75%至低於90%、90%及以上。這些是模型結果，不是現實機率。",
+      "simulation_tooltip_fire": "{{percent}}%的模擬路徑涵蓋了必要支出，並在結束時仍有資金結餘。路徑還必須達到財務獨立。顏色採用參考區間：低於75%、75%至低於90%、90%及以上。這些是模型結果，不是現實機率。"
     },
     "stress": {
       "eyebrow_with_count": "什麼情況可能使計畫失敗？ · {{count}} 個情境",
@@ -813,8 +821,8 @@
     },
     "montecarlo": {
       "eyebrow": "市場路徑",
-      "heading": "資金能維持多久的機率？",
-      "intro": "系統會以多種可能的市場路徑測試同一計畫。陰影區間顯示較差至較佳的結果；線條顯示中間路徑。",
+      "heading": "資金足夠的模擬路徑占比是多少？",
+      "intro": "我們根據您的假設模擬不同市場路徑。陰影顯示各年齡的第10至第90百分位區間；線條顯示各路徑的中位數，並非單一路徑。",
       "run_10k": "執行 10k 條路徑",
       "run_100k": "執行 100k 條路徑",
       "running_short": "正在執行……",
@@ -826,17 +834,17 @@
       "median_fi_age": "中位數財務獨立年齡",
       "withdrawals_start_detail": "開始提領",
       "vs_goal": "相較於目標 {{age}}",
-      "bad_path": "較差路徑",
-      "middle_path": "中間路徑",
-      "good_path": "較好路徑"
+      "bad_path": "較低結果",
+      "middle_path": "中位數",
+      "good_path": "較高結果"
     },
     "chart": {
       "age_label": "{{age}} 歲",
       "age_detail": "{{age}} 歲",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "中位數財務獨立 @{{age}}",
-      "bad_good_range": "較差至較佳區間",
-      "median_path": "中位數路徑",
+      "bad_good_range": "第10至第90百分位區間",
+      "median_path": "中位數",
       "retirement_age": "退休年齡",
       "goal_age": "目標年齡",
       "median_fi_age": "中位數財務獨立年齡",
@@ -844,12 +852,13 @@
       "retire": "退休",
       "goal": "目標",
       "market_paths_count_other": "{{count}} 條市場路徑",
-      "market_paths_count_one": "{{count}} 條市場路徑"
+      "market_paths_count_one": "{{count}} 條市場路徑",
+      "percentile_at_age": "第{{percentile}}百分位 · {{age}}歲"
     },
     "moves": {
       "eyebrow": "什麼對計畫影響最大？",
       "heading": "哪些因素影響計畫？",
-      "description": "顯示儲蓄、報酬率、退休年齡與支出如何改變結果。綠色代表剩餘資金較多；紅色代表仍有缺口或資金不足。",
+      "description": "比較儲蓄、報酬率、退休年齡和支出。綠色表示期末資金比基礎計畫多，黃色表示更少。紅色表示存在缺口或沒有剩餘資金。",
       "empty_title": "看看哪些改變最有幫助。",
       "empty_description": "比較多儲蓄、獲得不同報酬率、減少支出，或在不同年齡退休。",
       "building": "正在建立……",
@@ -878,6 +887,39 @@
       "unavailable_title": "崩盤路徑不可用。",
       "empty_description": "執行這五條路徑，查看哪一種市場變動順序會最早讓計畫承受壓力。",
       "unavailable_description": "此檢查需要退休開始時投資組合為正值。"
+    },
+    "labels": {
+      "crash_year_1": "第1年下跌（−30%）",
+      "crash_year_5": "第5年下跌（−30%）",
+      "double_crash": "兩次下跌",
+      "lost_decade": "失落的十年",
+      "after_fee_return": "扣費後報酬率"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "報酬率降低",
+        "description": "退休前和退休期間的報酬率降低2個百分點。"
+      },
+      "inflation-shock": {
+        "label": "通膨升高",
+        "description": "總體通膨率提高1.5個百分點。"
+      },
+      "spending-shock": {
+        "label": "支出增加",
+        "description": "所有退休支出金額增加10%。"
+      },
+      "retire-earlier": {
+        "label": "提前2年退休",
+        "description": "目標退休年齡提前兩年，受計畫目前年齡限制。"
+      },
+      "save-less": {
+        "label": "提撥減少",
+        "description": "每月提撥減少25%。"
+      },
+      "early-crash": {
+        "label": "退休初期市場下跌",
+        "description": "模型假設退休第一年市場下跌30%。"
+      }
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/zh-Hant/goals.json
+++ b/apps/frontend/src/i18n/locales/zh-Hant/goals.json
@@ -141,8 +141,8 @@
       "portfolio_today": "目前投資組合",
       "required_at_age": "{{age}} 歲時所需",
       "target_at_age": "{{age}} 歲時目標",
-      "capital_needed_tip_traditional": "根據計畫的支出、收入、稅收、報酬率和費用假設，估算目標退休年齡所需的資金。以{{valueLabel}}顯示。",
-      "capital_needed_tip_fire": "根據計畫的支出、收入、稅收、報酬率和費用假設，估算目標退休年齡所需的資金。以{{valueLabel}}顯示。",
+      "capital_needed_tip_traditional": "估算目標退休年齡所需的資金，已計入計畫的支出、收入、稅收、報酬率和費用假設。以{{valueLabel}}顯示。",
+      "capital_needed_tip_fire": "估算目標退休年齡所需的資金，已計入計畫的支出、收入、稅收、報酬率和費用假設。以{{valueLabel}}顯示。",
       "not_available": "無法計算",
       "funded_pct": "已達標 {{pct}}%"
     },

--- a/apps/frontend/src/i18n/locales/zh/goals.json
+++ b/apps/frontend/src/i18n/locales/zh/goals.json
@@ -107,17 +107,17 @@
       "on_track": "进展顺利",
       "fi_reached": "已实现财务独立",
       "at_risk": "有风险",
-      "never_reaches_fi": "永远无法实现财务独立",
+      "never_reaches_fi": "预计{{age}}岁前无法达到",
       "years_late_one": "晚 {{count}} 年",
       "years_late_other": "晚 {{count}} 年"
     },
     "verdict": {
       "age": "{{age}} 岁",
-      "spending_gap_prefix": "支出缺口开始于",
+      "spending_gap_prefix": "预计支出缺口开始于",
       "spending_gap_suffix": "而计划尚未到达 {{age}} 岁。",
-      "short_prefix": "在 {{age}} 岁时，您还差",
+      "short_prefix": "{{age}}岁时预计缺口为",
       "short_suffix": "才能支撑退休生活至 {{age}} 岁。",
-      "depleted_prefix": "投资组合资金将在此期间耗尽：",
+      "depleted_prefix": "预计投资组合资金不足的年龄为",
       "depleted_suffix": "即在 {{age}} 岁退休之后。",
       "surplus_prefix": "预计您将在 {{age}} 岁退休，并有",
       "surplus_suffix": "盈余。",
@@ -126,33 +126,23 @@
       "fi_reached_prefix": "您已实现",
       "financial_independence": "财务独立",
       "fi_reached_suffix": "——按当前假设计算。",
-      "fi_at_prefix": "您将实现财务独立于",
-      "years_after_one": "晚 {{count}} 年",
-      "years_after_other": "晚 {{count}} 年",
-      "years_before_one": "早 {{count}} 年",
-      "years_before_other": "早 {{count}} 年",
-      "your_goal_of": "您 {{age}} 岁的目标。",
-      "right_on_goal": "恰好符合您 {{age}} 岁的目标。",
-      "not_reachable_prefix": "无法达成于",
-      "not_reachable_suffix": "按当前假设计算。"
+      "not_reachable_prefix": "预计无法达到的年龄上限为",
+      "not_reachable_suffix": "按当前假设计算。",
+      "fi_projected": "预计您将在<age>{{age}}岁</age>达到财务独立。"
     },
     "summary": {
-      "at_your_current_prefix": "按您当前的",
-      "contribution": "供款，",
-      "capital_not_available": "按当前假设无法达到所需的资本目标。请检查支出、通胀、收益率和预期寿命。",
-      "projected_balance_is": "预计退休余额为",
-      "vs_required_capital_of": "对比所需资本",
       "at_age": "在 {{age}} 岁时。",
-      "the_plan_funds": "该计划可支撑",
-      "per_yr_expenses_to_age": "/年的支出至 {{age}} 岁。",
-      "youre_short": "您还差"
+      "youre_short": "预计缺口为",
+      "traditional": "根据当前假设及<contribution>{{contribution}}</contribution>的缴款，{{age}}岁时的预计余额为<balance>{{balance}}</balance>，所需资金为<target>{{target}}</target>。",
+      "fire": "根据当前假设及<contribution>{{contribution}}</contribution>的缴款，计划包括直至{{age}}岁的每年<budget>{{budget}}</budget>支出。",
+      "unavailable": "根据当前假设及<contribution>{{contribution}}</contribution>的缴款，无法估算资金目标。请在假设分析中比较假设。"
     },
     "progress": {
       "portfolio_today": "当前投资组合",
       "required_at_age": "{{age}} 岁时所需",
       "target_at_age": "{{age}} 岁时目标",
-      "capital_needed_tip_traditional": "在扣除支出、收入、税费、退休期收益率和费用后，退休年龄时所需的资本。以{{valueLabel}}显示。",
-      "capital_needed_tip_fire": "在扣除支出、收入、税费、退休期收益率和费用后，您期望退休年龄时所需的资本。以{{valueLabel}}显示。",
+      "capital_needed_tip_traditional": "根据计划的支出、收入、税收、收益率和费用假设，估算目标退休年龄所需的资金。以{{valueLabel}}显示。",
+      "capital_needed_tip_fire": "根据计划的支出、收入、税收、收益率和费用假设，估算目标退休年龄所需的资金。以{{valueLabel}}显示。",
       "not_available": "不可用",
       "funded_pct": "已达标 {{pct}}%"
     },
@@ -169,18 +159,18 @@
     },
     "milestone": {
       "coast_fire": "Coast FIRE",
-      "coast_hint": "停止供款，仍可按时退休",
-      "coast_tip_nominal": "换算为您期望退休年龄名义金额的 Coast 金额。",
-      "coast_tip_real": "您今天所需的资本——在不再供款的情况下，可在退休年龄时增长为完全财务独立。",
+      "coast_hint": "目前所需资金估算",
+      "coast_tip_nominal": "按假设通胀率，将目前所需资金估算换算为退休年龄时的金额。这是价值换算，并非投资增长预测。",
+      "coast_tip_real": "将退休目标按扣除费用后的退休前假设收益率折现，估算目前所需资金。养老金假设保持不变。",
       "lean_fire": "Lean FIRE",
       "lean_hint": "计划支出的 70%",
-      "lean_tip": "以节俭预算退休——约为您计划支出的 70%。可较早实现，但余地较小。",
+      "lean_tip": "在其他假设不变的情况下，为计划支出的70%估算所需资金。这是本规划器的Lean FIRE情景。",
       "fi": "FI",
       "fi_hint": "完整的计划支出",
       "fi_tip": "在整个退休期内支撑您计划退休支出的资本。",
       "fat_fire": "Fat FIRE",
       "fat_hint": "计划支出的 150%",
-      "fat_tip": "以比计划多约 50% 的支出退休——为旅行、馈赠、市场波动和生活品质提升留有余地。",
+      "fat_tip": "在其他假设不变的情况下，为计划支出的150%估算所需资金。这是本规划器的Fat FIRE情景。",
       "more_info_about": "关于 {{label}} 的更多信息",
       "done": "已完成"
     },
@@ -217,11 +207,26 @@
       "unfunded": "无资金支持",
       "planned_spending_legend": "计划支出",
       "showing": "显示{{valueLabel}}",
-      "projection_unavailable": "该计划的覆盖情况预测不可用。"
+      "projection_unavailable": "该计划的覆盖情况预测不可用。",
+      "age_range": "{{start}}岁 → {{end}}岁",
+      "starts_at": "{{age}}岁开始",
+      "ended_at": "{{age}}岁结束",
+      "not_active": "未生效"
     },
     "disclaimer": {
       "title": "有一点需要记住",
-      "body": "这并非财务建议。请将这些数字视为草图，而非预测。此处的一切都是基于您输入的数据构建的模拟：收益率、通胀、供款、税费，以及您预期的寿命。真实市场不会沿直线运行，税收规则会变化，政府项目也会被改写。请借此对各种想法进行压力测试并发现漏洞，然后在做出难以撤销的决定之前咨询合格的专业人士。"
+      "body": "预测取决于您的假设。实际结果可能不同。不构成财务建议。"
+    },
+    "guidance": {
+      "unavailable": "当前假设下无法估算目标。请在假设分析中比较假设。",
+      "depleted": "预计投资组合在{{age}}岁时出现资金不足。请在假设分析中比较假设。",
+      "gap": "预计从{{age}}岁起出现支出缺口。请在假设分析中比较假设。",
+      "fund": "预计{{label}}在{{age}}岁时耗尽，模型中的付款随后停止。请比较付款和收入假设。",
+      "shortfall": "预计退休时出现缺口。请在假设分析中比较假设。",
+      "reached": "当前投资组合已达到您的假设下估算的财务独立目标。",
+      "not_reached": "预计{{age}}岁前无法实现财务独立。请在假设分析中比较假设。",
+      "late_one": "预计在期望年龄的{{count}}年后实现财务独立。请在假设分析中比较假设。",
+      "late_other": "预计在期望年龄的{{count}}年后实现财务独立。请在假设分析中比较假设。"
     }
   },
   "sidebar": {
@@ -231,7 +236,8 @@
       "high_inflation": "通胀假设偏高。在该通胀率下，长期支出需求会变得更加敏感。",
       "high_fee": "费用假设偏高。费用拖累会显著降低长期收益。",
       "high_volatility": "波动率假设偏高。结果区间可能变得非常宽。",
-      "high_contribution_growth": "供款增长假设偏高。这意味着持续大幅增加储蓄。"
+      "high_contribution_growth": "供款增长假设偏高。这意味着持续大幅增加储蓄。",
+      "high_return": "收益率假设较高。预计余额对这一比率较为敏感。"
     },
     "plan": {
       "kicker": "计划",
@@ -252,14 +258,14 @@
       "desired_retirement_age_hint": "您希望实现财务独立的年龄。",
       "retirement_age_hint": "您希望退休的年龄。",
       "horizon_age_fire": "计划终止年龄",
-      "horizon_age_traditional": "预期寿命",
+      "horizon_age_traditional": "计划终止年龄",
       "horizon_hint": "计划应覆盖至的年龄。",
       "monthly_contribution": "每月供款",
       "monthly_contribution_hint": "退休前您每月增加的金额。",
-      "return_before_hint": "储蓄期间的预期年收益率。",
-      "return_during_hint": "开始提取后的预期年收益率。",
+      "return_before_hint": "储蓄期间的假设年收益率，未扣除投资费用。",
+      "return_during_hint": "开始提款后的假设年收益率，未扣除投资费用。",
       "annual_fee_hint": "估算的年度投资组合费用。",
-      "inflation_hint": "预期的物价年度涨幅。"
+      "inflation_hint": "假设的年度物价涨幅。"
     },
     "spending": {
       "kicker": "支出",
@@ -320,13 +326,13 @@
       "fund_return_before_payout": "支付前基金收益率",
       "fund_payout_rate": "支付比率",
       "fund_payout_mode": "支付方式",
-      "fund_payout_mode_help": "年金终身支付；提取则动用基金，直到耗尽。",
+      "fund_payout_mode_help": "年金模式假设付款持续至规划期末；提款模式使用基金余额直至耗尽。",
       "annuity": "年金",
       "drawdown": "提取",
       "fund_return_during_payout": "支付期间的基金收益率",
-      "drawdown_note": "提取按起始年龄时余额的 {{pct}}%/年支取，此后按下方的增长设置继续，直到基金耗尽。",
+      "drawdown_note": "提取金额按基金余额的每年 {{pct}}% 估算。若已开始领取，则优先使用输入的每月领取金额。此后按设定的增长率调整，直至资金耗尽。",
       "monthly_payout_after_tax": "税后每月支付额",
-      "payout_estimate_note": "除非您输入每月支付额，否则估算支付额按预计基金余额的 {{pct}}%/年计算。",
+      "payout_estimate_note": "预计领取金额按基金余额的每年 {{pct}}% 估算。若已开始领取，则优先使用输入的每月领取金额。",
       "start_age": "起始年龄",
       "income_growth": "收入增长",
       "income_growth_help": "选择此收入是随计划通胀上涨还是保持固定。",
@@ -465,15 +471,15 @@
     "quick_start": {
       "title": "快速入门——5 个步骤",
       "step1_title": "设置计划基础",
-      "step1_desc": "在“计划输入”中，选择计划类型、出生月份、退休年龄、预期寿命和每月供款。",
+      "step1_desc": "在计划输入中设置类型、出生月份、退休年龄、规划结束年龄和每月缴款。",
       "step2_title": "输入退休支出",
       "step2_desc": "在“退休支出”中，添加您希望计划支撑的每月支出项。使用今天的金额；通胀由计划假设处理。",
       "step3_title": "添加退休收入",
-      "step3_desc": "在“退休收入”中，添加每月收入流，例如公共养老金（如加拿大的 CPP/OAS、美国的 Social Security）、职场养老金、兼职工作或年金收入。仅当您希望规划器按基金余额的 3.5%/年估算支付额（除非您自行输入每月支付额）时，才使用“添加养老基金”。",
+      "step3_desc": "添加养老金、兼职或年金等退休收入。对于养老基金，除非输入每月付款额，否则会使用预计余额及设定的年度支付率估算月付款额。",
       "step4_title": "检查假设、税费和账户占比",
       "step4_desc": "查看预计收益率、费用、波动率、通胀、提取税率、税收类别，以及哪些账户为目标提供资金。",
       "step5_title": "先阅读“概览”，再打开“假设分析”",
-      "step5_desc": "“概览”回答基础计划是否可行，并显示轨迹、支出覆盖情况和计划输入。“假设分析”在市场路径、压力测试、决策图和高级检查中测试同一计划。"
+      "step5_desc": "概览显示基础预测、支出覆盖和输入。情景分析比较市场路径、压力情景和假设变化。"
     },
     "overview": {
       "title": "理解“概览”",
@@ -493,13 +499,13 @@
     "what_if": {
       "title": "理解“假设分析”",
       "market_paths_title": "市场路径",
-      "market_paths_desc": "使用您的收益率、波动率和通胀假设，在多种可能的市场路径中测试同一计划。阴影区间显示从差到好的结果；线条显示中间路径。“资金充足”表示计划覆盖必需支出，并在整个规划期限内仍有余钱。在 FIRE 模式下，计划还需要先实现财务独立。",
+      "market_paths_desc": "我们根据您的假设模拟不同市场路径。阴影显示各年龄的第10至第90百分位区间；线条显示各路径的中位数，并非单一路径。 统计覆盖必要支出且期末仍有结余的路径；FIRE路径还必须达到财务独立。",
       "base_case_title": "基准情形",
       "base_case_desc": "显示与“概览”相同的确定性基础计划，然后指出最大的压力测试结果，让您看到最重要的因素。",
       "stress_tests_title": "压力测试",
       "stress_tests_desc": "固定检查项显示当收益率降低、通胀升高、支出增加、退休提前、储蓄减少或退休前后发生市场崩盘时，计划将如何变化。",
       "what_moves_title": "哪些因素影响计划？",
-      "what_moves_desc": "决策图比较储蓄、收益率、退休年龄和支出。绿色单元格在最后留有更多余钱。红色单元格仍留有缺口或资金不足。",
+      "what_moves_desc": "比较储蓄、收益率、退休年龄和支出。绿色表示期末资金比基础计划多，黄色表示更少。红色表示存在缺口或没有剩余资金。",
       "crash_paths_title": "早期市场崩盘路径",
       "crash_paths_desc": "比较退休前后几种崩盘时点路径。退休第一年发生的崩盘可能比之后同样的崩盘造成更大伤害，因为提取发生在投资组合下跌之时。"
     },
@@ -508,25 +514,24 @@
       "yearly_spending_title": "年度支出如何建模",
       "yearly_spending_desc": "您的支出驱动提取。规划器每年为您输入的支出计划提供资金，减去退休收入，并估算投资组合提取的任何税收拖累。",
       "target_calc_title": "目标如何计算",
-      "target_calc_desc": "规划器计算从退休到您规划期限的完整支出计划表的现值——考虑每个支出类别的通胀率、在不同年龄开始的收入流，以及提取的税收拖累。当您的投资组合达到此金额时，基础计划就有足够的资本支撑您所输入的计划表。这比简单的支出倍数更准确，因为它处理了变化的支出、递延的养老金和有限的期限。",
+      "target_calc_desc": "规划器估算覆盖退休支出安排直至规划期末所需的初始投资组合。模型考虑支出通胀、收入时间、收益率、费用及提款税。目标取决于这些假设。",
       "inflation_title": "通胀率",
-      "inflation_desc": "所有预测均按此利率逐年增长支出和与通胀挂钩的收入。默认的 2% 与欧洲央行的目标一致。",
-      "inflation_it_note": "如需更保守的意大利 CPI 假设，请使用 2.5–3%。",
+      "inflation_desc": "通胀假设使支出及与通胀挂钩的收入随时间增长。各个项目可以使用各自的增长率。",
       "returns_title": "收益率、费用和波动率",
       "returns_desc": "退休前收益率驱动积累。退休期收益率驱动提取阶段和所需资本。年度投资费用从两者中扣除。波动率仅用于市场路径检查——数值越高，产生的结果分布越宽。",
       "horizon_title": "规划期限年龄",
-      "horizon_desc": "投资组合必须持续的时长。退休目标和“假设分析”检查运行至此年龄。将其设为 90–95 以对长寿风险进行压力测试。早期市场崩盘路径和“资金充足”均在此期限衡量。"
+      "horizon_desc": "退休支出及假设分析结果建模到的年龄。这是规划期间的假设，不是寿命预测。"
     },
     "italian": {
       "title": "意大利退休设置（fondo pensione、TFR、INPS）",
       "portfolio_title": "投资组合（Golden Butterfly、All-Weather……）",
       "portfolio_desc": "这是您的主投资组合——Wealthfolio 跟踪的价值。在此处设置您的收益率假设、费用拖累和每月供款。它是您退休计划的主要积累引擎。",
       "fondo_title": "Fondo pensione integrativo（补充养老基金）",
-      "fondo_desc": "使用“添加养老基金”。输入当前基金余额、每月供款、预期基金收益率和支付开始年龄。规划器会估算未来余额，如果您不输入每月支付额，则从起始年龄起按该预计余额的 3.5%/年估算支付额。",
+      "fondo_desc": "使用添加养老基金，输入余额、缴款、假设收益率及付款起始年龄。未输入月付款额时，使用设定支付率估算。提款在基金耗尽时停止；年金付款建模至规划期末。",
       "inps_title": "Pensione INPS（国家养老金——强制性社保）",
       "inps_desc": "使用“添加退休收入”。以今天的金额输入您估算的每月净养老金，并设置支付开始年龄。如果您希望收入随计划通胀假设上涨，请使用“挂钩”。",
       "tfr_title": "TFR（Trattamento di Fine Rapporto——离职补偿累积）",
-      "tfr_desc": "如果您的 TFR 存入养老基金，请将其计入每月基金供款中。如果您将其单独保留，请将其建模为另一个养老基金，拥有自己的余额、供款、收益率和支付开始年龄。除非您自行输入每月支付额，否则同样适用 3.5%/年的支付估算。"
+      "tfr_desc": "若TFR转入养老基金，请将其计入缴款。单独储蓄的TFR可用另一基金表示；模型付款按设定支付率或月付款额计算。"
     }
   },
   "type": {
@@ -773,7 +778,7 @@
       "retirement_gap": "退休缺口",
       "fi_moves_prefix": "财务独立推迟",
       "fi_moves_suffix": "年",
-      "largest_risk": "{{label}} 是最大风险",
+      "largest_risk": "在这些测试中，{{label}}的影响最大",
       "and": "和",
       "none": "无",
       "surplus": "盈余",
@@ -796,7 +801,10 @@
       "money_lasts_summary_traditional": "在 {{horizonAge}} 岁前保持资金充足",
       "money_lasts_summary_fire": "实现财务独立 + 在 {{horizonAge}} 岁前资金充足",
       "money_lasts_prompt_traditional": "运行 1 万条路径，查看计划在 {{horizonAge}} 岁前保持资金充足的频率。",
-      "money_lasts_prompt_fire": "运行 1 万条路径，查看计划实现财务独立并在 {{horizonAge}} 岁前保持资金充足的频率。"
+      "money_lasts_prompt_fire": "运行 1 万条路径，查看计划实现财务独立并在 {{horizonAge}} 岁前保持资金充足的频率。",
+      "of_simulated_paths": "模拟路径占比",
+      "simulation_tooltip_traditional": "{{percent}}%的模拟路径覆盖了必要支出，并在结束时仍有资金结余。颜色采用参考区间：低于75%、75%至低于90%、90%及以上。这些是模型结果，不是现实概率。",
+      "simulation_tooltip_fire": "{{percent}}%的模拟路径覆盖了必要支出，并在结束时仍有资金结余。路径还必须达到财务独立。颜色采用参考区间：低于75%、75%至低于90%、90%及以上。这些是模型结果，不是现实概率。"
     },
     "stress": {
       "eyebrow_with_count": "什么可能破坏此计划？ · {{count}} 个情景",
@@ -811,8 +819,8 @@
     },
     "montecarlo": {
       "eyebrow": "市场路径",
-      "heading": "资金能维持多久的概率？",
-      "intro": "我们在多种可能的市场路径中测试同一计划。阴影区间显示从差到好的结果；线条显示中间路径。",
+      "heading": "资金够用的模拟路径占比是多少？",
+      "intro": "我们根据您的假设模拟不同市场路径。阴影显示各年龄的第10至第90百分位区间；线条显示各路径的中位数，并非单一路径。",
       "run_10k": "运行 1 万条路径",
       "run_100k": "运行 10 万条路径",
       "running_short": "正在运行……",
@@ -824,29 +832,30 @@
       "median_fi_age": "中位数财务独立年龄",
       "withdrawals_start_detail": "提取开始",
       "vs_goal": "对比目标 {{age}}",
-      "bad_path": "较差路径",
-      "middle_path": "中间路径",
-      "good_path": "较好路径"
+      "bad_path": "较低结果",
+      "middle_path": "中位数",
+      "good_path": "较高结果"
     },
     "chart": {
       "age_label": "{{age}} 岁",
       "age_detail": "{{age}} 岁",
       "goal_at_age": "{{label}} @{{age}}",
       "median_fi_at_age": "中位数财务独立 @{{age}}",
-      "bad_good_range": "差—好区间",
-      "median_path": "中位数路径",
+      "bad_good_range": "第10至第90百分位区间",
+      "median_path": "中位数",
       "retirement_age": "退休年龄",
       "goal_age": "目标年龄",
       "median_fi_age": "中位数财务独立年龄",
       "market_paths_count": "{{count}} 条市场路径",
       "retire": "退休",
       "goal": "目标",
-      "market_paths_count_other": "{{count}} 条市场路径"
+      "market_paths_count_other": "{{count}} 条市场路径",
+      "percentile_at_age": "第{{percentile}}百分位 · {{age}}岁"
     },
     "moves": {
       "eyebrow": "什么对计划影响最大？",
       "heading": "哪些因素影响计划？",
-      "description": "显示储蓄、收益率、退休年龄和支出如何改变结果。绿色 = 剩余资金更多；红色 = 缺口或资金不足。",
+      "description": "比较储蓄、收益率、退休年龄和支出。绿色表示期末资金比基础计划多，黄色表示更少。红色表示存在缺口或没有剩余资金。",
       "empty_title": "看看哪些改变最有帮助。",
       "empty_description": "比较多储蓄、获得不同收益率、减少支出，或在不同年龄退休。",
       "building": "正在构建……",
@@ -875,6 +884,39 @@
       "unavailable_title": "崩盘路径不可用。",
       "empty_description": "运行这五条路径，查看哪种序列会最先给计划带来压力。",
       "unavailable_description": "此检查需要退休开始时投资组合为正值。"
+    },
+    "labels": {
+      "crash_year_1": "第1年下跌（−30%）",
+      "crash_year_5": "第5年下跌（−30%）",
+      "double_crash": "两次下跌",
+      "lost_decade": "失落的十年",
+      "after_fee_return": "扣费后收益率"
+    },
+    "scenarios": {
+      "return-drag": {
+        "label": "收益率降低",
+        "description": "退休前和退休期间的收益率降低2个百分点。"
+      },
+      "inflation-shock": {
+        "label": "通胀升高",
+        "description": "总体通胀率提高1.5个百分点。"
+      },
+      "spending-shock": {
+        "label": "支出增加",
+        "description": "所有退休支出金额增加10%。"
+      },
+      "retire-earlier": {
+        "label": "提前2年退休",
+        "description": "目标退休年龄提前两年，受计划当前年龄限制。"
+      },
+      "save-less": {
+        "label": "缴款减少",
+        "description": "每月缴款减少25%。"
+      },
+      "early-crash": {
+        "label": "退休初期市场下跌",
+        "description": "模型假设退休第一年市场下跌30%。"
+      }
     }
   }
 }

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2480,6 +2480,8 @@ export interface RetirementOverview {
   portfolioAtGoalAge: number;
   requiredCapitalReachable: boolean;
   requiredCapitalAtGoalAge: number;
+  leanRequiredCapitalAtGoalAge?: number | null;
+  fatRequiredCapitalAtGoalAge?: number | null;
   shortfallAtGoalAge: number;
   surplusAtGoalAge: number;
   fundedThroughAge: number | null;

--- a/crates/core/src/goals/goals_service.rs
+++ b/crates/core/src/goals/goals_service.rs
@@ -6,8 +6,8 @@ use crate::goals::goals_model::{
 };
 use crate::goals::goals_traits::{GoalRepositoryTrait, GoalServiceTrait};
 use crate::planning::retirement::{
-    normalize_retirement_plan_ages, RetirementPlan, RetirementTimingMode, TaxBucketBalances,
-    TaxProfile,
+    normalize_retirement_plan_ages, try_compute_required_capital, RetirementPlan,
+    RetirementTimingMode, TaxBucketBalances, TaxProfile,
 };
 use crate::planning::{validate_save_up_input, SaveUpInput, SaveUpOverview};
 use crate::portfolio::fire::{compute_retirement_overview_with_mode, RetirementOverview};
@@ -26,6 +26,14 @@ const RETIREMENT_MAX_DC_PAYOUT_RATE: f64 = 0.25;
 const RETIREMENT_MAX_ANNUAL_VOLATILITY: f64 = 1.0;
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
+
+fn spending_scenario_target(plan: &RetirementPlan, spending_factor: f64) -> Option<f64> {
+    let mut scenario = plan.clone();
+    for item in &mut scenario.expenses.items {
+        item.monthly_amount *= spending_factor;
+    }
+    try_compute_required_capital(&scenario, scenario.personal.target_retirement_age)
+}
 
 fn extract_plan_dc_linked_account_ids(plan: &RetirementPlan) -> HashSet<String> {
     plan.income_streams
@@ -861,12 +869,18 @@ impl<T: GoalRepositoryTrait + Send + Sync> GoalServiceTrait for GoalService<T> {
         valuation_map: &AccountValuationMap,
     ) -> Result<RetirementOverview> {
         let prepared = self.prepare_retirement_input(goal_id, valuation_map)?;
-        let overview = compute_retirement_overview_with_mode(
+        let mut overview = compute_retirement_overview_with_mode(
             &prepared.plan,
             prepared.current_portfolio,
             prepared.planner_mode,
         );
 
+        if matches!(prepared.planner_mode, RetirementTimingMode::Fire) {
+            overview.lean_required_capital_at_goal_age =
+                spending_scenario_target(&prepared.plan, 0.7);
+            overview.fat_required_capital_at_goal_age =
+                spending_scenario_target(&prepared.plan, 1.5);
+        }
         Ok(overview)
     }
 
@@ -1025,6 +1039,39 @@ mod tests {
             tax: None,
             currency: "USD".into(),
         }
+    }
+
+    #[test]
+    fn spending_scenario_targets_preserve_income_and_original_plan() {
+        let mut plan = valid_retirement_plan();
+        plan.investment.inflation_rate = 0.0;
+        plan.investment.retirement_annual_return = 0.0;
+        plan.investment.annual_investment_fee_rate = 0.0;
+        plan.income_streams.push(RetirementIncomeStream {
+            id: "pension".into(),
+            label: "Pension".into(),
+            stream_type: StreamKind::DefinedBenefit,
+            start_age: 55,
+            annual_growth_rate: None,
+            adjust_for_inflation: false,
+            monthly_amount: Some(1_500.0),
+            linked_account_id: None,
+            current_value: None,
+            monthly_contribution: None,
+            accumulation_return: None,
+            payout_rate: None,
+            payout_mode: None,
+            post_payout_return: None,
+        });
+        let original = plan.clone();
+        let base = try_compute_required_capital(&plan, 55).unwrap();
+        let lean = spending_scenario_target(&plan, 0.7).unwrap();
+        let fat = spending_scenario_target(&plan, 1.5).unwrap();
+        // Expenses change; pension income does not. Net spending is 40% / 200%
+        // of the base plan here, rather than 70% / 150% of its capital target.
+        assert!((lean / base - 0.4).abs() < 0.000_001);
+        assert!((fat / base - 2.0).abs() < 0.000_001);
+        assert_eq!(plan, original);
     }
 
     fn retirement_goal(id: &str, status_lifecycle: &str) -> Goal {

--- a/crates/core/src/planning/retirement/dto.rs
+++ b/crates/core/src/planning/retirement/dto.rs
@@ -296,6 +296,10 @@ pub struct RetirementOverview {
     pub portfolio_at_goal_age: f64,
     pub required_capital_reachable: bool,
     pub required_capital_at_goal_age: f64,
+    #[serde(default)]
+    pub lean_required_capital_at_goal_age: Option<f64>,
+    #[serde(default)]
+    pub fat_required_capital_at_goal_age: Option<f64>,
     pub shortfall_at_goal_age: f64,
     pub surplus_at_goal_age: f64,
     pub funded_through_age: Option<u32>,
@@ -886,6 +890,8 @@ pub fn compute_retirement_overview_with_mode(
         portfolio_at_goal_age: portfolio_at_goal,
         required_capital_reachable,
         required_capital_at_goal_age: required_capital_value,
+        lean_required_capital_at_goal_age: None,
+        fat_required_capital_at_goal_age: None,
         shortfall_at_goal_age: shortfall,
         surplus_at_goal_age: surplus,
         funded_through_age,

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -23,10 +23,10 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+const CommandDialog = ({ children, contentClassName, ...props }: DialogProps & { contentClassName?: string }) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg [&>button]:top-5">
+      <DialogContent className={cn("overflow-hidden p-0 shadow-lg [&>button]:top-5", contentClassName)}>
         <Command className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 [&_[data-cmdk-input-wrapper]_svg]:h-5 [&_[data-cmdk-input-wrapper]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Description

Retirement projections now describe modeled outcomes and assumptions consistently across all 10 locales. Lean/Fat FIRE targets solve for 70%/150% of planned spending while preserving pension income and other assumptions, instead of multiplying the base capital target.

The two “Money lasts” metrics share rounded 75%/90% reference bands and accessible explanations of simulated-path results. Familiar labels remain, with revised payout guidance and fewer certainty or advice-like claims.

## Review order

1. Calculate Lean/Fat targets, expose nullable response fields, and verify pension, zero/null, and value-mode behavior.
2. Update projection copy, simulation percentages, tooltips, guide, and translations.
3. Remove retirement-card accent bars, widen desktop summaries, center mobile tabs, and add muted icon circles.
4. Widen and round the launcher, enlarge its search field, and keep its height stable while filtering.

## Validation

- 66 focused frontend tests and 91 focused Rust tests passed.
- TypeScript, web and desktop frontend builds, and server/Tauri Rust compile checks passed.
- Focused lint has no errors; existing query-key and build warnings remain.
- Earlier manual checks covered retirement desktop/mobile fixtures and German, French, and Japanese text. Latest live launcher inspection was blocked by the local backend being unavailable.
- No E2E tests. Existing Coast modeling, goals-list value-basis alignment, and Monte Carlo horizon alignment remain separate follow-ups.

## Checklist

- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
