### PR TITLE
chore(release): prepare version 3.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8578,7 +8578,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-agent-tools"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8683,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8746,7 +8746,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8770,7 +8770,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8792,7 +8792,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-mcp"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8817,7 +8817,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-spending"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8890,7 +8890,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.8.0"
+version = "3.9.0"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.8.0",
+  "version": "3.9.0",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {

--- a/apps/frontend/src/addons/iframe/host-dependencies.ts
+++ b/apps/frontend/src/addons/iframe/host-dependencies.ts
@@ -81,8 +81,8 @@ Object.assign(globalThis, {
 
 export const HOST_DEPENDENCY_VERSION_RANGES = {
   "@tanstack/react-query": "^5.90.0",
-  "@wealthfolio/addon-sdk": "^3.8.0",
-  "@wealthfolio/ui": "^3.8.0",
+  "@wealthfolio/addon-sdk": "^3.9.0",
+  "@wealthfolio/ui": "^3.9.0",
   "date-fns": "^4.1.0",
   "lucide-react": "^0.561.0",
   react: "^19.2.0",

--- a/apps/tauri/gen/apple/project.yml
+++ b/apps/tauri/gen/apple/project.yml
@@ -51,8 +51,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.8.0
-        CFBundleVersion: "3.8.0"
+        CFBundleShortVersionString: 3.9.0
+        CFBundleVersion: "5"
     entitlements:
       path: wealthfolio-app_iOS/wealthfolio-app_iOS.entitlements
     scheme:

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0</string>
+	<string>3.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>3.8.0</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -21,6 +21,7 @@
     "category": "public.app-category.finance",
     "createUpdaterArtifacts": "v1Compatible",
     "iOS": {
+      "bundleVersion": "5",
       "developmentTeam": "DYDJ2RNL5H",
       "infoPlist": "Info.ios.plist"
     },
@@ -40,7 +41,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.8.0",
+  "version": "3.9.0",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-dev-tools/templates/CHANGELOG.md.template
+++ b/packages/addon-dev-tools/templates/CHANGELOG.md.template
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release of {{addonName}} addon
 - Basic addon functionality and core features
-- Integration with Wealthfolio addon SDK v3.8.0
+- Integration with Wealthfolio addon SDK v3.9.0
 - Sidebar navigation integration for easy access
 - Responsive design for all screen sizes
 
@@ -35,4 +35,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compatible with Wealthfolio platform
 
 ### Compatibility
-- Requires Wealthfolio 3.8.0 or newer
+- Requires Wealthfolio 3.9.0 or newer

--- a/packages/addon-dev-tools/templates/manifest.json.template
+++ b/packages/addon-dev-tools/templates/manifest.json.template
@@ -5,8 +5,8 @@
   "description": "{{description}}",
   "author": "{{author}}",
   "main": "dist/addon.js",
-  "sdkVersion": "3.8.0",
-  "minWealthfolioVersion": "3.8.0",
+  "sdkVersion": "3.9.0",
+  "minWealthfolioVersion": "3.9.0",
   "enabled": true,
   "contributes": {
     "routes": [{ "id": "{{addonId}}" }],
@@ -24,8 +24,8 @@
   },
   "hostDependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@wealthfolio/addon-sdk": "^3.8.0",
-    "@wealthfolio/ui": "^3.8.0",
+    "@wealthfolio/addon-sdk": "^3.9.0",
+    "@wealthfolio/ui": "^3.9.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.561.0",
     "react": "^19.2.0",

--- a/packages/addon-dev-tools/templates/package.json.template
+++ b/packages/addon-dev-tools/templates/package.json.template
@@ -18,8 +18,8 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@wealthfolio/addon-sdk": "^3.8.0",
-    "@wealthfolio/ui": "^3.8.0",
+    "@wealthfolio/addon-sdk": "^3.9.0",
+    "@wealthfolio/ui": "^3.9.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.561.0",
     "react": "^19.2.0",
@@ -29,9 +29,9 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.90.20",
     "@tailwindcss/vite": "^4.1.13",
-    "@wealthfolio/addon-dev-tools": "^3.8.0",
-    "@wealthfolio/addon-sdk": "^3.8.0",
-    "@wealthfolio/ui": "^3.8.0",
+    "@wealthfolio/addon-dev-tools": "^3.9.0",
+    "@wealthfolio/addon-sdk": "^3.9.0",
+    "@wealthfolio/ui": "^3.9.0",
     "@types/node": "^20.0.0",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/addon-sdk/src/host-dependencies.ts
+++ b/packages/addon-sdk/src/host-dependencies.ts
@@ -1,7 +1,7 @@
 export const HOST_DEPENDENCIES = {
   '@tanstack/react-query': '^5.90.0',
-  '@wealthfolio/addon-sdk': '^3.8.0',
-  '@wealthfolio/ui': '^3.8.0',
+  '@wealthfolio/addon-sdk': '^3.9.0',
+  '@wealthfolio/ui': '^3.9.0',
   'date-fns': '^4.1.0',
   'lucide-react': '^0.561.0',
   react: '^19.2.0',

--- a/packages/addon-sdk/src/index.ts
+++ b/packages/addon-sdk/src/index.ts
@@ -4,7 +4,7 @@
  * TypeScript SDK for building Wealthfolio addons with enhanced functionality,
  * type safety, and comprehensive permission management.
  *
- * @version 3.8.0
+ * @version 3.9.0
  * @author Wealthfolio Team
  * @license MIT
  */

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

Prepare Wealthfolio 3.9.0 by updating the app, Rust workspace and lockfile, frontend, SDK, UI, and addon development tools from 3.8.0. Align the sandbox host dependency declarations and generated addon templates with 3.9.0, including the minimum Wealthfolio version for newly scaffolded addons.

Set the iOS build number to 5 in the Tauri configuration and generated Apple project metadata, while keeping the marketing version at 3.9.0.

## Validation

- `pnpm test --run`: 252 test files and 2,120 tests passed.
- `pnpm build`: passed, including TypeScript and addon sandbox verification.
- `pnpm build:tauri`: passed, including addon sandbox verification.
- `cargo check --workspace --locked`: passed, including desktop and web server crates.
- Release metadata consistency, addon template JSON, iOS plist validation, changed frontend/config JSON formatting, and `git diff --check`: passed.

Builds emit sourcemap and chunk-size warnings. Native iOS packaging/signing was not run.

## Review notes

No blocking issues found in the release metadata changes. The SDK README still identifies 3.8.0 as the current version; a documentation update remains separate from this version bump.

## Checklist

- [ ] Contributor License Agreement acknowledgment by the author.
