### PR TITLE
fix(performance): Fix metric warning popover on the Insights page

### DIFF
--- a/apps/frontend/src/components/metric-display.tsx
+++ b/apps/frontend/src/components/metric-display.tsx
@@ -225,6 +225,52 @@ function renderWarningText(text: string, boldTerms: string[]): React.ReactNode {
   );
 }
 
+/** Normalize the `string | string[] | undefined` warning prop into a deduped, trimmed list. */
+export function metricWarningItems(warningText?: string | string[]): string[] {
+  return Array.from(
+    new Set(
+      (Array.isArray(warningText) ? warningText : warningText ? [warningText] : [])
+        .map((warning) => warning.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+/** Shared body of a metric's info popover: explanatory text plus any calculation notes. */
+export const MetricInfoPopoverBody: React.FC<{
+  infoText: string;
+  warningItems: string[];
+  boldTerms?: string[];
+}> = ({ infoText, warningItems, boldTerms = [] }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-3 p-5">
+      <p className="text-muted-foreground leading-relaxed">{infoText}</p>
+      {warningItems.length > 0 && (
+        <div className="space-y-2 border-t pt-3">
+          <div className="text-warning flex items-center gap-1.5 font-medium">
+            <Icons.AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>
+              {warningItems.length === 1
+                ? t("common:component.calculation_note")
+                : t("common:component.calculation_notes", { count: warningItems.length })}
+            </span>
+          </div>
+          <ul className="text-muted-foreground max-h-[60vh] space-y-2 overflow-y-auto pr-1 leading-relaxed">
+            {warningItems.map((warning, index) => (
+              <li key={`${warning}-${index}`} className="flex gap-1.5">
+                <span className="bg-warning/70 mt-1.5 h-1 w-1 shrink-0 rounded-full" />
+                <span className="min-w-0 break-words">{renderWarningText(warning, boldTerms)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const MetricLabelWithInfo: React.FC<MetricLabelWithInfoProps> = ({
   label,
   infoText,
@@ -233,13 +279,7 @@ export const MetricLabelWithInfo: React.FC<MetricLabelWithInfoProps> = ({
   className,
 }) => {
   const { t } = useTranslation();
-  const warningItems = Array.from(
-    new Set(
-      (Array.isArray(warningText) ? warningText : warningText ? [warningText] : [])
-        .map((warning) => warning.trim())
-        .filter(Boolean),
-    ),
-  );
+  const warningItems = metricWarningItems(warningText);
   const hasWarnings = warningItems.length > 0;
 
   return (
@@ -272,31 +312,11 @@ export const MetricLabelWithInfo: React.FC<MetricLabelWithInfoProps> = ({
           side="top"
           align="center"
         >
-          <div className="space-y-3 p-5">
-            <p className="text-muted-foreground leading-relaxed">{infoText}</p>
-            {hasWarnings && (
-              <div className="space-y-2 border-t pt-3">
-                <div className="text-warning flex items-center gap-1.5 font-medium">
-                  <Icons.AlertTriangle className="h-4 w-4 shrink-0" />
-                  <span>
-                    {warningItems.length === 1
-                      ? t("common:component.calculation_note")
-                      : t("common:component.calculation_notes", { count: warningItems.length })}
-                  </span>
-                </div>
-                <ul className="text-muted-foreground max-h-[60vh] space-y-2 overflow-y-auto pr-1 leading-relaxed">
-                  {warningItems.map((warning, index) => (
-                    <li key={`${warning}-${index}`} className="flex gap-1.5">
-                      <span className="bg-warning/70 mt-1.5 h-1 w-1 shrink-0 rounded-full" />
-                      <span className="min-w-0 break-words">
-                        {renderWarningText(warning, boldTerms)}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </div>
+          <MetricInfoPopoverBody
+            infoText={infoText}
+            warningItems={warningItems}
+            boldTerms={boldTerms}
+          />
         </PopoverContent>
       </Popover>
     </div>

--- a/apps/frontend/src/pages/performance/performance-page.test.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.test.tsx
@@ -59,6 +59,32 @@ const accounts = [
   { id: "b", name: "Hidden TFSA", accountType: "SECURITIES", isActive: false },
   { id: "card", name: "Credit Card", accountType: "CREDIT_CARD", isActive: true },
 ].map((account) => ({ ...account, isArchived: false, currency: "USD" })) as Account[];
+const TWR_WARNING = "Some holdings are missing valuations for part of the period.";
+
+const resultWithWarning = {
+  id: ALL_PORTFOLIO_ITEM.id,
+  type: "account",
+  name: ALL_PORTFOLIO_ITEM.name,
+  scope: { id: ALL_PORTFOLIO_ITEM.id, currency: "USD" },
+  period: { startDate: "2026-01-01", endDate: "2026-03-01" },
+  mode: "timeWeighted",
+  returns: { twr: 0.1, annualizedTwr: 0.2, irr: null, annualizedIrr: null, valueReturn: null },
+  attribution: {
+    contributions: 0,
+    distributions: 0,
+    income: 0,
+    realizedPnl: 0,
+    unrealizedPnlChange: 0,
+    fxEffect: 0,
+    fees: 0,
+    taxes: 0,
+    residual: 0,
+  },
+  risk: { volatility: 0.05, maxDrawdown: -0.02 },
+  dataQuality: { status: "partial", warnings: [TWR_WARNING], notApplicableReasons: [] },
+  series: [{ date: "2026-01-01", value: 0 }],
+};
+
 const initialState = useAccountScopeStore.getState();
 
 function setScope(scope: AccountScope) {
@@ -303,6 +329,23 @@ describe("PerformancePage shared scope", () => {
     );
     expect(JSON.parse(localStorage.getItem("performance:selectedItemId")!)).toBe("b");
     expect(useAccountScopeStore.getState().bridgedItemId).toBe("b");
+  });
+
+  it("opens the TWR calculation notes from the desktop strip warning icon", async () => {
+    mocks.performance.mockReturnValue({
+      data: [resultWithWarning],
+      isLoading: false,
+      hasErrors: false,
+      errorMessages: [],
+      displayDateRange: "",
+    });
+    renderPage();
+    const trigger = await screen.findByRole("button", {
+      name: /calculation note for/i,
+    });
+    expect(screen.queryByText(TWR_WARNING)).toBeNull();
+    await userEvent.click(trigger);
+    expect(await screen.findByText(TWR_WARNING)).toBeInTheDocument();
   });
 
   it("does not request unvalidated persisted scopes during a cold load", async () => {

--- a/apps/frontend/src/pages/performance/performance-page.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.tsx
@@ -3,7 +3,9 @@ import { BenchmarkSymbolSelector } from "@/components/benchmark-symbol-selector"
 import {
   ANNUALIZED_RETURN_INFO as annualizedReturnInfo,
   MAX_DRAWDOWN_INFO as maxDrawdownInfo,
+  MetricInfoPopoverBody,
   MetricLabelWithInfo,
+  metricWarningItems,
   MONEY_WEIGHTED_RETURN_INFO,
   PRICE_RETURN_INFO,
   SIMPLE_RETURN_INFO,
@@ -450,19 +452,52 @@ function StripMetric({
   value,
   tone = "gain",
   reason,
-  hasWarning = false,
+  infoText,
+  warningText,
+  boldTerms,
 }: {
   label: string;
   value: number | null;
   tone?: "gain" | "neutral";
   reason?: string;
-  hasWarning?: boolean;
+  infoText: string;
+  warningText?: string | string[];
+  boldTerms?: string[];
 }) {
+  const { t } = useTranslation();
+  const warningItems = metricWarningItems(warningText);
+
   return (
     <div className="flex min-w-0 flex-col items-start gap-2">
       <div className="flex max-w-full items-center gap-1">
         <span className={STRIP_LABEL_CLASS}>{label}</span>
-        {hasWarning && <Icons.AlertTriangle className="text-warning h-3 w-3 shrink-0" />}
+        {warningItems.length > 0 && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-warning hover:text-warning h-4 w-4 shrink-0 rounded-full p-0"
+              >
+                <Icons.AlertTriangle className="h-3 w-3" />
+                <span className="sr-only">
+                  {t("common:component.calculation_note_for", { label })}
+                </span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-[34rem] max-w-[calc(100vw-2rem)] p-0 text-sm"
+              side="bottom"
+              align="start"
+            >
+              <MetricInfoPopoverBody
+                infoText={infoText}
+                warningItems={warningItems}
+                boldTerms={boldTerms}
+              />
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
       {value == null && reason ? (
         <span className="text-muted-foreground line-clamp-2 max-w-[12rem] text-xs leading-snug">
@@ -1735,24 +1770,29 @@ export default function PerformancePage() {
                                 label={stripReturnLabel(selectedItemData?.label, t)}
                                 value={selectedItemData?.selectedMetricValue ?? null}
                                 reason={selectedItemData?.selectedMetricReason}
-                                hasWarning={Boolean(
-                                  selectedItemData?.returnWarnings.length ||
-                                  selectedItemData?.selectedMetricReason,
-                                )}
+                                infoText={selectedItemData?.infoText ?? SIMPLE_RETURN_INFO}
+                                warningText={[
+                                  ...(selectedItemData?.returnWarnings ?? []),
+                                  ...(selectedItemData?.selectedMetricReason
+                                    ? [selectedItemData.selectedMetricReason]
+                                    : []),
+                                ]}
+                                boldTerms={selectedItemData?.warningTerms}
                               />
                               {selectedItemData?.showMoneyWeightedReturn && (
                                 <StripMetric
                                   label={selectedItemData.moneyWeightedReturnLabel}
                                   value={selectedItemData.moneyWeightedReturn}
                                   reason={selectedItemData.moneyWeightedReason}
-                                  hasWarning={Boolean(
-                                    selectedItemData.moneyWeightedWarnings.length,
-                                  )}
+                                  infoText={MONEY_WEIGHTED_RETURN_INFO}
+                                  warningText={selectedItemData.moneyWeightedWarnings}
+                                  boldTerms={selectedItemData.warningTerms}
                                 />
                               )}
                               <StripMetric
                                 label={t("performance:metric.annualized_short")}
                                 value={selectedItemData?.annualizedReturn ?? null}
+                                infoText={annualizedReturnInfo}
                               />
                             </div>
                           </StripSection>
@@ -1763,11 +1803,14 @@ export default function PerformancePage() {
                                 label={t("performance:metric.volatility")}
                                 value={selectedItemData?.volatility ?? null}
                                 tone="neutral"
-                                hasWarning={Boolean(selectedItemData?.volatilityWarnings.length)}
+                                infoText={volatilityInfo}
+                                warningText={selectedItemData?.volatilityWarnings}
+                                boldTerms={selectedItemData?.warningTerms}
                               />
                               <StripMetric
                                 label={t("performance:metric.max_drawdown_short")}
                                 value={selectedItemData?.maxDrawdown ?? null}
+                                infoText={maxDrawdownInfo}
                               />
                             </div>
                           </StripSection>


### PR DESCRIPTION
## Summary

On desktop, the amber warning triangle next to a performance metric was a decorative icon — no trigger, no accessible label. The warning text behind it was reachable only through the shared `(i)` popover at the top-right of the card. The same icon works on mobile, which is why narrowing the viewport "fixes" it: the metric strip renders two entirely different trees gated on an `isMobile` boolean, and only the mobile branch (`HeaderMetric` → `MetricLabelWithInfo`) wraps the triangle in a `Popover`.

This makes the desktop triangle a real button that opens that metric's calculation notes, using the same popover body as mobile.

Fixes #1484

## Changes

Three commits:

1. **`refactor(metrics): extract shared metric info popover body`** — pulls the info text + calculation-notes block out of `MetricLabelWithInfo` into `MetricInfoPopoverBody`, plus `metricWarningItems()` for normalizing the `string | string[] | undefined` warning prop. No behavior change.
2. **`fix(performance): make the desktop metric warning icon clickable`** — wraps `StripMetric`'s triangle in a `Popover` rendering that shared body, and replaces its `hasWarning: boolean` prop with the `infoText` / `warningText` / `boldTerms` the popover needs.
3. **`test(performance): cover the desktop metric warning popover`** — asserts a TWR data-quality warning renders an accessible button in the desktop strip and that clicking it reveals the warning text.

Commits 2 and 3 in the original plan (the component change and its call sites) are combined: they live in the same file, and a commit that changes `StripMetric`'s prop signature without updating its five call sites would not type-check.

## Notes for review

- **The `(i)` popover is kept as-is.** It is still the only help affordance for metrics that have no warnings (annualized return, max drawdown), so removing it would lose information.
- **The triangle appears in exactly the cases it did before.** The selected-return metric previously showed it for `returnWarnings.length || selectedMetricReason`. Since the popover needs content, the reason is now folded into `warningText` for that metric rather than dropping the triangle when only a reason is present. This does mean the reason can appear both inline under the value and in the popover — which already matches how the money-weighted metric behaves on both layouts.
- **No new i18n keys.** `calculation_note`, `calculation_notes`, and `calculation_note_for` already exist in all ten locales.
- **Frontend only** — no Rust, no IPC, no data-model changes.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
