### PR TITLE
fix(performance): resolve symbol/benchmark comparisons to full history on All Time

### DIFF
--- a/apps/frontend/src/pages/performance/hooks/use-performance-data.ts
+++ b/apps/frontend/src/pages/performance/hooks/use-performance-data.ts
@@ -6,6 +6,8 @@ import { calendarDateFromLocalDate, useDateFormatting } from "@wealthfolio/ui";
 import { format } from "date-fns";
 import { DateRange } from "react-day-picker";
 
+const SYMBOL_ALL_TIME_START_DATE = "1970-01-01";
+
 /**
  * Hook to calculate cumulative returns for a list of comparison items.
  * Uses the user-selected date range directly for queries, except when the
@@ -46,6 +48,8 @@ export function useCalculatePerformanceHistory({
   const performanceQueries = useQueries({
     queries: validItems.map((item) => {
       const accountFilter = item.type === "account" ? item.accountScope : undefined;
+      const effectiveStartDate =
+        dateRange === undefined && item.type === "symbol" ? SYMBOL_ALL_TIME_START_DATE : startDate;
 
       return {
         queryKey: [
@@ -53,7 +57,7 @@ export function useCalculatePerformanceHistory({
           item.type,
           item.id,
           accountFilter,
-          startDate,
+          effectiveStartDate,
           endDate,
           trackingMode,
         ],
@@ -61,7 +65,7 @@ export function useCalculatePerformanceHistory({
           calculatePerformanceHistory(
             item.type,
             item.id,
-            startDate,
+            effectiveStartDate,
             endDate,
             // Only pass trackingMode for accounts, not for symbols
             item.type === "account" ? trackingMode : undefined,


### PR DESCRIPTION
## Description

Fixes #1683.

`calculate_symbol_performance()` falls back to a trailing 365 days when no `start_date` is provided, unlike account performance which resolves to the account's actual inception. The "All Time" range intentionally omits `startDate`/`endDate` so the backend can apply inception semantics, but symbols have none, so benchmark comparisons (e.g. a custom ETF symbol) silently capped at ~1 year regardless of the selected range.

Forces an explicit early anchor (`1970-01-01`) for symbol items on "All Time" so the backend fetches the full history the provider actually has, instead of the 365-day fallback. Account items are unaffected.