### PR TITLE
fix(mobile): number inputs stealing focus back to date pickers

### DIFF
--- a/apps/frontend/src/pages/activity/components/forms/fields/option-contract-fields.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/option-contract-fields.tsx
@@ -10,9 +10,9 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  MoneyInput,
   useDateFormatting,
 } from "@wealthfolio/ui";
-import { Input } from "@wealthfolio/ui/components/ui/input";
 import { motion } from "motion/react";
 import { useEffect, useId, useRef } from "react";
 import { useFormContext, type FieldPath, type FieldValues } from "react-hook-form";
@@ -271,14 +271,10 @@ export function OptionContractFields<TFieldValues extends FieldValues = FieldVal
             <FormItem>
               <FormLabel>{t("activity:form.strike_price")}</FormLabel>
               <FormControl>
-                <Input
-                  type="number"
-                  step="0.01"
+                <MoneyInput
                   {...field}
-                  value={(field.value as number) ?? ""}
-                  onChange={(e) =>
-                    field.onChange(e.target.value ? Number(e.target.value) : undefined)
-                  }
+                  value={field.value as number | undefined}
+                  maxDecimalPlaces={2}
                   className="h-10"
                   aria-label={t("activity:form.strike_price")}
                 />

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -881,7 +881,8 @@ export function MobileDetailsStep({
                       </span>
                       <span>·</span>
                       <input
-                        type="number"
+                        type="text"
+                        inputMode="decimal"
                         {...register("contractMultiplier" as any, { valueAsNumber: true })}
                         readOnly={isEditing}
                         className="hover:border-input focus:border-input focus:bg-background focus:ring-ring h-5 w-14 rounded border border-transparent bg-transparent px-1 text-center text-xs tabular-nums focus:outline-none focus:ring-1"

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
@@ -8,7 +8,7 @@ import {
   DataGrid,
   DatePickerInput,
   Icons,
-  Input,
+  MoneyInput,
   useAmountFormatting,
   useDataGrid,
   useDateFormatting,
@@ -473,17 +473,12 @@ export function QuoteHistoryDataGrid({
                           <label className="text-muted-foreground mb-1 block text-xs">
                             {t("asset:quoteGrid.close")}
                           </label>
-                          <Input
-                            type="number"
-                            value={entry.close || ""}
-                            step={stepValue}
+                          <MoneyInput
+                            value={entry.close}
+                            maxDecimalPlaces={QUOTE_DECIMAL_PRECISION}
                             placeholder="0"
-                            onChange={(e) =>
-                              handleMobileFieldChange(
-                                entry.id,
-                                "close",
-                                parseFloat(e.target.value) || 0,
-                              )
+                            onValueChange={(value) =>
+                              handleMobileFieldChange(entry.id, "close", value ?? 0)
                             }
                           />
                         </div>
@@ -491,17 +486,12 @@ export function QuoteHistoryDataGrid({
                           <label className="text-muted-foreground mb-1 block text-xs">
                             {t("asset:quoteGrid.open")}
                           </label>
-                          <Input
-                            type="number"
-                            value={entry.open || ""}
-                            step={stepValue}
+                          <MoneyInput
+                            value={entry.open}
+                            maxDecimalPlaces={QUOTE_DECIMAL_PRECISION}
                             placeholder="0"
-                            onChange={(e) =>
-                              handleMobileFieldChange(
-                                entry.id,
-                                "open",
-                                parseFloat(e.target.value) || 0,
-                              )
+                            onValueChange={(value) =>
+                              handleMobileFieldChange(entry.id, "open", value ?? 0)
                             }
                           />
                         </div>
@@ -509,17 +499,12 @@ export function QuoteHistoryDataGrid({
                           <label className="text-muted-foreground mb-1 block text-xs">
                             {t("asset:quoteGrid.high")}
                           </label>
-                          <Input
-                            type="number"
-                            value={entry.high || ""}
-                            step={stepValue}
+                          <MoneyInput
+                            value={entry.high}
+                            maxDecimalPlaces={QUOTE_DECIMAL_PRECISION}
                             placeholder="0"
-                            onChange={(e) =>
-                              handleMobileFieldChange(
-                                entry.id,
-                                "high",
-                                parseFloat(e.target.value) || 0,
-                              )
+                            onValueChange={(value) =>
+                              handleMobileFieldChange(entry.id, "high", value ?? 0)
                             }
                           />
                         </div>
@@ -527,17 +512,12 @@ export function QuoteHistoryDataGrid({
                           <label className="text-muted-foreground mb-1 block text-xs">
                             {t("asset:quoteGrid.low")}
                           </label>
-                          <Input
-                            type="number"
-                            value={entry.low || ""}
-                            step={stepValue}
+                          <MoneyInput
+                            value={entry.low}
+                            maxDecimalPlaces={QUOTE_DECIMAL_PRECISION}
                             placeholder="0"
-                            onChange={(e) =>
-                              handleMobileFieldChange(
-                                entry.id,
-                                "low",
-                                parseFloat(e.target.value) || 0,
-                              )
+                            onValueChange={(value) =>
+                              handleMobileFieldChange(entry.id, "low", value ?? 0)
                             }
                           />
                         </div>
@@ -545,16 +525,12 @@ export function QuoteHistoryDataGrid({
                           <label className="text-muted-foreground mb-1 block text-xs">
                             {t("asset:quoteGrid.volume")}
                           </label>
-                          <Input
-                            type="number"
-                            value={entry.volume || ""}
+                          <MoneyInput
+                            value={entry.volume}
+                            maxDecimalPlaces={0}
                             placeholder="0"
-                            onChange={(e) =>
-                              handleMobileFieldChange(
-                                entry.id,
-                                "volume",
-                                parseInt(e.target.value) || 0,
-                              )
+                            onValueChange={(value) =>
+                              handleMobileFieldChange(entry.id, "volume", value ?? 0)
                             }
                           />
                         </div>

--- a/apps/frontend/src/pages/asset/quote-history-table.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-table.tsx
@@ -18,7 +18,6 @@ import {
   calendarDateFromLocalDate,
   DatePickerInput,
   Icons,
-  Input,
   Label,
   MoneyInput,
   Popover,
@@ -475,37 +474,33 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
                     />
                   </TableCell>
                   <TableCell>
-                    <Input
-                      type="number"
+                    <MoneyInput
                       value={newQuote.open}
                       onChange={(e) => handleInputChange("open", e.target.value, true)}
                     />
                   </TableCell>
                   <TableCell>
-                    <Input
-                      type="number"
+                    <MoneyInput
                       value={newQuote.high}
                       onChange={(e) => handleInputChange("high", e.target.value, true)}
                     />
                   </TableCell>
                   <TableCell>
-                    <Input
-                      type="number"
+                    <MoneyInput
                       value={newQuote.low}
                       onChange={(e) => handleInputChange("low", e.target.value, true)}
                     />
                   </TableCell>
                   <TableCell>
-                    <Input
-                      type="number"
+                    <MoneyInput
                       value={newQuote.close}
                       onChange={(e) => handleInputChange("close", e.target.value, true)}
                     />
                   </TableCell>
                   <TableCell>
-                    <Input
-                      type="number"
+                    <MoneyInput
                       value={newQuote.volume}
+                      maxDecimalPlaces={0}
                       onChange={(e) => handleInputChange("volume", e.target.value, true)}
                     />
                   </TableCell>

--- a/apps/frontend/src/pages/settings/contribution-limits/components/contribution-limit-form.tsx
+++ b/apps/frontend/src/pages/settings/contribution-limits/components/contribution-limit-form.tsx
@@ -181,15 +181,11 @@ export function ContributionLimitForm({
                             {t("settings:limits_form_year_label")}
                           </FormLabel>
                           <FormControl>
-                            <Input
-                              type="number"
+                            <MoneyInput
                               placeholder={t("settings:limits_form_year_placeholder")}
-                              value={field.value || ""}
-                              onChange={(e) => {
-                                const numValue =
-                                  e.target.value === "" ? undefined : Number(e.target.value);
-                                field.onChange(numValue);
-                              }}
+                              maxDecimalPlaces={0}
+                              value={field.value}
+                              onValueChange={(value) => field.onChange(value)}
                             />
                           </FormControl>
 


### PR DESCRIPTION
## What's broken

On mobile, editing a price in the "New Quote" form was basically unusable. Type a digit into the Close field and focus would jump straight to the Date field — so the next digit you typed landed nowhere useful, and the value just kept growing garbage on the end instead of being replaced (`11,6787` → `11,67876` → `11,678762` → ...). You had to tap back into the field after every single keystroke.

I caught this on video while updating a quote from the mobile app and traced it back to how the number fields were built.

https://github.com/user-attachments/assets/b127bbb4-e8e7-41d6-983e-b0bf0b7373f8

## Root cause

The forms in question pair a native `<input type="number">` right next to a `DatePickerInput`. Native number inputs are notoriously unreliable on mobile browsers/WebViews once locale comes into play — comma decimal separators in particular (my device is set to a Spanish locale, hence `11,6787`) can put the input into a weird state and, combined with the date picker sitting right there, focus ends up bouncing over to it.

The app already has a `MoneyInput` component (built on `react-number-format`, rendered as `text` + `inputMode="decimal"`) specifically to avoid this class of bug, and it's used for price fields everywhere else. These four spots just hadn't been migrated to it yet.

## What changed

Swapped the native `type="number"` inputs for `MoneyInput` (or `type="text"` + `inputMode="decimal"` for one bespoke inline field that keeps its own custom styling) in:

- **Quote history — mobile card** (`quote-history-data-grid.tsx`): the exact form from the video — Close/Open/High/Low/Volume.
- **Quote history — desktop "Add Quote" row** (`quote-history-table.tsx`): same pattern, same bug.
- **Option contract fields** (`option-contract-fields.tsx`): Strike Price sits right next to Expiration Date — identical setup, used in the mobile Buy/Sell forms.
- **Contribution limit form** (`contribution-limit-form.tsx`): the Year field sits beside two date pickers.
- **Mobile activity form** (`mobile-details-step.tsx`): the small contract-multiplier field, for consistency.

No behavior change on desktop/non-locale-comma setups — this only fixes a mobile-specific failure mode while keeping the same validation and decimal precision.

## Test plan

- [x] `pnpm --filter frontend type-check` — clean on all touched files
- [x] `pnpm --filter frontend lint` (eslint) — no new errors on touched files
- [x] Existing test suites for quote history, buy/sell forms, mobile activity form, and account page all pass
- [ ] Manual check on a real device/mobile viewport: type a multi-digit price into the mobile "New Quote" form and confirm focus stays put


