### PR TITLE
Fix broker activity identity fallback and align final cash docs

### DIFF
--- a/crates/connect/src/broker/mapping.rs
+++ b/crates/connect/src/broker/mapping.rs
@@ -642,11 +642,15 @@ pub fn map_broker_activity(
         source_system: normalize_source_system(activity.source_system.as_deref())
             .or_else(|| normalize_source_system(activity.provider_type.as_deref()))
             .or_else(|| Some("SNAPTRADE".to_string())),
-        source_record_id: activity
-            .source_record_id
-            .clone()
-            .or(activity.external_reference_id.clone())
-            .or(activity.id.clone()),
+        source_record_id: [
+            activity.source_record_id.as_ref(),
+            activity.provider_activity_id.as_ref(),
+            activity.id.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .find(|value| !value.trim().is_empty())
+        .cloned(),
         source_group_id: activity.source_group_id.clone(),
         idempotency_key: None,
         import_run_id: None,
@@ -780,7 +784,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_broker_activity_uses_provider_and_external_reference_fallbacks() {
+    fn test_map_broker_activity_preserves_external_reference_without_using_it_as_identity() {
         let activity = AccountUniversalActivity {
             id: Some("act-1".to_string()),
             activity_type: Some("BUY".to_string()),
@@ -792,12 +796,66 @@ mod tests {
         let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.source_system.as_deref(), Some("SNAPTRADE"));
-        assert_eq!(mapped.source_record_id.as_deref(), Some("ext-123"));
+        assert_eq!(mapped.source_record_id.as_deref(), Some("act-1"));
 
         let metadata_json = mapped.metadata.expect("metadata should be present");
         let metadata: serde_json::Value = serde_json::from_str(&metadata_json).unwrap();
         assert_eq!(metadata["provider_type"], "snaptrade");
         assert_eq!(metadata["external_reference_id"], "ext-123");
+    }
+
+    #[test]
+    fn source_identity_uses_first_nonblank_candidate() {
+        for source in [
+            None,
+            Some(""),
+            Some(" \t\n"),
+            Some("kraken:composite:1"),
+            Some("external-1"),
+            Some(" supplied-id "),
+        ] {
+            for provider in [None, Some(""), Some(" \t\n"), Some("provider-1")] {
+                let activity: AccountUniversalActivity =
+                    serde_json::from_value(serde_json::json!({
+                        "id": "act-1",
+                        "type": "BUY",
+                        "source_record_id": source,
+                        "provider_activity_id": provider,
+                        "source_group_id": "group-1",
+                        "external_reference_id": "external-1",
+                    }))
+                    .unwrap();
+                let mapped = map_test_activity(&activity);
+                let expected = source
+                    .filter(|s| !s.trim().is_empty())
+                    .or(provider.filter(|s| !s.trim().is_empty()))
+                    .unwrap_or("act-1");
+                assert_eq!(mapped.source_record_id.as_deref(), Some(expected));
+                assert_eq!(mapped.id.as_deref(), Some("act-1"));
+                assert_eq!(mapped.source_group_id.as_deref(), Some("group-1"));
+                let metadata: serde_json::Value =
+                    serde_json::from_str(mapped.metadata.as_deref().unwrap()).unwrap();
+                assert_eq!(metadata["source_group_id"], "group-1");
+                assert_eq!(metadata["external_reference_id"], "external-1");
+                if let Some(source) = source {
+                    assert_eq!(metadata["source_record_id"], source);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn source_identity_does_not_replace_required_incoming_id() {
+        for id in [None, Some(""), Some(" \t\n")] {
+            let activity: AccountUniversalActivity = serde_json::from_value(serde_json::json!({
+                "id": id,
+                "source_record_id": "composite-1",
+                "provider_activity_id": "provider-1",
+                "external_reference_id": "external-1",
+            }))
+            .unwrap();
+            assert!(map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).is_none());
+        }
     }
 
     #[test]

--- a/crates/connect/src/broker/models.rs
+++ b/crates/connect/src/broker/models.rs
@@ -333,6 +333,9 @@ pub struct AccountUniversalActivity {
     /// Unique identifier for this activity from the API
     pub id: Option<String>,
 
+    /// Unique activity identifier from the upstream provider
+    pub provider_activity_id: Option<String>,
+
     /// Symbol information for the security
     pub symbol: Option<AccountUniversalActivitySymbol>,
 
@@ -386,7 +389,7 @@ pub struct AccountUniversalActivity {
     /// Institution/brokerage name
     pub institution: Option<String>,
 
-    /// External reference ID from the provider
+    /// Grouping reference from the provider; not a unique activity identity
     #[serde(rename = "external_reference_id")]
     pub external_reference_id: Option<String>,
 

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -5567,6 +5567,124 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bulk_upsert_broker_activities_keeps_grouped_records_distinct() {
+        use wealthfolio_connect::broker::{mapping::map_broker_activity, AccountUniversalActivity};
+
+        // Exercise provider fallback, incoming ID fallback, and generated composite IDs.
+        for identity in ["provider", "id", "composite"] {
+            let (pool, writer) = setup_db();
+            let repo = ActivityRepository::new(pool.clone(), writer);
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_account(&mut conn, "acc-sync");
+
+            let rows: Vec<ActivityUpsert> = ["BUY", "FEE", "TAX"]
+                .into_iter()
+                .map(|kind| {
+                    let incoming: AccountUniversalActivity =
+                        serde_json::from_value(serde_json::json!({
+                            "id": format!("activity-{kind}"),
+                            "type": kind,
+                            "amount": 10.0,
+                            "trade_date": "2024-01-15",
+                            "provider_activity_id": if identity == "id" {
+                                None
+                            } else {
+                                Some(format!("provider-{kind}"))
+                            },
+                            "source_record_id": if identity == "composite" {
+                                Some(format!("kraken:composite:{kind}"))
+                            } else {
+                                None
+                            },
+                            "source_group_id": "shared-reference",
+                            "external_reference_id": "shared-reference",
+                        }))
+                        .unwrap();
+                    let mapped =
+                        map_broker_activity(&incoming, "acc-sync", Some("USD"), Some("USD"))
+                            .expect("mapped broker activity");
+                    ActivityUpsert {
+                        id: mapped.id.unwrap(),
+                        account_id: mapped.account_id,
+                        asset_id: None,
+                        activity_type: mapped.activity_type,
+                        subtype: mapped.subtype,
+                        activity_date: mapped.activity_date,
+                        quantity: mapped.quantity,
+                        unit_price: mapped.unit_price,
+                        currency: mapped.currency,
+                        fee: mapped.fee,
+                        tax: mapped.tax,
+                        amount: mapped.amount,
+                        status: mapped.status,
+                        notes: mapped.notes,
+                        fx_rate: mapped.fx_rate,
+                        metadata: mapped.metadata,
+                        needs_review: mapped.needs_review,
+                        source_system: mapped.source_system,
+                        source_record_id: mapped.source_record_id,
+                        source_group_id: mapped.source_group_id,
+                        idempotency_key: mapped.idempotency_key,
+                        import_run_id: mapped.import_run_id,
+                    }
+                })
+                .collect();
+
+            let first = repo.bulk_upsert(rows.clone()).await.unwrap();
+            assert_eq!((first.created, first.updated, first.skipped), (3, 0, 0));
+
+            let reimport = repo.bulk_upsert(rows.clone()).await.unwrap();
+            assert_eq!(
+                (reimport.created, reimport.updated, reimport.skipped),
+                (0, 3, 0)
+            );
+
+            diesel::update(activities::table.filter(activities::id.eq("activity-BUY")))
+                .set((
+                    activities::is_user_modified.eq(1),
+                    activities::notes.eq("user correction"),
+                ))
+                .execute(&mut conn)
+                .unwrap();
+
+            // Churn local IDs to exercise matching and protection by source identity.
+            let mut changed = rows.clone();
+            for row in &mut changed {
+                row.id = format!("reimport-{}", row.id);
+                row.notes = Some("provider update".to_string());
+            }
+            let protected = repo.bulk_upsert(changed).await.unwrap();
+            assert_eq!(
+                (protected.created, protected.updated, protected.skipped),
+                (0, 2, 1)
+            );
+
+            let stored = activities::table
+                .filter(activities::account_id.eq("acc-sync"))
+                .select(ActivityDB::as_select())
+                .load(&mut conn)
+                .unwrap();
+            assert_eq!(stored.len(), 3);
+            for expected in &rows {
+                let row = stored.iter().find(|row| row.id == expected.id).unwrap();
+                assert_eq!(row.activity_type, expected.activity_type);
+                assert_eq!(row.source_record_id, expected.source_record_id);
+                assert_eq!(row.source_group_id.as_deref(), Some("shared-reference"));
+                let metadata: serde_json::Value =
+                    serde_json::from_str(row.metadata.as_deref().unwrap()).unwrap();
+                assert_eq!(metadata["external_reference_id"], "shared-reference");
+                assert_eq!(metadata["source_group_id"], "shared-reference");
+                if row.id == "activity-BUY" {
+                    assert_eq!(row.notes.as_deref(), Some("user correction"));
+                    assert_eq!(row.is_user_modified, 1);
+                } else {
+                    assert_eq!(row.notes.as_deref(), Some("provider update"));
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn bulk_upsert_prefers_source_identity_over_idempotency_fallback() {
         let (pool, writer) = setup_db();
         let repo = ActivityRepository::new(pool.clone(), writer);

--- a/docs/activities/activity-types.md
+++ b/docs/activities/activity-types.md
@@ -7,7 +7,8 @@ imports.
 
 ## Overview
 
-Wealthfolio uses a closed set of **14 canonical activity types**. Each activity
+Wealthfolio uses a closed set of **14 canonical activity types**. Activities can
+affect:
 
 - **Cash Balance**: The cash position in the account (by currency)
 - **Asset Quantity**: The number of shares/units held
@@ -17,24 +18,63 @@ Wealthfolio uses a closed set of **14 canonical activity types**. Each activity
 
 ---
 
+## Final amounts (3.8 and later)
+
+`amount` is the saved final cash magnitude, including fees and taxes. Runtime
+calculations use it as-is. They do not derive a missing total or deduct charges
+again. Type normally determines direction; a SELL can be an outflow when its
+trade details prove charges exceed proceeds. Explicit zero remains zero.
+
+Writers can derive missing trade totals from quantity × unit price × asset
+multiplier, plus charges for BUY or minus charges for SELL. Import can convert a
+matching gross total to final; a conflicting total is preserved for review.
+Plain cash and income require an explicit amount. Standalone charges and
+recognized asset-income composites have their own missing-amount derivation.
+
+All monetary inputs use activity currency. `fx_rate` converts activity currency
+to account currency. A positive supplied rate settles BUY/SELL cash in account
+currency; otherwise trade cash stays in activity currency. Non-trade cash stays
+in activity currency, even with a rate. The rate can still affect contribution
+reporting, while displayed cash valuation uses FX service data. Asset quote
+currency does not participate in calculating the trade total. The asset owns the
+multiplier.
+
+Cash and gross flows differ: a deposit's final amount plus included charges is
+its pre-charge contribution; a withdrawal's final amount minus included charges
+is its pre-charge withdrawal. Income uses final amount plus included charges to
+recover its gross value. This does not create another cash movement.
+
+Exceptions: SPLIT uses amount as a ratio; security transfers move holdings and
+only their fee affects cash; DRIP, staking rewards, and in-kind dividends
+compile into matching income/acquisition legs. These cancel in the same currency
+without FX. With a supplied positive FX rate and different activity/account
+currencies, the income stays in activity currency while the synthetic BUY uses
+account currency, so both cash balances change. Do not supply a rate for a
+reinvestment that had no currency conversion.
+
+See [upgrade notes](final-cash-upgrade.md) and the consumer
+[Activity Fields reference](https://wealthfolio.app/docs/concepts/activity-fields/).
+`needs_review` is independent of status: a Posted row still counts while
+flagged. Incomplete imported final amounts are kept as Draft for review.
+
 ## Summary Table
 
-| Type             | Category | Cash Impact          | Holdings Impact   | Cost Basis         | Net Contribution                 | Required Asset |
-| ---------------- | -------- | -------------------- | ----------------- | ------------------ | -------------------------------- | -------------- |
-| **BUY**          | Trading  | -(qty × price + fee) | +quantity         | +cost              | No change                        | Yes            |
-| **SELL**         | Trading  | +(qty × price - fee) | -quantity         | -cost (FIFO)       | No change                        | Yes            |
-| **SPLIT**        | Trading  | No change            | Adjusted          | Per-share adjusted | No change                        | Yes            |
-| **DEPOSIT**      | Cash     | +(amount - fee)      | N/A               | N/A                | +amount                          | No             |
-| **WITHDRAWAL**   | Cash     | -(amount + fee)      | N/A               | N/A                | -amount                          | No             |
-| **TRANSFER_IN**  | Transfer | +amount or +quantity | +quantity (asset) | Preserved/set      | +amount (ordinary account scope) | Optional       |
-| **TRANSFER_OUT** | Transfer | -amount or -quantity | -quantity (asset) | Removed (FIFO)     | -amount (ordinary account scope) | Optional       |
-| **DIVIDEND**     | Income   | +(amount - fee)      | No change         | No change          | No change                        | Yes            |
-| **INTEREST**     | Income   | +(amount - fee)      | No change         | No change          | No change                        | Optional       |
-| **CREDIT**       | Income   | +(amount - fee)      | No change         | No change          | Depends on subtype               | No             |
-| **FEE**          | Charge   | -amount              | No change         | No change          | No change                        | Optional       |
-| **TAX**          | Charge   | -amount              | No change         | No change          | No change                        | Optional       |
-| **ADJUSTMENT**   | Other    | Varies               | Varies            | Varies             | No change                        | Yes (required) |
-| **UNKNOWN**      | Other    | No auto impact       | No auto impact    | No auto impact     | No change                        | Optional       |
+| Type             | Category | Cash Impact          | Holdings Impact   | Cost Basis         | Net Contribution                     | Required Asset |
+| ---------------- | -------- | -------------------- | ----------------- | ------------------ | ------------------------------------ | -------------- |
+| **BUY**          | Trading  | -amount              | +quantity         | +cost              | No change                            | Yes            |
+| **SELL**         | Trading  | +amount              | -quantity         | -cost (FIFO)       | No change                            | Yes            |
+| **SPLIT**        | Trading  | No change            | Adjusted          | Per-share adjusted | No change                            | Yes            |
+| **DEPOSIT**      | Cash     | +amount              | N/A               | N/A                | +gross flow                          | No             |
+| **WITHDRAWAL**   | Cash     | -amount              | N/A               | N/A                | -gross flow                          | No             |
+| **TRANSFER_IN**  | Transfer | +amount or +quantity | +quantity (asset) | Preserved/set      | +gross flow (ordinary account scope) | Optional       |
+| **TRANSFER_OUT** | Transfer | -amount or -quantity | -quantity (asset) | Removed (FIFO)     | -gross flow (ordinary account scope) | Optional       |
+| **DIVIDEND**     | Income   | +amount              | No change         | No change          | No change                            | Yes            |
+| **INTEREST**     | Income   | +amount              | No change         | No change          | No change                            | Optional       |
+| **CREDIT**       | Income   | +amount              | No change         | No change          | Depends on subtype                   | No             |
+| **FEE**          | Charge   | -amount              | No change         | No change          | No change                            | Optional       |
+| **TAX**          | Charge   | -amount              | No change         | No change          | No change                            | Optional       |
+| **ADJUSTMENT**   | Other    | Varies               | Varies            | Varies             | No change                            | Yes (required) |
+| **UNKNOWN**      | Other    | No auto impact       | No auto impact    | No auto impact     | No change                            | Optional       |
 
 ---
 
@@ -46,15 +86,15 @@ Wealthfolio uses a closed set of **14 canonical activity types**. Each activity
 
 **Purpose**: Purchase of a security or other asset.
 
-| Impact               | Description                                                       |
-| -------------------- | ----------------------------------------------------------------- |
-| **Cash**             | Decreases by `(quantity × unit_price) + fee` in activity currency |
-| **Holdings**         | Increases quantity; new lot created with cost basis               |
-| **Cost Basis**       | Increases by `(quantity × unit_price) + fee`                      |
-| **Net Contribution** | No change (internal reallocation of cash to asset)                |
+| Impact               | Description                                                                    |
+| -------------------- | ------------------------------------------------------------------------------ |
+| **Cash**             | Decreases by `amount` (final total including fee and tax) in activity currency |
+| **Holdings**         | Increases quantity; new lot created with cost basis                            |
+| **Cost Basis**       | Increases by `amount` (final total including fee and tax)                      |
+| **Net Contribution** | No change (internal reallocation of cash to asset)                             |
 
-**Required Fields**: `asset`, `quantity`, `unit_price`, `currency` **Optional
-Fields**: `fee`, `amount`
+**Entry Fields**: `asset`, `quantity`, `unit_price`, `currency`, final `amount`.
+The writer can calculate an omitted amount. **Optional Fields**: `fee`, `tax`.
 
 **Example**: Buy 10 shares of AAPL at $150 with $5 fee
 
@@ -68,15 +108,15 @@ Fields**: `fee`, `amount`
 
 **Purpose**: Disposal of a security or other asset.
 
-| Impact               | Description                                                       |
-| -------------------- | ----------------------------------------------------------------- |
-| **Cash**             | Increases by `(quantity × unit_price) - fee` in activity currency |
-| **Holdings**         | Decreases quantity; lots reduced using FIFO                       |
-| **Cost Basis**       | Decreases by cost basis of sold lots (FIFO matching)              |
-| **Net Contribution** | No change (internal reallocation of asset to cash)                |
+| Impact               | Description                                                                   |
+| -------------------- | ----------------------------------------------------------------------------- |
+| **Cash**             | Increases by `amount` (final proceeds after fee and tax) in activity currency |
+| **Holdings**         | Decreases quantity; lots reduced using FIFO                                   |
+| **Cost Basis**       | Decreases by cost basis of sold lots (FIFO matching)                          |
+| **Net Contribution** | No change (internal reallocation of asset to cash)                            |
 
-**Required Fields**: `asset`, `quantity`, `unit_price`, `currency` **Optional
-Fields**: `fee`, `amount`
+**Entry Fields**: `asset`, `quantity`, `unit_price`, `currency`, final `amount`.
+The writer can calculate an omitted amount. **Optional Fields**: `fee`, `tax`.
 
 **Note**: Realized gain/loss = proceeds - cost basis of sold lots.
 
@@ -110,12 +150,12 @@ for ratio)
 
 **Purpose**: Incoming funds from outside Wealthfolio (external source).
 
-| Impact               | Description                                            |
-| -------------------- | ------------------------------------------------------ |
-| **Cash**             | Increases by `amount - fee` in activity currency       |
-| **Holdings**         | N/A                                                    |
-| **Cost Basis**       | N/A                                                    |
-| **Net Contribution** | Increases by `amount` (new capital entering portfolio) |
+| Impact               | Description                                           |
+| -------------------- | ----------------------------------------------------- |
+| **Cash**             | Increases by `amount` in activity currency            |
+| **Holdings**         | N/A                                                   |
+| **Cost Basis**       | N/A                                                   |
+| **Net Contribution** | Increases by the pre-charge flow (amount + fee + tax) |
 
 **Required Fields**: `amount`, `currency` **Optional Fields**: `fee`
 
@@ -128,12 +168,12 @@ calculation.
 
 **Purpose**: Outgoing funds to an external destination.
 
-| Impact               | Description                                       |
-| -------------------- | ------------------------------------------------- |
-| **Cash**             | Decreases by `amount + fee` in activity currency  |
-| **Holdings**         | N/A                                               |
-| **Cost Basis**       | N/A                                               |
-| **Net Contribution** | Decreases by `amount` (capital leaving portfolio) |
+| Impact               | Description                                           |
+| -------------------- | ----------------------------------------------------- |
+| **Cash**             | Decreases by `amount` in activity currency            |
+| **Holdings**         | N/A                                                   |
+| **Cost Basis**       | N/A                                                   |
+| **Net Contribution** | Decreases by the pre-charge flow (amount - fee - tax) |
 
 **Required Fields**: `amount`, `currency` **Optional Fields**: `fee`
 
@@ -163,7 +203,7 @@ automatically contribution-neutral.
 
 | Scenario                            | Cash Impact         | Holdings Impact     | Net Contribution            |
 | ----------------------------------- | ------------------- | ------------------- | --------------------------- |
-| **Ordinary cash transfer**          | +amount             | N/A                 | +amount (account scope)     |
+| **Ordinary cash transfer**          | +amount             | N/A                 | +gross flow (account scope) |
 | **Recognized same-account FX pair** | +destination amount | N/A                 | No change                   |
 | **Asset transfer**                  | -fee only           | +quantity (new lot) | +cost_basis (account scope) |
 
@@ -172,7 +212,7 @@ automatically contribution-neutral.
 - Cash: `amount`, `currency`
 - Asset: `asset`, `quantity`, `unit_price`, `currency`
 
-**Optional Fields**: `fee`, `metadata.flow.is_external`
+**Optional Fields**: `fee`, `tax` (cash transfers), `metadata.flow.is_external`
 
 **Flow Behavior**:
 
@@ -193,18 +233,18 @@ automatically contribution-neutral.
 
 **Purpose**: Move cash or assets out of this account.
 
-| Scenario                            | Cash Impact     | Holdings Impact  | Net Contribution            |
-| ----------------------------------- | --------------- | ---------------- | --------------------------- |
-| **Ordinary cash transfer**          | -(amount + fee) | N/A              | -amount (account scope)     |
-| **Recognized same-account FX pair** | -source amount  | N/A              | No change                   |
-| **Asset transfer**                  | -fee only       | -quantity (FIFO) | -cost_basis (account scope) |
+| Scenario                            | Cash Impact    | Holdings Impact  | Net Contribution            |
+| ----------------------------------- | -------------- | ---------------- | --------------------------- |
+| **Ordinary cash transfer**          | -amount        | N/A              | -gross flow (account scope) |
+| **Recognized same-account FX pair** | -source amount | N/A              | No change                   |
+| **Asset transfer**                  | -fee only      | -quantity (FIFO) | -cost_basis (account scope) |
 
 **Required Fields**:
 
 - Cash: `amount`, `currency`
 - Asset: `asset`, `quantity`, `currency`
 
-**Optional Fields**: `fee`, `metadata.flow.is_external`
+**Optional Fields**: `fee`, `tax` (cash transfers), `metadata.flow.is_external`
 
 **Flow Behavior**: Ordinary transfers use the opposite sign from TRANSFER_IN.
 Recognized same-account cash FX pairs use the contribution-neutral behavior
@@ -226,7 +266,7 @@ described above.
 
 | Impact               | Description                                         |
 | -------------------- | --------------------------------------------------- |
-| **Cash**             | Increases by `amount - fee` in activity currency    |
+| **Cash**             | Increases by `amount` in activity currency          |
 | **Holdings**         | No change (unless DRIP or DIVIDEND_IN_KIND subtype) |
 | **Cost Basis**       | No change                                           |
 | **Net Contribution** | No change (income, not new capital)                 |
@@ -242,12 +282,12 @@ described above.
 
 **Purpose**: Interest earned on cash or fixed-income positions.
 
-| Impact               | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| **Cash**             | Increases by `amount - fee` in activity currency |
-| **Holdings**         | No change (unless STAKING_REWARD subtype)        |
-| **Cost Basis**       | No change                                        |
-| **Net Contribution** | No change (income, not new capital)              |
+| Impact               | Description                                |
+| -------------------- | ------------------------------------------ |
+| **Cash**             | Increases by `amount` in activity currency |
+| **Holdings**         | No change (unless STAKING_REWARD subtype)  |
+| **Cost Basis**       | No change                                  |
+| **Net Contribution** | No change (income, not new capital)        |
 
 **Required Fields**: `amount`, `currency` **Optional Fields**: `asset`, `fee`
 
@@ -259,12 +299,12 @@ described above.
 
 **Purpose**: Cash-only credit such as refunds, rebates, or bonuses.
 
-| Impact               | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| **Cash**             | Increases by `amount - fee` in activity currency |
-| **Holdings**         | N/A                                              |
-| **Cost Basis**       | N/A                                              |
-| **Net Contribution** | Depends on subtype (see below)                   |
+| Impact               | Description                                |
+| -------------------- | ------------------------------------------ |
+| **Cash**             | Increases by `amount` in activity currency |
+| **Holdings**         | N/A                                        |
+| **Cost Basis**       | N/A                                        |
+| **Net Contribution** | Depends on subtype (see below)             |
 
 **Required Fields**: `amount`, `currency` **Optional Fields**: `subtype`
 
@@ -272,7 +312,7 @@ described above.
 
 | Subtype   | Net Contribution | Rationale                                   |
 | --------- | ---------------- | ------------------------------------------- |
-| `BONUS`   | +amount          | New capital (sign-up bonus, referral bonus) |
+| `BONUS`   | +gross flow      | New capital (sign-up bonus, referral bonus) |
 | `REBATE`  | No change        | Reduced trading cost, not new capital       |
 | `REFUND`  | No change        | Reversal of existing fee, not new capital   |
 | (default) | No change        | Internal adjustment                         |
@@ -285,15 +325,15 @@ described above.
 
 **Purpose**: Stand-alone brokerage or platform fee not tied to a trade.
 
-| Impact               | Description                                                 |
-| -------------------- | ----------------------------------------------------------- |
-| **Cash**             | Decreases by `amount` (or `fee` field) in activity currency |
-| **Holdings**         | No change                                                   |
-| **Cost Basis**       | No change                                                   |
-| **Net Contribution** | No change                                                   |
+| Impact               | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| **Cash**             | Decreases by the saved `amount` in activity currency |
+| **Holdings**         | No change                                            |
+| **Cost Basis**       | No change                                            |
+| **Net Contribution** | No change                                            |
 
-**Required Fields**: `amount` or `fee`, `currency` **Optional Fields**: `asset`
-(for asset-specific fees)
+**Required saved Fields**: `amount`, `currency`. A writer can fill a missing
+amount from `fee`. **Optional Fields**: `asset` (for asset-specific fees)
 
 **Common Subtypes**:
 
@@ -399,9 +439,11 @@ The compiler expands these into canonical activity postings.
 **Compiled Postings**:
 
 1. **DIVIDEND**: `amount = $100` (income recognition)
-2. **BUY**: `quantity = 0.5, unit_price = $200` (share acquisition)
+2. **BUY**: `quantity = 0.5, unit_price = $200, amount = $100` (share
+   acquisition)
 
-**Net Cash Effect**: ~$0 (dividend received equals purchase cost)
+**Net Cash Effect**: $0 without a supplied FX rate (both legs use the same
+currency).
 
 ---
 
@@ -423,7 +465,8 @@ The compiler expands these into canonical activity postings.
 **Compiled Postings**:
 
 1. **DIVIDEND**: `amount = $250` (income recognition)
-2. **BUY**: `asset = AAPL, quantity = 10, unit_price = $25` (share acquisition)
+2. **BUY**: `asset = AAPL, quantity = 10, unit_price = $25, amount = $250`
+   (share acquisition)
 
 ---
 
@@ -453,9 +496,11 @@ The compiler expands these into canonical activity postings.
 **Compiled Postings**:
 
 1. **INTEREST**: `amount = $20` (income recognition)
-2. **BUY**: `quantity = 0.01, unit_price = $2000` (token acquisition)
+2. **BUY**: `quantity = 0.01, unit_price = $2000, amount = $20` (token
+   acquisition)
 
-**Net Cash Effect**: $0 (income equals acquisition cost)
+**Net Cash Effect**: $0 without a supplied FX rate (both legs use the same
+currency).
 
 ---
 
@@ -547,13 +592,17 @@ DIVIDEND, INTEREST
 DEPOSIT, WITHDRAWAL, FEE, TAX, CREDIT
 ```
 
-**Note**: TRANSFER_IN/TRANSFER_OUT can be cash OR asset depending on whether
-quantity/price is provided. INTEREST can have an optional asset (e.g., bond
-interest).
+**Note**: TRANSFER_IN/TRANSFER_OUT can be cash OR asset depending on whether an
+asset is linked. INTEREST can have an optional asset (e.g., bond interest).
 
 ---
 
 ## Form Field Requirements
+
+Trade entry can calculate an omitted final amount before saving. Cash and income
+amounts are final, including any charges. Asset-income subtypes also use
+quantity and price. These entry requirements do not imply runtime fallback
+calculations.
 
 | Type             | Required Fields                                              |
 | ---------------- | ------------------------------------------------------------ |
@@ -609,8 +658,8 @@ For precise IRR, cash-flow, and tax analytics:
 4. **Use subtypes for semantic variations** - Instead of custom types, use
    subtypes (e.g., DIVIDEND with subtype DRIP).
 
-5. **Include fees in the activity** - Fees are automatically factored into cost
-   basis and cash calculations.
+5. **Include charges in the final amount** - Record fee and tax details too, but
+   never deduct them again or duplicate them as standalone activities.
 
 6. **Set currency explicitly** - Always specify the activity currency for proper
    multi-currency handling.

--- a/docs/activities/final-cash-upgrade.md
+++ b/docs/activities/final-cash-upgrade.md
@@ -1,7 +1,7 @@
-# Upgrade notes: authoritative final cash (v3.7)
+# Upgrade notes: authoritative final cash (v3.8)
 
-From this version, an activity's **amount** is the final cash that moved — fees
-and taxes included. Readers book it as-is; nothing re-derives it at read time.
+From this version, an activity's **amount** is the final cash that moved, including fees
+and taxes. Readers book it as-is; nothing re-derives it at read time.
 On first launch after upgrading, a one-shot migration rewrites legacy rows to
 this contract. Make a normal database backup before updating. The application
 does not create a potentially large automatic startup backup. What you may
@@ -12,7 +12,7 @@ notice:
 - A trade whose stored amount was the pre-fee **gross** now stores the final
   total (for example, a buy of `10 × $100` with a `$9.99` fee changes from
   `$1,000` to `$1,009.99`). The replaced value is recorded on the row's metadata
-  (`final_cash_migration.legacy_amount`) — nothing is lost.
+  (`final_cash_migration.legacy_amount`) so you can inspect the previous value.
 - A trade whose stored amount **contradicts** its own quantity × price ± charges
   keeps your number untouched and is flagged for review instead.
 - Flagged rows appear in the review banner on the Activities page; open each one
@@ -59,3 +59,22 @@ missing trade total is derived, a gross total is converted to final, and a
 contradicting total is kept but flagged. A row whose final cash cannot be
 established is imported as a **draft** for review instead of silently booking
 zero.
+
+## Review and zero amounts
+
+The upgrade preserves lifecycle status. `needs_review` is a separate flag, so
+Posted activities still count while flagged. A Posted row with no final amount
+has no runtime cash movement until corrected. Legacy Draft rows are added to the
+review queue without becoming Posted.
+
+Legacy zero trade totals are treated as missing when trustworthy inputs can
+calculate a final total. This is an upgrade-only rule; a user-confirmed zero
+remains zero during normal use.
+
+Affected accounts rebuild their holdings and valuation histories. Failed
+rebuilds remain pending and retry on a later launch. Update all synced devices
+before recording more activities: each device runs its own migration and the
+rewrites do not emit sync events.
+
+For field meanings and examples, see the
+[Activity Fields reference](https://wealthfolio.app/docs/concepts/activity-fields/).

--- a/docs/activities/final-cash-upgrade.md
+++ b/docs/activities/final-cash-upgrade.md
@@ -1,9 +1,9 @@
 # Upgrade notes: authoritative final cash (v3.8)
 
-From this version, an activity's **amount** is the final cash that moved, including fees
-and taxes. Readers book it as-is; nothing re-derives it at read time.
-On first launch after upgrading, a one-shot migration rewrites legacy rows to
-this contract. Make a normal database backup before updating. The application
+From this version, an activity's **amount** is the final cash that moved,
+including fees and taxes. Readers book it as-is; nothing re-derives it at read
+time. On first launch after upgrading, a one-shot migration rewrites legacy rows
+to this contract. Make a normal database backup before updating. The application
 does not create a potentially large automatic startup backup. What you may
 notice:
 


### PR DESCRIPTION
## Description

Broker activities with a missing source record ID could use a shared external order reference as their SQLite identity, causing a buy, fee, and tax to overwrite one another. Resolve the first nonblank `source_record_id → provider_activity_id → id` instead. Preserve explicit composite identities, grouping provenance, the required incoming ID, and user-modified activity protection.

Also align the activity reference and upgrade notes with the final cash policy introduced in v3.8 (#1334): saved amounts already include charges; clarify cash direction, FX behavior, composite postings, review status, zero amounts, and migration/rebuild behavior.

Includes both commits:
- `5f24e6daf` — docs: align activity references with final cash policy (#1334)
- `307bddbb9` — Fix broker activity identity fallback

This is an app fallback fix. It does not repair historical collisions, migrate existing identities, change semantic deduplication, or sanitize incorrect source record IDs explicitly supplied by older cloud responses.

## Validation

- `cargo test -p wealthfolio-connect -p wealthfolio-storage-sqlite --lib` — 371 tests passed.
- `cargo check -p wealthfolio-app -p wealthfolio-server` — passed.
- `cargo fmt --all --check` and `git diff --check` — passed.
- Regression coverage passes mapped broker activities through the actual SQLite upsert: distinct grouped rows, repeated imports, composite identities, and user-modified protection after incoming row IDs change.
- Independent review of the identity fix found no actionable issues.

## Checklist

- [ ] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
