### PR TITLE
Keep Connect sessions signed in while subscription sync is paused

### DIFF
--- a/apps/frontend/src/adapters/shared/connect.ts
+++ b/apps/frontend/src/adapters/shared/connect.ts
@@ -339,3 +339,7 @@ export const storeSyncSession = async (refreshToken: string): Promise<void> => {
 export const clearSyncSession = async (): Promise<void> => {
   return invoke<void>("clear_sync_session");
 };
+
+export const getSyncSessionStatus = (): Promise<{ isConfigured: boolean }> => {
+  return invoke("get_sync_session_status");
+};

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -299,6 +299,7 @@ export {
   claimPairing,
   clearDeviceSyncData,
   clearSyncSession,
+  getSyncSessionStatus,
   completePairing,
   completePairingWithTransfer,
   confirmPairing,

--- a/apps/frontend/src/components/external-link.tsx
+++ b/apps/frontend/src/components/external-link.tsx
@@ -11,13 +11,15 @@ interface ExternalLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement
  * Renders a normal `<a>` for semantics/accessibility; click is handled by `openUrlInBrowser`.
  */
 export const ExternalLink = forwardRef<HTMLAnchorElement, ExternalLinkProps>(
-  ({ href, children, ...props }, ref) => {
+  ({ href, children, onClick, ...props }, ref) => {
     const handleClick = useCallback(
       (e: React.MouseEvent<HTMLAnchorElement>) => {
+        onClick?.(e);
+        if (e.defaultPrevented) return;
         e.preventDefault();
         openUrlInBrowser(href);
       },
-      [href],
+      [href, onClick],
     );
 
     return (

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -11,6 +11,7 @@ import {
   openFolderDialog,
   saveAppDataFileViaPicker,
 } from "@/adapters";
+import { PortalLink } from "@/features/wealthfolio-connect/components/portal-link";
 import { getPlatform as getRuntimePlatform } from "@/hooks/use-platform";
 import { useQueryClient } from "@tanstack/react-query";
 import { Icons, isKeyboardEventComposing, Skeleton } from "@wealthfolio/ui";
@@ -760,7 +761,7 @@ export function DeviceSyncSection() {
       <Card>
         <CardContent className="p-4">
           {/* Header row - matches Broker connections / Accounts pattern */}
-          <div className="flex items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
                 <Icons.Smartphone className="text-muted-foreground h-4 w-4" />
@@ -772,7 +773,10 @@ export function DeviceSyncSection() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="text-muted-foreground hover:text-foreground h-8 w-8 sm:hidden"
+                className="text-muted-foreground hover:text-foreground size-11 sm:hidden"
+                aria-label={t(
+                  isBackgroundRunning ? "sync:engine.pauseSync" : "sync:engine.resumeSync",
+                )}
                 onClick={handleToggleEngine}
                 disabled={isTogglingEngine}
               >
@@ -811,31 +815,14 @@ export function DeviceSyncSection() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="text-muted-foreground hover:text-foreground h-8 w-8"
+                className="text-muted-foreground hover:text-foreground size-11 sm:size-8"
+                aria-label={t("common:refresh")}
                 onClick={handleRefreshDevices}
                 disabled={isRefreshing}
               >
                 <Icons.RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
               </Button>
-              {/* Mobile: icon only */}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-muted-foreground hover:text-foreground sm:hidden"
-                onClick={() => window.open(PORTAL_DEVICES_URL, "_blank")}
-              >
-                <Icons.ExternalLink className="h-4 w-4" />
-              </Button>
-              {/* Desktop: full text */}
-              <Button
-                variant="ghost"
-                size="sm"
-                className="text-muted-foreground hover:text-foreground hidden sm:inline-flex"
-                onClick={() => window.open(PORTAL_DEVICES_URL, "_blank")}
-              >
-                {t("sync:section.manageDevices")}
-                <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
-              </Button>
+              <PortalLink href={PORTAL_DEVICES_URL} label={t("sync:section.manageDevices")} />
             </div>
           </div>
 
@@ -1353,7 +1340,7 @@ function PairThisDeviceItem({ onPair }: { onPair: () => void }) {
               <Button
                 variant="ghost"
                 size="icon"
-                className="text-muted-foreground h-8 w-8 shrink-0"
+                className="text-muted-foreground size-11 shrink-0 sm:size-8"
               >
                 <Icons.MoreVertical className="h-4 w-4" />
                 <span className="sr-only">{t("sync:section.options")}</span>
@@ -1543,7 +1530,8 @@ function DeviceCard({
               <Button
                 size="icon"
                 variant="ghost"
-                className="h-7 w-7 shrink-0"
+                className="size-11 shrink-0 sm:size-7"
+                aria-label={t("common:save")}
                 onClick={handleRename}
                 disabled={renameDevice.isPending}
               >
@@ -1556,7 +1544,8 @@ function DeviceCard({
               <Button
                 size="icon"
                 variant="ghost"
-                className="h-7 w-7 shrink-0"
+                className="size-11 shrink-0 sm:size-7"
+                aria-label={t("common:cancel")}
                 onClick={handleCancelRename}
               >
                 <Icons.Close className="h-3.5 w-3.5" />
@@ -1618,7 +1607,7 @@ function DeviceCard({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="text-muted-foreground h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 max-md:opacity-100"
+                  className="text-muted-foreground size-11 shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 max-md:opacity-100 sm:size-7"
                 >
                   <Icons.MoreVertical className="h-4 w-4" />
                   <span className="sr-only">{t("sync:section.deviceActions")}</span>

--- a/apps/frontend/src/features/devices-sync/hooks/use-sync-status.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/use-sync-status.ts
@@ -4,6 +4,7 @@
 // ==========================================================================
 
 import { useWealthfolioConnect } from "@/features/wealthfolio-connect";
+import { isSubscriptionStatusActive } from "@/features/wealthfolio-connect/lib/plan-capabilities";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { syncService } from "../services/sync-service";
@@ -12,9 +13,7 @@ import { SyncError, SyncStates } from "../types";
 export function useSyncStatus() {
   const { isConnected, isEnabled, userInfo } = useWealthfolioConnect();
 
-  const hasSubscription =
-    userInfo?.team?.subscription_status === "active" ||
-    userInfo?.team?.subscription_status === "trialing";
+  const hasSubscription = isSubscriptionStatusActive(userInfo?.team?.subscription_status);
 
   const enabled = !!isEnabled && !!isConnected && !!hasSubscription;
 

--- a/apps/frontend/src/features/wealthfolio-connect/components/connect-flow-diagram.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/connect-flow-diagram.tsx
@@ -171,7 +171,7 @@ export function ConnectFlowDiagram() {
             className="fill-[#b5b0a6] dark:fill-white/30"
             fontSize="10"
           >
-            (e.g. SnapTrade)
+            {t("connect:flow.aggregatorExample")}
           </text>
         </g>
 

--- a/apps/frontend/src/features/wealthfolio-connect/components/connected-view.test.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/connected-view.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConnectedView } from "./connected-view";
+
+const context = vi.hoisted(() => ({
+  user: { email: "user@example.com" },
+  session: { access_token: "test" },
+  userInfo: null as unknown,
+  signOut: vi.fn(),
+  clearError: vi.fn(),
+  refetchUserInfo: vi.fn(),
+  isLoading: false,
+  isLoadingUserInfo: false,
+  error: null as string | null,
+}));
+vi.mock("../providers/wealthfolio-connect-provider", () => ({
+  useWealthfolioConnect: () => context,
+}));
+vi.mock("./subscription-plans", () => ({
+  SubscriptionPlans: () => <div data-testid="pricing" />,
+}));
+vi.mock("@/features/devices-sync", () => ({
+  DeviceSyncSection: () => <div data-testid="device-sync" />,
+}));
+vi.mock("@/adapters", () => ({ openUrlInBrowser: vi.fn() }));
+vi.mock("../services/broker-service", () => ({
+  listBrokerAccounts: vi.fn().mockResolvedValue([]),
+  listBrokerConnections: vi.fn().mockResolvedValue([]),
+  syncBrokerData: vi.fn(),
+}));
+vi.mock("@wealthfolio/ui", () => ({
+  useDateFormatting: () => ({ dateFormat: "yyyy-MM-dd" }),
+  ActionConfirm: ({ button }: { button: React.ReactNode }) => button,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  Trans: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  context.error = null;
+  vi.clearAllMocks();
+});
+
+function renderView() {
+  render(
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
+      <ConnectedView />
+    </QueryClientProvider>,
+  );
+}
+
+describe("authenticated subscription view", () => {
+  it.each([null, "canceled", "unpaid", "incomplete", "paused", "unknown"])(
+    "shows pricing and preserves the session for status %s",
+    (status) => {
+      context.userInfo = { team: { subscription_status: status } };
+      renderView();
+      expect(screen.getByTestId("pricing")).toBeTruthy();
+      expect(screen.getByText("connect:subscription.syncPausedDescription")).toBeTruthy();
+      expect(screen.queryByTestId("device-sync")).toBeNull();
+      expect(context.signOut).not.toHaveBeenCalled();
+    },
+  );
+
+  it("shows pricing when the user has no team", () => {
+    context.userInfo = { team: null };
+    renderView();
+    expect(screen.getByTestId("pricing")).toBeTruthy();
+    expect(screen.getByText("connect:subscription.syncPausedDescription")).toBeTruthy();
+  });
+
+  it("shows retry instead of pricing when subscription lookup fails", () => {
+    context.userInfo = null;
+    context.error = "Service unavailable";
+    renderView();
+    expect(screen.getByText("connect:serviceUnavailable.tryAgain")).toBeTruthy();
+    expect(screen.queryByTestId("pricing")).toBeNull();
+    expect(screen.queryByText("connect:subscription.syncPausedTitle")).toBeNull();
+    expect(context.signOut).not.toHaveBeenCalled();
+  });
+  it.each(["active", "trialing", "past_due"])(
+    "does not show subscription pause for %s",
+    (status) => {
+      context.userInfo = { team: { plan: "basic", subscription_status: status } };
+      renderView();
+      expect(screen.queryByText("connect:subscription.syncPausedTitle")).toBeNull();
+      expect(screen.queryByTestId("pricing")).toBeNull();
+    },
+  );
+});

--- a/apps/frontend/src/features/wealthfolio-connect/components/connected-view.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/connected-view.tsx
@@ -6,6 +6,7 @@ import { QueryKeys } from "@/lib/query-keys";
 import { formatDate } from "@/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ActionConfirm, useDateFormatting } from "@wealthfolio/ui";
+import { Alert, AlertDescription, AlertTitle } from "@wealthfolio/ui/components/ui/alert";
 import { Avatar, AvatarFallback, AvatarImage } from "@wealthfolio/ui/components/ui/avatar";
 import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Button } from "@wealthfolio/ui/components/ui/button";
@@ -16,7 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/compone
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { useCallback, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { hasBrokerSync } from "../lib/plan-capabilities";
+import { hasBrokerSync, isSubscriptionStatusActive } from "../lib/plan-capabilities";
 import { useWealthfolioConnect } from "../providers/wealthfolio-connect-provider";
 import {
   listBrokerAccounts,
@@ -376,9 +377,7 @@ export function ConnectedView() {
   const isServiceUnavailable = !!error && !isLoadingUserInfo && !userInfo;
 
   // Check if user has an active subscription
-  const hasSubscription =
-    userInfo?.team?.subscription_status === "active" ||
-    userInfo?.team?.subscription_status === "trialing";
+  const hasSubscription = isSubscriptionStatusActive(userInfo?.team?.subscription_status);
 
   // Check if user's plan includes broker sync
   const showBrokerSync = hasBrokerSync(userInfo);
@@ -518,11 +517,18 @@ export function ConnectedView() {
 
       {/* Show Subscription Plans if user has no active subscription (keep mounted during refresh) */}
       {!isServiceUnavailable && !hasSubscription && !!userInfo && (
-        <SubscriptionPlans
-          enabled={isConnected && !hasSubscription}
-          onRefresh={refetchUserInfo}
-          isRefreshing={isLoadingUserInfo}
-        />
+        <>
+          <Alert role="status" className="bg-muted/30">
+            <Icons.PauseCircle className="h-4 w-4" aria-hidden="true" />
+            <AlertTitle>{t("connect:subscription.syncPausedTitle")}</AlertTitle>
+            <AlertDescription>{t("connect:subscription.syncPausedDescription")}</AlertDescription>
+          </Alert>
+          <SubscriptionPlans
+            enabled={isConnected && !hasSubscription}
+            onRefresh={refetchUserInfo}
+            isRefreshing={isLoadingUserInfo}
+          />
+        </>
       )}
 
       {/* Broker Connections Card - Only show if user has broker sync */}

--- a/apps/frontend/src/features/wealthfolio-connect/components/connected-view.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/connected-view.tsx
@@ -25,6 +25,7 @@ import {
   syncBrokerData,
 } from "../services/broker-service";
 import type { BrokerAccount, BrokerConnection } from "../types";
+import { PortalLink } from "./portal-link";
 import { SubscriptionPlans } from "./subscription-plans";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -240,14 +241,10 @@ function BrokerConnectionsCard({
   isRefreshing,
 }: BrokerConnectionsCardProps) {
   const { t } = useTranslation();
-  const openConnectionsPortal = () => {
-    openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`);
-  };
-
   return (
     <Card>
       <CardContent className="p-4">
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
               <Icons.Link className="text-muted-foreground h-4 w-4" />
@@ -258,31 +255,17 @@ function BrokerConnectionsCard({
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-foreground h-8 w-8"
+              className="text-muted-foreground hover:text-foreground size-11 sm:size-8"
+              aria-label={t("common:refresh")}
               onClick={onRefresh}
               disabled={isRefreshing}
             >
               <Icons.RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
             </Button>
-            {/* Mobile: icon only */}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-muted-foreground hover:text-foreground sm:hidden"
-              onClick={openConnectionsPortal}
-            >
-              <Icons.ExternalLink className="h-4 w-4" />
-            </Button>
-            {/* Desktop: full text */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-muted-foreground hover:text-foreground hidden sm:inline-flex"
-              onClick={openConnectionsPortal}
-            >
-              {t("connect:connections.manage")}
-              <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
-            </Button>
+            <PortalLink
+              href={`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`}
+              label={t("connect:connections.manage")}
+            />
           </div>
         </div>
 
@@ -295,9 +278,14 @@ function BrokerConnectionsCard({
           ) : connections.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-6 text-center">
               <p className="text-muted-foreground text-sm">{t("connect:connections.empty")}</p>
-              <Button className="mt-3" onClick={openConnectionsPortal}>
+              <Button
+                className="mt-3"
+                onClick={() => openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`)}
+                title={t("connect:opensInBrowser")}
+              >
                 <Icons.Plus className="h-4 w-4" />
                 {t("connect:connections.connectBroker")}
+                <Icons.ExternalLink className="size-4" aria-hidden="true" />
               </Button>
             </div>
           ) : (
@@ -545,7 +533,7 @@ export function ConnectedView() {
       {showBrokerSync && (
         <Card>
           <CardContent className="p-4">
-            <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
               <div className="flex items-center gap-2">
                 <div className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
                   <Icons.Wallet className="text-muted-foreground h-4 w-4" />
@@ -562,25 +550,10 @@ export function ConnectedView() {
                   <Icons.CloudSync2 className={`h-4 w-4 ${isSyncing ? "animate-pulse" : ""}`} />
                   {t("connect:sync.syncNow")}
                 </Button>
-                {/* Mobile: icon only */}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-muted-foreground hover:text-foreground sm:hidden"
-                  onClick={() => openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/accounts`)}
-                >
-                  <Icons.ExternalLink className="h-4 w-4" />
-                </Button>
-                {/* Desktop: full text */}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground hover:text-foreground hidden sm:inline-flex"
-                  onClick={() => openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/accounts`)}
-                >
-                  {t("connect:accounts.manage")}
-                  <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
-                </Button>
+                <PortalLink
+                  href={`${WEALTHFOLIO_CONNECT_PORTAL_URL}/accounts`}
+                  label={t("connect:accounts.manage")}
+                />
               </div>
             </div>
 
@@ -631,12 +604,13 @@ export function ConnectedView() {
               </div>
               <Button
                 size="sm"
+                title={t("connect:opensInBrowser")}
                 onClick={() =>
                   openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/settings/billing`)
                 }
               >
                 {t("connect:upgrade.button")}
-                <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
+                <Icons.ExternalLink className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
               </Button>
             </div>
           </CardContent>

--- a/apps/frontend/src/features/wealthfolio-connect/components/portal-link.test.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/portal-link.test.tsx
@@ -1,0 +1,33 @@
+import { ExternalLink } from "@/components/external-link";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { PortalLink } from "./portal-link";
+
+const openUrl = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("@/adapters", () => ({ openUrlInBrowser: openUrl }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: () => "Opens in browser" }),
+}));
+
+it("names the destination and opens it through the platform adapter", () => {
+  render(
+    <PortalLink href="https://connect.wealthfolio.app/settings/devices" label="Manage devices" />,
+  );
+  fireEvent.click(screen.getByRole("link", { name: "Manage devices — Opens in browser" }));
+  expect(openUrl).toHaveBeenCalledWith("https://connect.wealthfolio.app/settings/devices");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("respects a caller that cancels external navigation", () => {
+  render(
+    <ExternalLink href="https://example.com" onClick={(event) => event.preventDefault()}>
+      Cancel navigation
+    </ExternalLink>,
+  );
+  fireEvent.click(screen.getByRole("link", { name: "Cancel navigation" }));
+  expect(openUrl).not.toHaveBeenCalled();
+});

--- a/apps/frontend/src/features/wealthfolio-connect/components/portal-link.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/portal-link.tsx
@@ -1,0 +1,41 @@
+import { ExternalLink } from "@/components/external-link";
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@wealthfolio/ui/components/ui/tooltip";
+import { useTranslation } from "react-i18next";
+
+interface PortalLinkProps {
+  href: string;
+  label: string;
+}
+
+export function PortalLink({ href, label }: PortalLinkProps) {
+  const { t } = useTranslation();
+  const hint = t("connect:opensInBrowser");
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground size-11 shrink-0 p-0 sm:h-8 sm:w-auto sm:px-3"
+            asChild
+          >
+            <ExternalLink href={href} aria-label={`${label} — ${hint}`}>
+              <span className="hidden sm:inline">{label}</span>
+              <Icons.ExternalLink className="size-4" aria-hidden="true" />
+            </ExternalLink>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{hint}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/frontend/src/features/wealthfolio-connect/components/subscription-plans.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/subscription-plans.tsx
@@ -227,7 +227,8 @@ export function SubscriptionPlans({
                     <Button
                       size="icon"
                       variant="ghost"
-                      className="h-7 w-7"
+                      className="size-11 sm:size-7"
+                      aria-label={t("connect:subscription.copySupportEmail")}
                       onClick={() => {
                         navigator.clipboard.writeText("support@wealthfolio.app");
                         toast.success(t("connect:subscription.emailCopied"));
@@ -290,7 +291,8 @@ export function SubscriptionPlans({
                     <Button
                       size="icon"
                       variant="ghost"
-                      className="h-7 w-7"
+                      className="size-11 sm:size-7"
+                      aria-label={t("connect:subscription.copySupportEmail")}
                       onClick={() => {
                         navigator.clipboard.writeText("support@wealthfolio.app");
                         toast.success(t("connect:subscription.emailCopied"));

--- a/apps/frontend/src/features/wealthfolio-connect/components/sync-button.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/sync-button.tsx
@@ -20,6 +20,7 @@ interface SyncButtonProps {
 
 const statusColors: Record<AggregatedSyncStatus, string> = {
   not_connected: "text-muted-foreground",
+  subscription_required: "text-warning",
   idle: "text-green-500",
   running: "text-blue-500",
   needs_review: "text-yellow-500",

--- a/apps/frontend/src/features/wealthfolio-connect/components/sync-status-icon.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/sync-status-icon.tsx
@@ -1,3 +1,4 @@
+import { CloudWarningIcon } from "@phosphor-icons/react/dist/csr/CloudWarning";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { cn } from "@wealthfolio/ui/lib/utils";
 import type { AggregatedSyncStatus } from "../types";
@@ -9,6 +10,10 @@ interface SyncStatusIconProps {
 
 export function SyncStatusIcon({ status, className }: SyncStatusIconProps) {
   const iconClassName = cn("size-6", className);
+
+  if (status === "subscription_required") {
+    return <CloudWarningIcon weight="duotone" className={cn(iconClassName, "text-warning")} />;
+  }
 
   // For not_connected, show a muted cloud icon
   if (status === "not_connected") {

--- a/apps/frontend/src/features/wealthfolio-connect/components/sync-summary-card.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/sync-summary-card.tsx
@@ -26,6 +26,10 @@ function buildStatusConfig(
 > {
   return {
     not_connected: { label: t("connect:status.notConnected"), variant: "secondary" },
+    subscription_required: {
+      label: t("connect:subscription.syncPausedTitle"),
+      variant: "secondary",
+    },
     idle: { label: t("connect:status.upToDate"), variant: "default" },
     running: { label: t("connect:status.syncingEllipsis"), variant: "outline" },
     needs_review: { label: t("connect:status.needsReview"), variant: "destructive" },

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-aggregated-sync-status.test.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-aggregated-sync-status.test.ts
@@ -1,0 +1,59 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAggregatedSyncStatus } from "./use-aggregated-sync-status";
+
+const context = vi.hoisted(() => ({
+  isConnected: true,
+  isEnabled: true,
+  userInfo: null as unknown,
+}));
+vi.mock("../providers/wealthfolio-connect-provider", () => ({
+  useWealthfolioConnect: () => context,
+}));
+vi.mock("./use-sync-states", () => ({
+  useSyncStates: () => ({ data: [], isLoading: false }),
+}));
+afterEach(() => {
+  cleanup();
+  context.isConnected = true;
+  context.isEnabled = true;
+  context.userInfo = null;
+});
+
+describe("subscription navigation status", () => {
+  it.each([null, "canceled", "unpaid", "paused", "unknown"])(
+    "distinguishes signed-in status %s from signed out",
+    (status) => {
+      context.userInfo = { team: { subscription_status: status } };
+      const { result } = renderHook(useAggregatedSyncStatus);
+      expect(result.current.status).toBe("subscription_required");
+    },
+  );
+
+  it("shows subscription required when the account has no team", () => {
+    context.userInfo = { team: null };
+    const { result } = renderHook(useAggregatedSyncStatus);
+    expect(result.current.status).toBe("subscription_required");
+  });
+
+  it.each(["active", "trialing", "past_due"])("preserves active status %s", (status) => {
+    context.userInfo = { team: { subscription_status: status, plan: "basic" } };
+    const { result } = renderHook(useAggregatedSyncStatus);
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("does not infer an inactive subscription before user info is available", () => {
+    const { result } = renderHook(useAggregatedSyncStatus);
+    expect(result.current.status).toBe("not_connected");
+  });
+
+  it.each(["isConnected", "isEnabled"] as const)(
+    "keeps disconnected status when %s is false",
+    (key) => {
+      context[key] = false;
+      context.userInfo = { team: { subscription_status: null } };
+      const { result } = renderHook(useAggregatedSyncStatus);
+      expect(result.current.status).toBe("not_connected");
+    },
+  );
+});

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-aggregated-sync-status.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-aggregated-sync-status.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useWealthfolioConnect } from "../providers/wealthfolio-connect-provider";
-import { hasBrokerSync } from "../lib/plan-capabilities";
+import { hasBrokerSync, isSubscriptionStatusActive } from "../lib/plan-capabilities";
 import { useSyncStates } from "./use-sync-states";
 import type { AggregatedSyncStatus, BrokerSyncState } from "../types";
 
@@ -46,17 +46,17 @@ export function useAggregatedSyncStatus() {
 
   // Determine if user has an active subscription
   const hasSubscription = useMemo(() => {
-    if (!userInfo?.team) return false;
-    const status = userInfo.team.subscription_status;
-    return status === "active" || status === "trialing";
+    return isSubscriptionStatusActive(userInfo?.team?.subscription_status);
   }, [userInfo]);
 
   const status = useMemo<AggregatedSyncStatus>(() => {
     if (!isEnabled) return "not_connected";
-    if (!isConnected || !hasSubscription) return "not_connected";
+    if (!isConnected) return "not_connected";
+    if (userInfo && !hasSubscription) return "subscription_required";
+    if (!hasSubscription) return "not_connected";
     if (!showBrokerSync) return "idle";
     return determineAggregatedStatus(isConnected, hasSubscription, syncStates);
-  }, [isEnabled, showBrokerSync, isConnected, hasSubscription, syncStates]);
+  }, [isEnabled, showBrokerSync, isConnected, hasSubscription, userInfo, syncStates]);
 
   // Find the last successful sync time across all states
   const lastSyncTime = useMemo(() => {

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.test.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { usePostLoginConnectSync } from "./use-post-login-connect-sync";
 
 const adapterMocks = vi.hoisted(() => ({
@@ -24,6 +24,11 @@ const toastMocks = vi.hoisted(() => ({
   },
 }));
 
+vi.mock("react-i18next", () => {
+  const t = (key: string) =>
+    key === "connect:sync.syncingBrokerData" ? "Syncing broker data..." : key;
+  return { useTranslation: () => ({ t }) };
+});
 vi.mock("@/adapters", () => adapterMocks);
 vi.mock("../providers/wealthfolio-connect-provider", () => connectMocks);
 vi.mock("../services/auth-service", () => authServiceMocks);
@@ -63,6 +68,10 @@ function mockConnectContext(overrides: Record<string, unknown> = {}) {
 }
 
 describe("usePostLoginConnectSync", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
   beforeEach(() => {
     vi.clearAllMocks();
     authServiceMocks.postLoginBootstrap.mockResolvedValue(brokerStartedResult);
@@ -93,10 +102,10 @@ describe("usePostLoginConnectSync", () => {
 
     renderHook(() => usePostLoginConnectSync({ enabled: true }));
 
-    expect(consumePostLoginSyncRequest).toHaveBeenCalledWith("request-1");
     await waitFor(() => {
-      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+      expect(consumePostLoginSyncRequest).toHaveBeenCalledWith("request-1");
     });
+    expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
   });
 
   it("does not start the same request twice across rerenders", async () => {
@@ -168,18 +177,109 @@ describe("usePostLoginConnectSync", () => {
     expect(toastMocks.toast.loading).not.toHaveBeenCalled();
   });
 
-  it("logs bootstrap rejection and consumes the request", async () => {
+  it("logs bootstrap rejection and keeps the request pending", async () => {
     const consumePostLoginSyncRequest = vi.fn();
     authServiceMocks.postLoginBootstrap.mockRejectedValue(new Error("network down"));
     mockConnectContext({ consumePostLoginSyncRequest });
 
     renderHook(() => usePostLoginConnectSync({ enabled: true }));
 
-    expect(consumePostLoginSyncRequest).toHaveBeenCalledWith("request-1");
+    expect(consumePostLoginSyncRequest).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(adapterMocks.logger.warn).toHaveBeenCalledWith(
         "Post-login sync bootstrap failed: network down",
       );
     });
+  });
+  it.each(["rejection", "broker-error", "device-error"])(
+    "retries %s and consumes the unchanged request only after recovery",
+    async (failure) => {
+      vi.useFakeTimers();
+      const consume = vi.fn();
+      mockConnectContext({ consumePostLoginSyncRequest: consume });
+      if (failure === "rejection") {
+        authServiceMocks.postLoginBootstrap.mockRejectedValueOnce(new Error("offline"));
+      } else {
+        authServiceMocks.postLoginBootstrap.mockResolvedValueOnce({
+          ...skippedResult,
+          [failure === "broker-error" ? "brokerSync" : "deviceSync"]: {
+            status: "skipped",
+            reason: "error",
+          },
+        });
+      }
+      renderHook(() => usePostLoginConnectSync({ enabled: true }));
+      await act(() => vi.advanceTimersByTimeAsync(59_999));
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+      expect(consume).not.toHaveBeenCalled();
+      await act(() => vi.advanceTimersByTimeAsync(1));
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(2);
+      expect(consume).toHaveBeenCalledWith("request-1");
+      await act(() => vi.advanceTimersByTimeAsync(120_000));
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["logout", "account-change", "inactive-subscription", "unmount"])(
+    "cancels scheduled retries on %s",
+    async (change) => {
+      vi.useFakeTimers();
+      authServiceMocks.postLoginBootstrap.mockRejectedValue(new Error("offline"));
+      const { rerender, unmount } = renderHook(() => usePostLoginConnectSync({ enabled: true }));
+      await act(() => vi.advanceTimersByTimeAsync(0));
+      if (change === "unmount") {
+        unmount();
+      } else {
+        mockConnectContext(
+          change === "logout"
+            ? { isConnected: false }
+            : change === "account-change"
+              ? { user: { id: "user-2" }, session: { user: { id: "user-2" } } }
+              : { userInfo: { team: { subscription_status: null } } },
+        );
+        rerender();
+      }
+      await act(() => vi.advanceTimersByTimeAsync(120_000));
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("ignores an in-flight failure after logout", async () => {
+    vi.useFakeTimers();
+    let reject!: (error: Error) => void;
+    authServiceMocks.postLoginBootstrap.mockReturnValueOnce(
+      new Promise((_, rejectPromise) => {
+        reject = rejectPromise;
+      }),
+    );
+    const consume = vi.fn();
+    mockConnectContext({ consumePostLoginSyncRequest: consume });
+    const { rerender } = renderHook(() => usePostLoginConnectSync({ enabled: true }));
+    mockConnectContext({ isConnected: false });
+    rerender();
+    await act(async () => {
+      reject(new Error("late failure"));
+    });
+    await act(() => vi.advanceTimersByTimeAsync(120_000));
+    expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+    expect(consume).not.toHaveBeenCalled();
+  });
+
+  it("reuses an in-flight request across effect restarts", async () => {
+    let resolve!: (result: typeof skippedResult) => void;
+    authServiceMocks.postLoginBootstrap.mockReturnValueOnce(
+      new Promise((resolvePromise) => {
+        resolve = resolvePromise;
+      }),
+    );
+    const { rerender } = renderHook(() => usePostLoginConnectSync({ enabled: true }));
+    const consume = vi.fn();
+    mockConnectContext({ consumePostLoginSyncRequest: consume });
+    rerender();
+    expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolve(skippedResult);
+    });
+    expect(consume).toHaveBeenCalledWith("request-1");
   });
 });

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.ts
@@ -1,26 +1,36 @@
+import { useTranslation } from "react-i18next";
 import { logger } from "@/adapters";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { useEffect, useRef } from "react";
 import { useWealthfolioConnect } from "../providers/wealthfolio-connect-provider";
+import { isSubscriptionStatusActive } from "../lib/plan-capabilities";
 import { postLoginBootstrap } from "../services/auth-service";
 
 const BROKER_SYNC_START_TOAST_ID = "broker-sync-start";
-const MAX_ATTEMPTED_REQUEST_IDS = 20;
+const MAX_COMPLETED_REQUEST_IDS = 20;
 
 interface UsePostLoginConnectSyncOptions {
   enabled: boolean;
 }
 
 export function usePostLoginConnectSync({ enabled }: UsePostLoginConnectSyncOptions) {
+  const { t } = useTranslation();
   const {
     isConnected,
     isInitializing,
     postLoginSyncRequest,
     session,
     user,
+    userInfo,
     consumePostLoginSyncRequest,
   } = useWealthfolioConnect();
-  const attemptedRequestIdsRef = useRef<Set<string>>(new Set());
+  const completedRequestIdsRef = useRef<Set<string>>(new Set());
+  const inFlightRef = useRef<{
+    id: string;
+    promise: ReturnType<typeof postLoginBootstrap>;
+  } | null>(null);
+  const subscriptionInactive =
+    !!userInfo && !isSubscriptionStatusActive(userInfo.team?.subscription_status);
 
   useEffect(() => {
     if (!enabled || isInitializing || !isConnected || !postLoginSyncRequest) {
@@ -36,47 +46,83 @@ export function usePostLoginConnectSync({ enabled }: UsePostLoginConnectSyncOpti
       return;
     }
 
-    if (attemptedRequestIdsRef.current.has(request.id)) {
+    if (completedRequestIdsRef.current.has(request.id)) {
       consumePostLoginSyncRequest(request.id);
       return;
     }
 
-    attemptedRequestIdsRef.current.add(request.id);
-    while (attemptedRequestIdsRef.current.size > MAX_ATTEMPTED_REQUEST_IDS) {
-      const oldestRequestId = attemptedRequestIdsRef.current.keys().next().value;
-      if (!oldestRequestId) break;
-      attemptedRequestIdsRef.current.delete(oldestRequestId);
+    if (subscriptionInactive) {
+      consumePostLoginSyncRequest(request.id);
+      return;
     }
 
-    consumePostLoginSyncRequest(request.id);
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
-    void postLoginBootstrap()
-      .then((result) => {
+    const attemptBootstrap = async () => {
+      // Reuse an in-flight attempt when React re-runs the effect.
+      let attempt = inFlightRef.current;
+      if (attempt?.id !== request.id) {
+        attempt = { id: request.id, promise: postLoginBootstrap() };
+        inFlightRef.current = attempt;
+      }
+      let shouldRetry = false;
+      try {
+        const result = await attempt.promise;
+        if (cancelled) return;
+
         if (result.brokerSync.status === "started") {
-          toast.loading("Syncing broker data...", { id: BROKER_SYNC_START_TOAST_ID });
+          toast.loading(t("connect:sync.syncingBrokerData"), { id: BROKER_SYNC_START_TOAST_ID });
           logger.info(`Post-login broker sync started after ${request.source}`);
         }
 
         if (result.brokerSync.status === "skipped" && result.brokerSync.reason === "error") {
           logger.warn("Post-login broker sync bootstrap skipped due to an unexpected error");
+          shouldRetry = true;
         }
 
         if (result.deviceSync.status === "skipped" && result.deviceSync.reason === "error") {
           logger.warn("Post-login device sync bootstrap skipped due to an unexpected error");
+          shouldRetry = true;
         }
 
         if (result.deviceSync.status === "started") {
           logger.info(`Post-login device sync started after ${request.source}`);
         }
-      })
-      .catch((err) => {
+      } catch (err) {
+        if (cancelled) return;
         const message = err instanceof Error ? err.message : String(err);
         logger.warn(`Post-login sync bootstrap failed: ${message}`);
-      });
+        shouldRetry = true;
+      } finally {
+        if (inFlightRef.current === attempt) inFlightRef.current = null;
+      }
+      if (cancelled) return;
+
+      if (shouldRetry) {
+        retryTimer = setTimeout(() => void attemptBootstrap(), 60_000);
+        return;
+      }
+      completedRequestIdsRef.current.add(request.id);
+      while (completedRequestIdsRef.current.size > MAX_COMPLETED_REQUEST_IDS) {
+        const oldestRequestId = completedRequestIdsRef.current.keys().next().value;
+        if (!oldestRequestId) break;
+        completedRequestIdsRef.current.delete(oldestRequestId);
+      }
+      consumePostLoginSyncRequest(request.id);
+    };
+
+    void attemptBootstrap();
+    return () => {
+      cancelled = true;
+      clearTimeout(retryTimer);
+    };
   }, [
+    t,
     enabled,
     isConnected,
     isInitializing,
+    subscriptionInactive,
     postLoginSyncRequest,
     session?.user.id,
     user?.id,

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-sync-broker-data.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-sync-broker-data.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useMutation } from "@tanstack/react-query";
 import { syncBrokerData } from "../services/broker-service";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
@@ -8,14 +9,17 @@ import { toast } from "@wealthfolio/ui/components/ui/use-toast";
  * global event listeners (SSE events trigger toasts and query invalidation).
  */
 export function useSyncBrokerData() {
+  const { t } = useTranslation();
   return useMutation({
     mutationFn: syncBrokerData,
     onSuccess: () => {
-      toast.loading("Syncing broker data...", { id: "broker-sync-start" });
+      toast.loading(t("connect:sync.syncingBrokerData"), { id: "broker-sync-start" });
     },
     onError: (error) => {
       toast.error(
-        `Failed to start sync: ${error instanceof Error ? error.message : "Unknown error"}`,
+        t("connect:sync.startFailed", {
+          error: error instanceof Error ? error.message : t("connect:errors.unknown"),
+        }),
       );
     },
   });

--- a/apps/frontend/src/features/wealthfolio-connect/lib/plan-capabilities.test.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/plan-capabilities.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { hasBrokerSync, isSubscriptionStatusActive } from "./plan-capabilities";
+import type { UserInfo } from "../types";
+
+function userInfo(status: string): UserInfo {
+  return {
+    id: "user-1",
+    full_name: null,
+    email: null,
+    avatar_url: null,
+    locale: null,
+    week_starts_on_monday: null,
+    timezone: null,
+    timezone_auto_sync: null,
+    time_format: null,
+    date_format: null,
+    team_id: "team-1",
+    team_role: "owner",
+    team: {
+      id: "team-1",
+      name: "Team",
+      logo_url: null,
+      plan: "essentials",
+      subscription_status: status,
+      subscription_current_period_end: null,
+      subscription_cancel_at_period_end: false,
+      canceled_at: null,
+      country_code: null,
+      created_at: null,
+    },
+  };
+}
+
+describe("subscription capabilities", () => {
+  it.each(["active", "trialing", "past_due"] as const)("allows sync for %s", (status) => {
+    expect(isSubscriptionStatusActive(status)).toBe(true);
+    expect(hasBrokerSync(userInfo(status))).toBe(true);
+  });
+
+  it.each(["canceled", "unpaid"] as const)("disables sync for %s", (status) => {
+    expect(hasBrokerSync(userInfo(status))).toBe(false);
+  });
+
+  it.each([null, undefined, "incomplete", "incomplete_expired", "paused", "unknown"])(
+    "disables sync for %s",
+    (status) => {
+      expect(isSubscriptionStatusActive(status)).toBe(false);
+    },
+  );
+});

--- a/apps/frontend/src/features/wealthfolio-connect/lib/plan-capabilities.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/plan-capabilities.ts
@@ -1,10 +1,13 @@
 import type { UserInfo } from "../types";
 
+export function isSubscriptionStatusActive(status: string | null | undefined): boolean {
+  return status === "active" || status === "trialing" || status === "past_due";
+}
+
 export function hasBrokerSync(userInfo: UserInfo | null): boolean {
   const team = userInfo?.team;
   if (!team) return false;
-  const isActive = team.subscription_status === "active" || team.subscription_status === "trialing";
-  if (!isActive) return false;
+  if (!isSubscriptionStatusActive(team.subscription_status)) return false;
   if (!team.plan) return false;
   return team.plan !== "basic";
 }

--- a/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
@@ -1,8 +1,8 @@
-import { ConnectedView } from "../components/connected-view";
-import { isSubscriptionStatusActive } from "../lib/plan-capabilities";
 import { openUrlInBrowser, syncTriggerCycle } from "@/adapters";
 import { Page, PageContent, PageHeader } from "@/components/page";
 import { useDevices, useSyncStatus } from "@/features/devices-sync/hooks";
+import { PortalLink } from "../components/portal-link";
+import { ConnectedView } from "../components/connected-view";
 import { ConnectEmptyState } from "@/features/wealthfolio-connect/components/connect-empty-state";
 import {
   useAggregatedSyncStatus,
@@ -11,6 +11,7 @@ import {
 } from "@/features/wealthfolio-connect/hooks";
 import { useSyncBrokerData } from "@/features/wealthfolio-connect/hooks/use-sync-broker-data";
 import { useWealthfolioConnect } from "@/features/wealthfolio-connect/providers/wealthfolio-connect-provider";
+import { isSubscriptionStatusActive } from "@/features/wealthfolio-connect/lib/plan-capabilities";
 import { useAccounts } from "@/hooks/use-accounts";
 import { WEALTHFOLIO_CONNECT_PORTAL_URL } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
@@ -234,7 +235,13 @@ export default function ConnectPage() {
         text={showBrokerSync ? t("connect:page.subtitleWithBrokers") : t("connect:page.subtitle")}
         actions={
           <div className="flex items-center gap-2 sm:gap-3">
-            <Button onClick={handleSyncAll} disabled={isSyncRunning} size="sm">
+            <Button
+              onClick={handleSyncAll}
+              disabled={isSyncRunning}
+              size="sm"
+              className="min-h-11 min-w-11 sm:min-h-0 sm:min-w-0"
+              aria-label={t(isSyncRunning ? "connect:sync.syncingShort" : "connect:sync.syncNow")}
+            >
               {isSyncRunning ? (
                 <>
                   <Icons.Spinner className="h-4 w-4 animate-spin sm:mr-2" />
@@ -247,6 +254,18 @@ export default function ConnectPage() {
                 </>
               )}
             </Button>
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="outline" size="icon" className="size-11 sm:size-9" asChild>
+                    <Link to="/settings/connect" aria-label={t("common:settings")}>
+                      <Icons.Settings className="size-4" />
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("common:settings")}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         }
       />
@@ -308,27 +327,10 @@ export default function ConnectPage() {
                       )}
                     </div>
                     <div className="flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-muted-foreground hover:text-foreground h-8 w-8 sm:hidden"
-                        onClick={() =>
-                          openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`)
-                        }
-                      >
-                        <Icons.ExternalLink className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-muted-foreground hover:text-foreground hidden sm:inline-flex"
-                        onClick={() =>
-                          openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`)
-                        }
-                      >
-                        {t("connect:page.manage")}
-                        <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
-                      </Button>
+                      <PortalLink
+                        href={`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`}
+                        label={t("connect:connections.manage")}
+                      />
                     </div>
                   </CardTitle>
                 </CardHeader>
@@ -380,25 +382,10 @@ export default function ConnectPage() {
                     <DeviceSyncStatusBadge engineStatus={deviceSyncEngineStatus} />
                   </div>
                   <div className="flex items-center gap-1">
-                    <Link to="/settings/connect">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-muted-foreground hover:text-foreground h-8 w-8 sm:hidden"
-                      >
-                        <Icons.Settings className="h-4 w-4" />
-                      </Button>
-                    </Link>
-                    <Link to="/settings/connect">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-muted-foreground hover:text-foreground hidden sm:inline-flex"
-                      >
-                        {t("connect:page.manage")}
-                        <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
-                      </Button>
-                    </Link>
+                    <PortalLink
+                      href={`${WEALTHFOLIO_CONNECT_PORTAL_URL}/settings/devices`}
+                      label={t("sync:section.manageDevices")}
+                    />
                   </div>
                 </CardTitle>
               </CardHeader>
@@ -480,12 +467,13 @@ export default function ConnectPage() {
                   </div>
                   <Button
                     size="sm"
+                    title={t("connect:opensInBrowser")}
                     onClick={() =>
                       openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/settings/billing`)
                     }
                   >
                     {t("connect:upgrade.button")}
-                    <Icons.ArrowRight className="ml-1 h-3.5 w-3.5" />
+                    <Icons.ExternalLink className="ml-1 h-3.5 w-3.5" aria-hidden="true" />
                   </Button>
                 </div>
               </CardContent>
@@ -757,7 +745,12 @@ function BrokerSyncAttentionSection({
               )}
               {t("common:retry")}
             </Button>
-            <Button size="sm" variant="ghost" onClick={onManage}>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onManage}
+              title={t("connect:opensInBrowser")}
+            >
               <Icons.ExternalLink className="mr-2 h-4 w-4" />
               {t("connect:page.manage")}
             </Button>

--- a/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
@@ -1,3 +1,5 @@
+import { ConnectedView } from "../components/connected-view";
+import { isSubscriptionStatusActive } from "../lib/plan-capabilities";
 import { openUrlInBrowser, syncTriggerCycle } from "@/adapters";
 import { Page, PageContent, PageHeader } from "@/components/page";
 import { useDevices, useSyncStatus } from "@/features/devices-sync/hooks";
@@ -149,9 +151,7 @@ export default function ConnectPage() {
   }, [localAccounts]);
 
   const hasSubscription = useMemo(() => {
-    if (!userInfo?.team) return false;
-    const subStatus = userInfo.team.subscription_status;
-    return subStatus === "active" || subStatus === "trialing";
+    return isSubscriptionStatusActive(userInfo?.team?.subscription_status);
   }, [userInfo]);
 
   if (isInitializing) {
@@ -221,7 +221,7 @@ export default function ConnectPage() {
       <Page>
         <PageHeader heading={t("connect:page.title")} />
         <PageContent>
-          <ConnectEmptyState />
+          {isEnabled && isConnected ? <ConnectedView /> : <ConnectEmptyState />}
         </PageContent>
       </Page>
     );

--- a/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.test.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.test.tsx
@@ -1,0 +1,238 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WealthfolioConnectProvider, useWealthfolioConnect } from "./wealthfolio-connect-provider";
+
+const mocks = vi.hoisted(() => ({
+  platform: "web",
+  configured: false,
+  account: "",
+  onAuth: (_event: string) => {},
+  onDeepLink: (_event: { payload: string }) => {},
+  signOut: vi.fn(),
+  signIn: vi.fn(),
+  exchange: vi.fn(),
+  getUserInfo: vi.fn(),
+  getStatus: vi.fn(),
+  store: vi.fn(),
+  clear: vi.fn(),
+  t: (key: string) => key,
+}));
+
+vi.mock("@/lib/connect-config", () => ({ CONNECT_ENABLED: true }));
+vi.mock("@/context/auth-context", () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: mocks.t }) }));
+vi.mock("@/hooks/use-platform", () => ({
+  getPlatform: async () => ({
+    os: mocks.platform,
+    is_mobile: mocks.platform !== "web",
+    capabilities: { cloud_sync: true },
+  }),
+}));
+vi.mock("tauri-plugin-web-auth-api", () => ({ authenticate: vi.fn() }));
+vi.mock("@/adapters", () => ({
+  isDesktop: true,
+  getCurrentDeepLinks: async () => [],
+  listenDeepLink: async (callback: typeof mocks.onDeepLink) => {
+    mocks.onDeepLink = callback;
+    return async () => {};
+  },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  openUrlInBrowser: vi.fn(),
+}));
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    auth: {
+      signOut: mocks.signOut,
+      signInWithPassword: mocks.signIn,
+      exchangeCodeForSession: mocks.exchange,
+      onAuthStateChange: (callback: typeof mocks.onAuth) => {
+        mocks.onAuth = callback;
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      },
+    },
+  }),
+}));
+vi.mock("../services/auth-service", () => ({
+  restoreSyncSession: async () => {
+    throw new Error("No stored session");
+  },
+  getSyncSessionStatus: mocks.getStatus,
+  clearSyncSession: mocks.clear,
+  storeSyncSession: mocks.store,
+}));
+vi.mock("../services/broker-service", () => ({ getUserInfo: mocks.getUserInfo }));
+
+const session = (account: string) => ({
+  user: { id: account },
+  refresh_token: account,
+  access_token: `${account}-access`,
+});
+const info = (account: string, status: string | null = "active") => ({
+  id: account,
+  team: { subscription_status: status },
+});
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <WealthfolioConnectProvider>{children}</WealthfolioConnectProvider>
+);
+async function setup() {
+  const hook = renderHook(useWealthfolioConnect, { wrapper });
+  await waitFor(() => expect(hook.result.current.isInitializing).toBe(false));
+  return hook;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.configured = false;
+  mocks.account = "";
+  mocks.platform = "web";
+  mocks.getStatus.mockImplementation(async () => ({ isConfigured: mocks.configured }));
+  mocks.store.mockImplementation(async (account: string) => {
+    mocks.account = account;
+    mocks.configured = true;
+  });
+  mocks.clear.mockImplementation(async () => {
+    mocks.configured = false;
+  });
+  mocks.signIn.mockImplementation(async ({ email }: { email: string }) => ({
+    data: { session: session(email) },
+    error: null,
+  }));
+  mocks.exchange.mockResolvedValue({ data: { session: session("B") }, error: null });
+  mocks.signOut.mockImplementation(async () => {
+    mocks.onAuth("SIGNED_OUT");
+    return { error: null };
+  });
+  mocks.getUserInfo.mockImplementation(async () => info(mocks.account));
+});
+
+describe("Cloud session lifecycle", () => {
+  it.each(["web", "ios", "android"])(
+    "ignores a canceled response from a replaced session on %s",
+    async (platform) => {
+      mocks.platform = platform;
+      const old = deferred<ReturnType<typeof info>>();
+      mocks.getUserInfo.mockImplementationOnce(() => old.promise);
+      const { result } = await setup();
+      await act(() => result.current.signInWithEmail("A", "password"));
+      await waitFor(() => expect(mocks.getUserInfo).toHaveBeenCalledTimes(1));
+      await act(() => result.current.signOut());
+      await act(() => result.current.signInWithEmail("B", "password"));
+      await waitFor(() => expect(result.current.userInfo?.id).toBe("B"));
+      await act(async () => {
+        old.resolve(info("A", "canceled"));
+      });
+      expect(result.current.user?.id).toBe("B");
+      expect(result.current.userInfo?.id).toBe("B");
+      expect(mocks.signOut).toHaveBeenCalledTimes(1);
+      expect(mocks.clear).toHaveBeenCalledTimes(1);
+      expect(mocks.configured).toBe(true);
+    },
+  );
+
+  it("ignores errors from an obsolete request", async () => {
+    const old = deferred<ReturnType<typeof info>>();
+    mocks.getUserInfo.mockImplementationOnce(() => old.promise);
+    const { result } = await setup();
+    await act(() => result.current.signInWithEmail("A", "password"));
+    await waitFor(() => expect(mocks.getUserInfo).toHaveBeenCalledTimes(1));
+    await act(() => result.current.signInWithEmail("B", "password"));
+    await waitFor(() => expect(result.current.userInfo?.id).toBe("B"));
+    await act(async () => {
+      old.reject(new Error("Old account request failed"));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.userInfo?.id).toBe("B");
+    expect(result.current.isLoadingUserInfo).toBe(false);
+  });
+
+  it.each([null, "canceled", "unpaid", "incomplete", "incomplete_expired", "paused", "unknown"])(
+    "keeps authentication and exposes inactive status %s for pricing",
+    async (status) => {
+      mocks.getUserInfo.mockResolvedValue(info("A", status));
+      const { result } = await setup();
+      await act(() => result.current.signInWithEmail("A", "password"));
+      await waitFor(() => expect(result.current.userInfo?.id).toBe("A"));
+      expect(result.current.isConnected).toBe(true);
+      expect(result.current.userInfo?.team?.subscription_status).toBe(status);
+      expect(mocks.signOut).not.toHaveBeenCalled();
+      expect(mocks.clear).not.toHaveBeenCalled();
+      expect(mocks.configured).toBe(true);
+    },
+  );
+
+  it("resumes sync after purchasing a subscription without another login", async () => {
+    mocks.getUserInfo.mockResolvedValue(info("A", null));
+    const { result } = await setup();
+    await act(() => result.current.signInWithEmail("A", "password"));
+    await waitFor(() => expect(result.current.userInfo?.id).toBe("A"));
+    const oldRequest = result.current.postLoginSyncRequest!.id;
+    act(() => result.current.consumePostLoginSyncRequest(oldRequest));
+    mocks.getUserInfo.mockResolvedValue(info("A", "active"));
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await waitFor(() =>
+      expect(result.current.postLoginSyncRequest?.source).toBe("subscription-activated"),
+    );
+    expect(result.current.isConnected).toBe(true);
+    expect(mocks.signIn).toHaveBeenCalledTimes(1);
+    expect(mocks.signOut).not.toHaveBeenCalled();
+  });
+
+  it("keeps login on lookup failures and recovers on refresh", async () => {
+    mocks.getUserInfo.mockRejectedValue(new Error("Service unavailable"));
+    const { result } = await setup();
+    await act(() => result.current.signInWithEmail("A", "password"));
+    await waitFor(() => expect(result.current.error).toBe("Service unavailable"));
+    expect(result.current.userInfo).toBeNull();
+    expect(result.current.isConnected).toBe(true);
+    mocks.getUserInfo.mockResolvedValue(info("A", "active"));
+    await act(() => result.current.refetchUserInfo());
+    expect(result.current.postLoginSyncRequest?.source).toBe("subscription-activated");
+    expect(mocks.signOut).not.toHaveBeenCalled();
+  });
+
+  it("signs out only when the backend auth session is missing on mobile resume", async () => {
+    mocks.platform = "ios";
+    const { result } = await setup();
+    await act(() => result.current.signInWithEmail("A", "password"));
+    await waitFor(() => expect(result.current.userInfo?.id).toBe("A"));
+    mocks.configured = false;
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+    await waitFor(() => expect(result.current.isConnected).toBe(false));
+    expect(mocks.clear).not.toHaveBeenCalled();
+  });
+
+  it("queues a mobile OAuth callback behind ongoing sign-out cleanup", async () => {
+    mocks.platform = "ios";
+    const cleanup = deferred<void>();
+    const { result } = await setup();
+    await act(() => result.current.signInWithEmail("A", "password"));
+    await waitFor(() => expect(result.current.userInfo?.id).toBe("A"));
+    mocks.clear.mockImplementationOnce(() => cleanup.promise);
+    let logout!: Promise<void>;
+    act(() => {
+      logout = result.current.signOut();
+    });
+    await waitFor(() => expect(mocks.clear).toHaveBeenCalledTimes(1));
+    await act(async () =>
+      mocks.onDeepLink({ payload: "wealthfolio://auth/callback?code=mobile-code" }),
+    );
+    expect(mocks.exchange).not.toHaveBeenCalled();
+    await act(async () => {
+      cleanup.resolve();
+      await logout;
+    });
+    await waitFor(() => expect(result.current.user?.id).toBe("B"));
+    expect(mocks.account).toBe("B");
+    expect(mocks.configured).toBe(true);
+  });
+});

--- a/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.test.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePostLoginConnectSync } from "../hooks/use-post-login-connect-sync";
 import { WealthfolioConnectProvider, useWealthfolioConnect } from "./wealthfolio-connect-provider";
 
 const mocks = vi.hoisted(() => ({
@@ -9,6 +10,11 @@ const mocks = vi.hoisted(() => ({
   account: "",
   onAuth: (_event: string) => {},
   onDeepLink: (_event: { payload: string }) => {},
+  bootstrap: vi.fn(),
+  toast: vi.fn(),
+  restore: vi.fn(),
+  setSession: vi.fn(),
+  verifyOtp: vi.fn(),
   signOut: vi.fn(),
   signIn: vi.fn(),
   exchange: vi.fn(),
@@ -43,6 +49,8 @@ vi.mock("@/adapters", () => ({
 vi.mock("@supabase/supabase-js", () => ({
   createClient: () => ({
     auth: {
+      setSession: mocks.setSession,
+      verifyOtp: mocks.verifyOtp,
       signOut: mocks.signOut,
       signInWithPassword: mocks.signIn,
       exchangeCodeForSession: mocks.exchange,
@@ -54,14 +62,15 @@ vi.mock("@supabase/supabase-js", () => ({
   }),
 }));
 vi.mock("../services/auth-service", () => ({
-  restoreSyncSession: async () => {
-    throw new Error("No stored session");
-  },
+  restoreSyncSession: mocks.restore,
+  postLoginBootstrap: mocks.bootstrap,
   getSyncSessionStatus: mocks.getStatus,
   clearSyncSession: mocks.clear,
   storeSyncSession: mocks.store,
 }));
 vi.mock("../services/broker-service", () => ({ getUserInfo: mocks.getUserInfo }));
+
+vi.mock("@wealthfolio/ui/components/ui/use-toast", () => ({ toast: { loading: mocks.toast } }));
 
 const session = (account: string) => ({
   user: { id: account },
@@ -92,6 +101,9 @@ async function setup() {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  mocks.restore.mockRejectedValue(new Error("No stored session"));
+  mocks.setSession.mockResolvedValue({ data: { session: session("A") }, error: null });
+  mocks.verifyOtp.mockResolvedValue({ data: { session: session("A") }, error: null });
   mocks.configured = false;
   mocks.account = "";
   mocks.platform = "web";
@@ -196,7 +208,7 @@ describe("Cloud session lifecycle", () => {
     expect(result.current.isConnected).toBe(true);
     mocks.getUserInfo.mockResolvedValue(info("A", "active"));
     await act(() => result.current.refetchUserInfo());
-    expect(result.current.postLoginSyncRequest?.source).toBe("subscription-activated");
+    expect(result.current.postLoginSyncRequest?.source).toBe("email-sign-in");
     expect(mocks.signOut).not.toHaveBeenCalled();
   });
 
@@ -234,5 +246,61 @@ describe("Cloud session lifecycle", () => {
     await waitFor(() => expect(result.current.user?.id).toBe("B"));
     expect(mocks.account).toBe("B");
     expect(mocks.configured).toBe(true);
+  });
+});
+
+describe("Login and subscription bootstrap coordination", () => {
+  const started = {
+    brokerSync: { status: "started" },
+    deviceSync: { status: "started" },
+  };
+
+  it.each(["email", "otp", "oauth"])(
+    "preserves the in-flight %s bootstrap and its started toast",
+    async (method) => {
+      const userInfo = deferred<ReturnType<typeof info>>();
+      const bootstrap = deferred<typeof started>();
+      mocks.getUserInfo.mockReturnValue(userInfo.promise);
+      mocks.bootstrap.mockReturnValue(bootstrap.promise);
+      const { result } = renderHook(
+        () => {
+          usePostLoginConnectSync({ enabled: true });
+          return useWealthfolioConnect();
+        },
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.isInitializing).toBe(false));
+      await act(async () => {
+        if (method === "email") await result.current.signInWithEmail("A", "password");
+        else if (method === "otp") await result.current.verifyOtp("A", "123456");
+        else mocks.onDeepLink({ payload: "wealthfolio://auth/callback?code=activation-test" });
+      });
+      await waitFor(() => expect(mocks.bootstrap).toHaveBeenCalledTimes(1));
+      const loginRequest = result.current.postLoginSyncRequest;
+      await act(async () => userInfo.resolve(info(mocks.account, "active")));
+      expect(result.current.postLoginSyncRequest).toBe(loginRequest);
+      expect(mocks.bootstrap).toHaveBeenCalledTimes(1);
+      await act(async () => bootstrap.resolve(started));
+      expect(mocks.toast).toHaveBeenCalledTimes(1);
+      expect(result.current.postLoginSyncRequest).toBeNull();
+    },
+  );
+
+  it("bootstraps a restored active session without an explicit login request", async () => {
+    mocks.configured = true;
+    mocks.account = "A";
+    mocks.restore.mockResolvedValue({ accessToken: "A-access", refreshToken: "A" });
+    mocks.bootstrap.mockResolvedValue(started);
+    const { result } = renderHook(
+      () => {
+        usePostLoginConnectSync({ enabled: true });
+        return useWealthfolioConnect();
+      },
+      { wrapper },
+    );
+    await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
+    expect(mocks.bootstrap).toHaveBeenCalledTimes(1);
+    expect(result.current.postLoginSyncRequest).toBeNull();
+    expect(mocks.signIn).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.tsx
@@ -284,11 +284,17 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
     const sequence = postLoginSyncRequestSequenceRef.current + 1;
     postLoginSyncRequestSequenceRef.current = sequence;
 
-    setPostLoginSyncRequest({
-      id: `${session.user.id}:${now}:${sequence}`,
-      userId: session.user.id,
-      createdAt: now,
-      source,
+    setPostLoginSyncRequest((current) => {
+      // Keep pending login work and its result handler when subscription info arrives.
+      if (source === "subscription-activated" && current?.userId === session.user.id) {
+        return current;
+      }
+      return {
+        id: `${session.user.id}:${now}:${sequence}`,
+        userId: session.user.id,
+        createdAt: now,
+        source,
+      };
     });
   }, []);
 

--- a/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.tsx
@@ -1,11 +1,9 @@
 import {
-  deleteSecret,
   getCurrentDeepLinks,
   isDesktop,
   listenDeepLink,
   logger,
   openUrlInBrowser,
-  setSecret,
 } from "@/adapters";
 import { useAuth } from "@/context/auth-context";
 import { getPlatform } from "@/hooks/use-platform";
@@ -23,10 +21,16 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { authenticate as authenticateWithASWebAuth } from "tauri-plugin-web-auth-api";
-import { clearSyncSession, restoreSyncSession, storeSyncSession } from "../services/auth-service";
+import {
+  clearSyncSession,
+  getSyncSessionStatus,
+  restoreSyncSession,
+  storeSyncSession,
+} from "../services/auth-service";
 import { getUserInfo } from "../services/broker-service";
 import type { UserInfo } from "../types";
 import { parseAuthCallbackUrl } from "../lib/auth-callback";
+import { hasBrokerSync, isSubscriptionStatusActive } from "../lib/plan-capabilities";
 
 // Auth configuration - these are public/publishable keys (safe for client-side)
 // Can be overridden via environment variables: CONNECT_AUTH_URL and CONNECT_AUTH_PUBLISHABLE_KEY
@@ -34,10 +38,6 @@ const AUTH_URL = (import.meta.env.CONNECT_AUTH_URL as string) || "https://auth.w
 const AUTH_PUBLISHABLE_KEY =
   (import.meta.env.CONNECT_AUTH_PUBLISHABLE_KEY as string) ||
   "sb_publishable_ZSZbXNtWtnh9i2nqJ2UL4A_NV8ZVutd";
-
-// Key for storing refresh token in keyring/localStorage (for session restoration)
-// Note: For keyring (Tauri), the "wealthfolio_" prefix is added automatically by SecretStore
-const REFRESH_TOKEN_KEY = "sync_refresh_token";
 
 // Deep-link URL for desktop callbacks (custom URL scheme)
 const DESKTOP_DEEP_LINK_URL = "wealthfolio://auth/callback";
@@ -60,7 +60,12 @@ const parseConfiguredAuthCallbackUrl = (url: string) =>
 const PROCESSED_AUTH_CODE_TTL_MS = 10 * 60 * 1000;
 const MAX_PROCESSED_AUTH_CODES = 20;
 
-type PostLoginSyncSource = "auth-callback" | "email-sign-in" | "email-sign-up" | "otp";
+type PostLoginSyncSource =
+  | "auth-callback"
+  | "email-sign-in"
+  | "email-sign-up"
+  | "otp"
+  | "subscription-activated";
 
 interface PostLoginSyncRequest {
   id: string;
@@ -207,7 +212,30 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingUserInfo, setIsLoadingUserInfo] = useState(false);
   const [user, setUser] = useState<User | null>(null);
-  const [session, setSession] = useState<Session | null>(null);
+  const [session, setSessionState] = useState<Session | null>(null);
+  const sessionRef = useRef<Session | null>(null);
+  const sessionGenerationRef = useRef(0);
+  const syncAccessRef = useRef<string | null>(null);
+  const userInfoRequestRef = useRef(0);
+  const authTransitionRef = useRef<Promise<unknown>>(Promise.resolve());
+
+  const setSession = useCallback((next: Session | null) => {
+    sessionRef.current = next;
+    syncAccessRef.current = null;
+    sessionGenerationRef.current += 1;
+    userInfoRequestRef.current += 1;
+    setSessionState(next);
+  }, []);
+
+  // Serialize credential-changing operations, including mobile OAuth callbacks.
+  const runAuthTransition = useCallback(<T,>(operation: () => Promise<T>): Promise<T> => {
+    const next = authTransitionRef.current.then(operation, operation);
+    authTransitionRef.current = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }, []);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [postLoginSyncRequest, setPostLoginSyncRequest] = useState<PostLoginSyncRequest | null>(
     null,
@@ -268,42 +296,12 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
     setPostLoginSyncRequest((current) => (current?.id === requestId ? null : current));
   }, []);
 
-  // Store tokens: refresh token goes to backend (for cloud API calls) and locally (for session restoration)
-  const storeTokens = useCallback(async (session: Session | null) => {
-    logger.debug(`storeTokens called, isDesktop=${isDesktop}, hasSession=${!!session}`);
-
-    if (!session) {
-      // Clear from backend - throw on failure so signOut properly reports errors
+  // The backend is the sole owner of persistent credentials and token rotation.
+  const storeTokens = useCallback(async (next: Session | null) => {
+    if (next?.refresh_token) {
+      await storeSyncSession(next.refresh_token);
+    } else {
       await clearSyncSession();
-
-      // Clear session restoration token from secret store (keyring on desktop, FileSecretStore on web)
-      await deleteSecret(REFRESH_TOKEN_KEY).catch((err) => {
-        logger.warn(`Failed to delete refresh token: ${err}`);
-      });
-      return;
-    }
-
-    // Store tokens in backend's encrypted secret store (backend can mint fresh access tokens if needed)
-    if (session.refresh_token) {
-      try {
-        await storeSyncSession(session.refresh_token);
-      } catch (err) {
-        logger.error(`Failed to store tokens in backend: ${err}`);
-      }
-    }
-
-    // Also store refresh token in secret store for session restoration on app restart
-    // Desktop: OS keyring, Web: backend FileSecretStore (both via setSecret command)
-    if (session.refresh_token) {
-      try {
-        await setSecret(REFRESH_TOKEN_KEY, session.refresh_token);
-      } catch (err) {
-        logger.error(`setSecret failed: ${err}`);
-        // Fallback to localStorage only on desktop where keyring might fail
-        if (isDesktop) {
-          localStorage.setItem(REFRESH_TOKEN_KEY, session.refresh_token);
-        }
-      }
     }
   }, []);
 
@@ -331,31 +329,33 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       let didExchangeSession = false;
 
       try {
-        const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(
-          payload.code,
-        );
+        await runAuthTransition(async () => {
+          const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(
+            payload.code,
+          );
 
-        if (exchangeError) {
-          processedAuthCodesRef.current.delete(payload.code);
-          logger.error(`Failed to exchange auth code: ${exchangeError.message}`);
-          setError(exchangeError.message);
-          return;
-        }
+          if (exchangeError) {
+            processedAuthCodesRef.current.delete(payload.code);
+            logger.error(`Failed to exchange auth code: ${exchangeError.message}`);
+            setError(exchangeError.message);
+            return;
+          }
 
-        if (!data.session) {
-          processedAuthCodesRef.current.delete(payload.code);
-          logger.error("No session returned after code exchange");
-          setError(t("connect:authErrors.noSessionReturned"));
-          return;
-        }
+          if (!data.session) {
+            processedAuthCodesRef.current.delete(payload.code);
+            logger.error("No session returned after code exchange");
+            setError(t("connect:authErrors.noSessionReturned"));
+            return;
+          }
 
-        didExchangeSession = true;
-        // Store tokens BEFORE setting session to avoid race condition
-        await storeTokens(data.session);
-        setSession(data.session);
-        setUser(data.session.user);
-        requestPostLoginSync("auth-callback", data.session);
-        logger.info("Auth callback completed successfully");
+          didExchangeSession = true;
+          // Store tokens BEFORE setting session to avoid race condition
+          await storeTokens(data.session);
+          setSession(data.session);
+          setUser(data.session.user);
+          requestPostLoginSync("auth-callback", data.session);
+          logger.info("Auth callback completed successfully");
+        });
       } catch (err) {
         if (!didExchangeSession) {
           processedAuthCodesRef.current.delete(payload.code);
@@ -364,7 +364,15 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setError(err instanceof Error ? err.message : t("connect:authErrors.completeSignInFailed"));
       }
     },
-    [supabase, storeTokens, rememberAuthCodeIfNew, requestPostLoginSync, t],
+    [
+      runAuthTransition,
+      setSession,
+      supabase,
+      storeTokens,
+      rememberAuthCodeIfNew,
+      requestPostLoginSync,
+      t,
+    ],
   );
 
   // Restore session from stored tokens on mount
@@ -373,27 +381,29 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
 
     const restoreSession = async () => {
       try {
-        // Ask the backend for fresh tokens. The backend is the single owner of
-        // the refresh token and will rotate it via Supabase when needed, avoiding
-        // the race condition where both the JS client and backend independently
-        // rotate the same refresh token.
-        try {
-          const { accessToken, refreshToken } = await restoreSyncSession();
-          const { data, error: setErr } = await supabase.auth.setSession({
-            access_token: accessToken,
-            refresh_token: refreshToken,
-          });
-          if (setErr) {
-            logger.debug("Failed to set session from backend tokens.");
-            await storeTokens(null);
-          } else if (data.session && !cancelled) {
-            setSession(data.session);
-            setUser(data.session.user);
+        await runAuthTransition(async () => {
+          if (cancelled) return;
+          // Ask the backend for fresh tokens. The backend is the single owner of
+          // the refresh token and will rotate it via Supabase when needed, avoiding
+          // the race condition where both the JS client and backend independently
+          // rotate the same refresh token.
+          try {
+            const { accessToken, refreshToken } = await restoreSyncSession();
+            const { data, error: setErr } = await supabase.auth.setSession({
+              access_token: accessToken,
+              refresh_token: refreshToken,
+            });
+            if (setErr) {
+              logger.debug("Failed to set session from backend tokens.");
+            } else if (data.session && !cancelled) {
+              setSession(data.session);
+              setUser(data.session.user);
+            }
+          } catch (_err) {
+            // No backend session (not logged in or backend unreachable) — that's fine
+            logger.debug("No backend session to restore.");
           }
-        } catch (_err) {
-          // No backend session (not logged in or backend unreachable) — that's fine
-          logger.debug("No backend session to restore.");
-        }
+        });
       } catch (_err) {
         logger.error("Error restoring session.");
       } finally {
@@ -408,21 +418,17 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
     // Listen for auth state changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, newSession) => {
+    } = supabase.auth.onAuthStateChange((event) => {
       if (cancelled) return;
-
-      if (event === "SIGNED_IN" || event === "TOKEN_REFRESHED") {
-        // Store tokens BEFORE setting session to avoid race condition
-        // where isConnected becomes true before token is in keyring
-        await storeTokens(newSession);
-        setSession(newSession);
-        setUser(newSession?.user ?? null);
-      } else if (event === "SIGNED_OUT") {
+      // Explicit auth operations install sessions after backend persistence. A
+      // local SDK sign-out must never delete a newer backend session.
+      if (event === "SIGNED_OUT") {
         setSession(null);
         setUser(null);
+        setUserInfo(null);
+        setIsLoadingUserInfo(false);
         setPostLoginSyncRequest(null);
         clearProcessedAuthCodes();
-        await storeTokens(null);
       }
     });
 
@@ -430,7 +436,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       cancelled = true;
       subscription.unsubscribe();
     };
-  }, [supabase, storeTokens, isAuthenticated]);
+  }, [supabase, runAuthTransition, setSession, clearProcessedAuthCodes, isAuthenticated]);
 
   // Listen for deep link events on desktop
   useEffect(() => {
@@ -493,22 +499,24 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       setError(null);
 
       try {
-        const { data, error: signInError } = await supabase.auth.signInWithPassword({
-          email,
-          password,
+        await runAuthTransition(async () => {
+          const { data, error: signInError } = await supabase.auth.signInWithPassword({
+            email,
+            password,
+          });
+
+          if (signInError) {
+            throw signInError;
+          }
+
+          if (data.session) {
+            // Store tokens BEFORE setting session to avoid race condition
+            await storeTokens(data.session);
+            setSession(data.session);
+            setUser(data.session.user);
+            requestPostLoginSync("email-sign-in", data.session);
+          }
         });
-
-        if (signInError) {
-          throw signInError;
-        }
-
-        if (data.session) {
-          // Store tokens BEFORE setting session to avoid race condition
-          await storeTokens(data.session);
-          setSession(data.session);
-          setUser(data.session.user);
-          requestPostLoginSync("email-sign-in", data.session);
-        }
       } catch (err) {
         const message = err instanceof Error ? err.message : t("connect:authErrors.signInFailed");
         setError(message);
@@ -517,7 +525,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, storeTokens, requestPostLoginSync, t],
+    [runAuthTransition, setSession, supabase, storeTokens, requestPostLoginSync, t],
   );
 
   const signUpWithEmail = useCallback(
@@ -526,26 +534,28 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       setError(null);
 
       try {
-        const { data, error: signUpError } = await supabase.auth.signUp({
-          email,
-          password,
+        await runAuthTransition(async () => {
+          const { data, error: signUpError } = await supabase.auth.signUp({
+            email,
+            password,
+          });
+
+          if (signUpError) {
+            throw signUpError;
+          }
+
+          // If email confirmation is not required, user will be signed in
+          if (data.session) {
+            // Store tokens BEFORE setting session to avoid race condition
+            await storeTokens(data.session);
+            setSession(data.session);
+            setUser(data.session.user);
+            requestPostLoginSync("email-sign-up", data.session);
+          } else if (data.user && !data.session) {
+            // Email confirmation required
+            setError(t("connect:authErrors.confirmEmail"));
+          }
         });
-
-        if (signUpError) {
-          throw signUpError;
-        }
-
-        // If email confirmation is not required, user will be signed in
-        if (data.session) {
-          // Store tokens BEFORE setting session to avoid race condition
-          await storeTokens(data.session);
-          setSession(data.session);
-          setUser(data.session.user);
-          requestPostLoginSync("email-sign-up", data.session);
-        } else if (data.user && !data.session) {
-          // Email confirmation required
-          setError(t("connect:authErrors.confirmEmail"));
-        }
       } catch (err) {
         const message = err instanceof Error ? err.message : t("connect:authErrors.signUpFailed");
         setError(message);
@@ -554,7 +564,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, storeTokens, requestPostLoginSync, t],
+    [runAuthTransition, setSession, supabase, storeTokens, requestPostLoginSync, t],
   );
 
   const signInWithOAuth = useCallback(
@@ -699,23 +709,25 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       setError(null);
 
       try {
-        const { data, error: verifyError } = await supabase.auth.verifyOtp({
-          email,
-          token,
-          type: "email",
+        await runAuthTransition(async () => {
+          const { data, error: verifyError } = await supabase.auth.verifyOtp({
+            email,
+            token,
+            type: "email",
+          });
+
+          if (verifyError) {
+            throw verifyError;
+          }
+
+          if (data.session) {
+            // Store tokens BEFORE setting session to avoid race condition
+            await storeTokens(data.session);
+            setSession(data.session);
+            setUser(data.session.user);
+            requestPostLoginSync("otp", data.session);
+          }
         });
-
-        if (verifyError) {
-          throw verifyError;
-        }
-
-        if (data.session) {
-          // Store tokens BEFORE setting session to avoid race condition
-          await storeTokens(data.session);
-          setSession(data.session);
-          setUser(data.session.user);
-          requestPostLoginSync("otp", data.session);
-        }
       } catch (err) {
         const message =
           err instanceof Error ? err.message : t("connect:authErrors.invalidVerificationCode");
@@ -725,76 +737,109 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, storeTokens, requestPostLoginSync, t],
+    [runAuthTransition, setSession, supabase, storeTokens, requestPostLoginSync, t],
   );
 
+  const clearLocalSession = useCallback(() => {
+    setSession(null);
+    setUser(null);
+    setUserInfo(null);
+    setPostLoginSyncRequest(null);
+    setIsLoadingUserInfo(false);
+    clearProcessedAuthCodes();
+  }, [setSession, clearProcessedAuthCodes]);
+
   const signOut = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // Server-side invalidation may fail if the access token expired (since
-      // autoRefreshToken is off). That's acceptable — the session will expire
-      // naturally on the server. Always clear local state regardless.
-      const { error: signOutError } = await supabase.auth.signOut();
-      if (signOutError) {
-        logger.warn(`Server-side sign out failed (token may be expired): ${signOutError.message}`);
+    await runAuthTransition(async () => {
+      setIsLoading(true);
+      setError(null);
+      clearLocalSession();
+      try {
+        // Cleanup is local and independent of the remote auth service's availability.
+        await clearSyncSession();
+        const { error: signOutError } = await supabase.auth.signOut({ scope: "local" });
+        if (signOutError) logger.warn(`Server-side sign out failed: ${signOutError.message}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : t("connect:authErrors.signOutFailed"));
+        throw err;
+      } finally {
+        setIsLoading(false);
       }
+    });
+  }, [runAuthTransition, clearLocalSession, supabase, t]);
 
-      setSession(null);
-      setUser(null);
-      setPostLoginSyncRequest(null);
-      clearProcessedAuthCodes();
-      await storeTokens(null);
-    } catch (err) {
-      // Still clear local state even on unexpected errors
-      setSession(null);
-      setUser(null);
-      setPostLoginSyncRequest(null);
-      clearProcessedAuthCodes();
-      await storeTokens(null).catch(() => {});
-      const message = err instanceof Error ? err.message : t("connect:authErrors.signOutFailed");
-      setError(message);
-      throw err;
-    } finally {
-      setIsLoading(false);
-    }
-  }, [supabase, storeTokens, clearProcessedAuthCodes, t]);
+  // Only a missing backend auth session signs the user out; subscription access is separate.
+  const reconcileSession = useCallback(async () => {
+    const generation = sessionGenerationRef.current;
+    if (!sessionRef.current) return;
+    await runAuthTransition(async () => {
+      if (generation !== sessionGenerationRef.current) return;
+      const status = await getSyncSessionStatus();
+      if (generation !== sessionGenerationRef.current || status.isConfigured) return;
+      clearLocalSession();
+      const { error: signOutError } = await supabase.auth.signOut({ scope: "local" });
+      if (signOutError) logger.warn(`Local session sign out failed: ${signOutError.message}`);
+    });
+  }, [runAuthTransition, clearLocalSession, supabase]);
 
   const clearError = useCallback(() => setError(null), []);
 
   // Fetch user info from the cloud API
   const refetchUserInfo = useCallback(async () => {
-    if (!session) {
-      setUserInfo(null);
-      setIsLoadingUserInfo(false);
-      return;
-    }
-
+    const generation = sessionGenerationRef.current;
+    const request = ++userInfoRequestRef.current;
+    const isCurrent = () =>
+      generation === sessionGenerationRef.current && request === userInfoRequestRef.current;
+    if (!sessionRef.current) return;
     setIsLoadingUserInfo(true);
     setError(null);
-
     try {
+      await reconcileSession();
+      if (!isCurrent()) return;
       const info = await getUserInfo();
+      if (!isCurrent()) return;
+      const access = hasBrokerSync(info)
+        ? "broker"
+        : isSubscriptionStatusActive(info.team?.subscription_status)
+          ? "device"
+          : "none";
+      if (syncAccessRef.current !== access && access !== "none" && sessionRef.current) {
+        requestPostLoginSync("subscription-activated", sessionRef.current);
+      }
+      syncAccessRef.current = access;
       setUserInfo(info);
     } catch (err) {
+      if (!isCurrent()) return;
       logger.error("Failed to fetch user info from API.");
       setUserInfo(null);
-      const message =
-        err instanceof Error ? err.message : t("connect:authErrors.fetchUserInfoFailed");
-      setError(message);
+      setError(err instanceof Error ? err.message : t("connect:authErrors.fetchUserInfoFailed"));
     } finally {
-      setIsLoadingUserInfo(false);
+      if (isCurrent()) setIsLoadingUserInfo(false);
     }
-  }, [session, t]);
+  }, [reconcileSession, requestPostLoginSync, t]);
 
-  // Fetch user info when session changes
   useEffect(() => {
-    if (session) {
-      void refetchUserInfo();
-    } else {
-      setUserInfo(null);
-    }
+    if (session) void refetchUserInfo();
+    else setUserInfo(null);
+    return () => {
+      userInfoRequestRef.current += 1;
+    };
+  }, [session, refetchUserInfo]);
+
+  useEffect(() => {
+    if (!session) return;
+    const handleFocus = () => void refetchUserInfo();
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") void refetchUserInfo();
+    };
+    const interval = window.setInterval(handleFocus, 60_000);
+    window.addEventListener("focus", handleFocus);
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("focus", handleFocus);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
   }, [session, refetchUserInfo]);
 
   // Extract team_id from user's app_metadata

--- a/apps/frontend/src/features/wealthfolio-connect/services/auth-service.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/services/auth-service.ts
@@ -1,5 +1,6 @@
 import {
   logger,
+  getSyncSessionStatus as getSyncSessionStatusApi,
   storeSyncSession as storeSyncSessionApi,
   clearSyncSession as clearSyncSessionApi,
   postLoginBootstrap as postLoginBootstrapApi,
@@ -49,4 +50,8 @@ export const clearSyncSession = async (): Promise<void> => {
     logger.error("Error clearing sync session from backend");
     throw error;
   }
+};
+
+export const getSyncSessionStatus = (): Promise<{ isConfigured: boolean }> => {
+  return getSyncSessionStatusApi();
 };

--- a/apps/frontend/src/features/wealthfolio-connect/types.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/types.ts
@@ -237,4 +237,10 @@ export interface ImportRun {
 // Aggregated Sync Status (for navigation icon)
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type AggregatedSyncStatus = "not_connected" | "idle" | "running" | "needs_review" | "failed";
+export type AggregatedSyncStatus =
+  | "not_connected"
+  | "subscription_required"
+  | "idle"
+  | "running"
+  | "needs_review"
+  | "failed";

--- a/apps/frontend/src/i18n/locales/de/connect.json
+++ b/apps/frontend/src/i18n/locales/de/connect.json
@@ -222,6 +222,9 @@
     "lastUsed": "Zuletzt verwendet"
   },
   "subscription": {
+    "syncPausedTooltip": "Synchronisierung pausiert — aktives Abonnement erforderlich",
+    "syncPausedTitle": "Synchronisierung pausiert",
+    "syncPausedDescription": "Für die Synchronisierung ist ein aktives Abonnement erforderlich. Deine lokalen Daten und ausstehenden Änderungen bleiben erhalten.",
     "comingSoon": "Demnächst verfügbar",
     "getStarted": "Loslegen",
     "perMonthShort": "Mon.",

--- a/apps/frontend/src/i18n/locales/de/connect.json
+++ b/apps/frontend/src/i18n/locales/de/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "Wird im Browser geöffnet",
   "page": {
     "title": "Synchronisierung & Verbindungen",
     "subtitle": "Ihre Geräte, alle an einem Ort.",
@@ -222,6 +223,7 @@
     "lastUsed": "Zuletzt verwendet"
   },
   "subscription": {
+    "copySupportEmail": "Support-E-Mail-Adresse kopieren",
     "syncPausedTooltip": "Synchronisierung pausiert — aktives Abonnement erforderlich",
     "syncPausedTitle": "Synchronisierung pausiert",
     "syncPausedDescription": "Für die Synchronisierung ist ein aktives Abonnement erforderlich. Deine lokalen Daten und ausstehenden Änderungen bleiben erhalten.",

--- a/apps/frontend/src/i18n/locales/de/connect.json
+++ b/apps/frontend/src/i18n/locales/de/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(z. B. SnapTrade)",
     "yourDevice": "Ihr Gerät",
     "localDatabase": "Lokale Datenbank",
     "dataStaysHere": "Daten bleiben hier",

--- a/apps/frontend/src/i18n/locales/en/connect.json
+++ b/apps/frontend/src/i18n/locales/en/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(e.g. SnapTrade)",
     "yourDevice": "Your Device",
     "localDatabase": "Local database",
     "dataStaysHere": "Data stays here",

--- a/apps/frontend/src/i18n/locales/en/connect.json
+++ b/apps/frontend/src/i18n/locales/en/connect.json
@@ -222,6 +222,9 @@
     "lastUsed": "Last used"
   },
   "subscription": {
+    "syncPausedTooltip": "Sync paused — active subscription required",
+    "syncPausedTitle": "Sync is paused",
+    "syncPausedDescription": "An active subscription is required to sync. Your local data and pending changes are preserved.",
     "comingSoon": "Coming Soon",
     "getStarted": "Get Started",
     "perMonthShort": "mo",

--- a/apps/frontend/src/i18n/locales/en/connect.json
+++ b/apps/frontend/src/i18n/locales/en/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "Opens in browser",
   "page": {
     "title": "Sync & Connections",
     "subtitle": "Your devices, all in one place.",
@@ -222,6 +223,7 @@
     "lastUsed": "Last used"
   },
   "subscription": {
+    "copySupportEmail": "Copy support email",
     "syncPausedTooltip": "Sync paused — active subscription required",
     "syncPausedTitle": "Sync is paused",
     "syncPausedDescription": "An active subscription is required to sync. Your local data and pending changes are preserved.",

--- a/apps/frontend/src/i18n/locales/es/connect.json
+++ b/apps/frontend/src/i18n/locales/es/connect.json
@@ -239,6 +239,9 @@
     "lastUsed": "Usado por última vez"
   },
   "subscription": {
+    "syncPausedTooltip": "Sincronización pausada — se requiere una suscripción activa",
+    "syncPausedTitle": "La sincronización está pausada",
+    "syncPausedDescription": "Se requiere una suscripción activa para sincronizar. Tus datos locales y los cambios pendientes se conservan.",
     "comingSoon": "Próximamente",
     "getStarted": "Empezar",
     "perMonthShort": "mes",

--- a/apps/frontend/src/i18n/locales/es/connect.json
+++ b/apps/frontend/src/i18n/locales/es/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(p. ej., SnapTrade)",
     "yourDevice": "Tu dispositivo",
     "localDatabase": "Base de datos local",
     "dataStaysHere": "Los datos permanecen aquí",

--- a/apps/frontend/src/i18n/locales/es/connect.json
+++ b/apps/frontend/src/i18n/locales/es/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "Se abre en el navegador",
   "page": {
     "title": "Sincronización y conexiones",
     "subtitle": "Tus dispositivos, todos en un solo lugar.",
@@ -239,6 +240,7 @@
     "lastUsed": "Usado por última vez"
   },
   "subscription": {
+    "copySupportEmail": "Copiar el correo de soporte",
     "syncPausedTooltip": "Sincronización pausada — se requiere una suscripción activa",
     "syncPausedTitle": "La sincronización está pausada",
     "syncPausedDescription": "Se requiere una suscripción activa para sincronizar. Tus datos locales y los cambios pendientes se conservan.",

--- a/apps/frontend/src/i18n/locales/fr/connect.json
+++ b/apps/frontend/src/i18n/locales/fr/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(p. ex. SnapTrade)",
     "yourDevice": "Votre appareil",
     "localDatabase": "Base de données locale",
     "dataStaysHere": "Les données restent ici",

--- a/apps/frontend/src/i18n/locales/fr/connect.json
+++ b/apps/frontend/src/i18n/locales/fr/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "S’ouvre dans le navigateur",
   "page": {
     "title": "Synchronisation et connexions",
     "subtitle": "Vos appareils, tous au même endroit.",
@@ -239,6 +240,7 @@
     "lastUsed": "Dernier utilisé"
   },
   "subscription": {
+    "copySupportEmail": "Copier l’adresse e-mail du support",
     "syncPausedTooltip": "Synchronisation suspendue — abonnement actif requis",
     "syncPausedTitle": "La synchronisation est suspendue",
     "syncPausedDescription": "Un abonnement actif est nécessaire pour synchroniser. Vos données locales et vos modifications en attente sont conservées.",

--- a/apps/frontend/src/i18n/locales/fr/connect.json
+++ b/apps/frontend/src/i18n/locales/fr/connect.json
@@ -239,6 +239,9 @@
     "lastUsed": "Dernier utilisé"
   },
   "subscription": {
+    "syncPausedTooltip": "Synchronisation suspendue — abonnement actif requis",
+    "syncPausedTitle": "La synchronisation est suspendue",
+    "syncPausedDescription": "Un abonnement actif est nécessaire pour synchroniser. Vos données locales et vos modifications en attente sont conservées.",
     "comingSoon": "Bientôt disponible",
     "getStarted": "Commencer",
     "perMonthShort": "mois",

--- a/apps/frontend/src/i18n/locales/it/connect.json
+++ b/apps/frontend/src/i18n/locales/it/connect.json
@@ -239,6 +239,9 @@
     "lastUsed": "Usato l'ultima volta"
   },
   "subscription": {
+    "syncPausedTooltip": "Sincronizzazione in pausa — abbonamento attivo necessario",
+    "syncPausedTitle": "La sincronizzazione è in pausa",
+    "syncPausedDescription": "Per sincronizzare è necessario un abbonamento attivo. I dati locali e le modifiche in sospeso vengono conservati.",
     "comingSoon": "Prossimamente",
     "getStarted": "Inizia",
     "perMonthShort": "mese",

--- a/apps/frontend/src/i18n/locales/it/connect.json
+++ b/apps/frontend/src/i18n/locales/it/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(ad es. SnapTrade)",
     "yourDevice": "Il tuo dispositivo",
     "localDatabase": "Database locale",
     "dataStaysHere": "I dati restano qui",

--- a/apps/frontend/src/i18n/locales/it/connect.json
+++ b/apps/frontend/src/i18n/locales/it/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "Si apre nel browser",
   "page": {
     "title": "Sincronizzazione e connessioni",
     "subtitle": "I tuoi dispositivi, tutti in un unico posto.",
@@ -239,6 +240,7 @@
     "lastUsed": "Usato l'ultima volta"
   },
   "subscription": {
+    "copySupportEmail": "Copia l’indirizzo email di supporto",
     "syncPausedTooltip": "Sincronizzazione in pausa — abbonamento attivo necessario",
     "syncPausedTitle": "La sincronizzazione è in pausa",
     "syncPausedDescription": "Per sincronizzare è necessario un abbonamento attivo. I dati locali e le modifiche in sospeso vengono conservati.",

--- a/apps/frontend/src/i18n/locales/ja/connect.json
+++ b/apps/frontend/src/i18n/locales/ja/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "（例：SnapTrade）",
     "yourDevice": "お使いのデバイス",
     "localDatabase": "ローカルデータベース",
     "dataStaysHere": "データはここに保存されます",

--- a/apps/frontend/src/i18n/locales/ja/connect.json
+++ b/apps/frontend/src/i18n/locales/ja/connect.json
@@ -220,6 +220,9 @@
     "lastUsed": "前回使用"
   },
   "subscription": {
+    "syncPausedTooltip": "同期は一時停止中です — 有効なサブスクリプションが必要です",
+    "syncPausedTitle": "同期は一時停止中です",
+    "syncPausedDescription": "同期には有効なサブスクリプションが必要です。ローカルデータと未同期の変更は保持されます。",
     "comingSoon": "近日公開",
     "getStarted": "始める",
     "perMonthShort": "月",

--- a/apps/frontend/src/i18n/locales/ja/connect.json
+++ b/apps/frontend/src/i18n/locales/ja/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "ブラウザで開きます",
   "page": {
     "title": "同期と連携",
     "subtitle": "すべてのデバイスを一元管理。",
@@ -220,6 +221,7 @@
     "lastUsed": "前回使用"
   },
   "subscription": {
+    "copySupportEmail": "サポートのメールアドレスをコピー",
     "syncPausedTooltip": "同期は一時停止中です — 有効なサブスクリプションが必要です",
     "syncPausedTitle": "同期は一時停止中です",
     "syncPausedDescription": "同期には有効なサブスクリプションが必要です。ローカルデータと未同期の変更は保持されます。",

--- a/apps/frontend/src/i18n/locales/ko/connect.json
+++ b/apps/frontend/src/i18n/locales/ko/connect.json
@@ -220,6 +220,9 @@
     "lastUsed": "마지막 사용"
   },
   "subscription": {
+    "syncPausedTooltip": "동기화 일시 중지 — 활성 구독 필요",
+    "syncPausedTitle": "동기화가 일시 중지되었습니다",
+    "syncPausedDescription": "동기화하려면 활성 구독이 필요합니다. 로컬 데이터와 대기 중인 변경 사항은 유지됩니다.",
     "comingSoon": "곧 출시 예정",
     "getStarted": "시작하기",
     "perMonthShort": "월",

--- a/apps/frontend/src/i18n/locales/ko/connect.json
+++ b/apps/frontend/src/i18n/locales/ko/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(예: SnapTrade)",
     "yourDevice": "내 기기",
     "localDatabase": "로컬 데이터베이스",
     "dataStaysHere": "데이터는 여기 저장됩니다",

--- a/apps/frontend/src/i18n/locales/ko/connect.json
+++ b/apps/frontend/src/i18n/locales/ko/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "브라우저에서 열립니다",
   "page": {
     "title": "동기화 및 연결",
     "subtitle": "모든 기기를 한 곳에서 관리하세요.",
@@ -220,6 +221,7 @@
     "lastUsed": "마지막 사용"
   },
   "subscription": {
+    "copySupportEmail": "지원 이메일 주소 복사",
     "syncPausedTooltip": "동기화 일시 중지 — 활성 구독 필요",
     "syncPausedTitle": "동기화가 일시 중지되었습니다",
     "syncPausedDescription": "동기화하려면 활성 구독이 필요합니다. 로컬 데이터와 대기 중인 변경 사항은 유지됩니다.",

--- a/apps/frontend/src/i18n/locales/pt/connect.json
+++ b/apps/frontend/src/i18n/locales/pt/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "Abre no navegador",
   "page": {
     "title": "Sincronização e conexões",
     "subtitle": "Seus dispositivos, todos em um só lugar.",
@@ -239,6 +240,7 @@
     "lastUsed": "Usado pela última vez"
   },
   "subscription": {
+    "copySupportEmail": "Copiar e-mail do suporte",
     "syncPausedTooltip": "Sincronização pausada — assinatura ativa necessária",
     "syncPausedTitle": "A sincronização está pausada",
     "syncPausedDescription": "É necessária uma assinatura ativa para sincronizar. Seus dados locais e alterações pendentes são preservados.",

--- a/apps/frontend/src/i18n/locales/pt/connect.json
+++ b/apps/frontend/src/i18n/locales/pt/connect.json
@@ -239,6 +239,9 @@
     "lastUsed": "Usado pela última vez"
   },
   "subscription": {
+    "syncPausedTooltip": "Sincronização pausada — assinatura ativa necessária",
+    "syncPausedTitle": "A sincronização está pausada",
+    "syncPausedDescription": "É necessária uma assinatura ativa para sincronizar. Seus dados locais e alterações pendentes são preservados.",
     "comingSoon": "Em breve",
     "getStarted": "Começar",
     "perMonthShort": "mês",

--- a/apps/frontend/src/i18n/locales/pt/connect.json
+++ b/apps/frontend/src/i18n/locales/pt/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "(por exemplo, SnapTrade)",
     "yourDevice": "Seu dispositivo",
     "localDatabase": "Banco de dados local",
     "dataStaysHere": "Os dados ficam aqui",

--- a/apps/frontend/src/i18n/locales/zh-Hant/connect.json
+++ b/apps/frontend/src/i18n/locales/zh-Hant/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "在瀏覽器中開啟",
   "page": {
     "title": "同步與連線",
     "subtitle": "所有裝置，集中管理。",
@@ -222,6 +223,7 @@
     "lastUsed": "上次使用"
   },
   "subscription": {
+    "copySupportEmail": "複製支援電子郵件地址",
     "syncPausedTooltip": "同步已暫停 — 需要有效訂閱",
     "syncPausedTitle": "同步已暫停",
     "syncPausedDescription": "同步需要有效訂閱。您的本機資料和待同步的變更會保留。",

--- a/apps/frontend/src/i18n/locales/zh-Hant/connect.json
+++ b/apps/frontend/src/i18n/locales/zh-Hant/connect.json
@@ -222,6 +222,9 @@
     "lastUsed": "上次使用"
   },
   "subscription": {
+    "syncPausedTooltip": "同步已暫停 — 需要有效訂閱",
+    "syncPausedTitle": "同步已暫停",
+    "syncPausedDescription": "同步需要有效訂閱。您的本機資料和待同步的變更會保留。",
     "comingSoon": "敬請期待",
     "getStarted": "開始使用",
     "perMonthShort": "月",

--- a/apps/frontend/src/i18n/locales/zh-Hant/connect.json
+++ b/apps/frontend/src/i18n/locales/zh-Hant/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "（例如 SnapTrade）",
     "yourDevice": "你的裝置",
     "localDatabase": "本機資料庫",
     "dataStaysHere": "資料保留在此",

--- a/apps/frontend/src/i18n/locales/zh/connect.json
+++ b/apps/frontend/src/i18n/locales/zh/connect.json
@@ -38,6 +38,7 @@
     }
   },
   "flow": {
+    "aggregatorExample": "（例如 SnapTrade）",
     "yourDevice": "您的设备",
     "localDatabase": "本地数据库",
     "dataStaysHere": "数据保留在此",

--- a/apps/frontend/src/i18n/locales/zh/connect.json
+++ b/apps/frontend/src/i18n/locales/zh/connect.json
@@ -220,6 +220,9 @@
     "lastUsed": "上次使用"
   },
   "subscription": {
+    "syncPausedTooltip": "同步已暂停 — 需要有效订阅",
+    "syncPausedTitle": "同步已暂停",
+    "syncPausedDescription": "同步需要有效订阅。您的本地数据和待同步的更改会保留。",
     "comingSoon": "敬请期待",
     "getStarted": "开始使用",
     "perMonthShort": "月",

--- a/apps/frontend/src/i18n/locales/zh/connect.json
+++ b/apps/frontend/src/i18n/locales/zh/connect.json
@@ -1,4 +1,5 @@
 {
+  "opensInBrowser": "在浏览器中打开",
   "page": {
     "title": "同步与连接",
     "subtitle": "您的所有设备,尽在一处。",
@@ -220,6 +221,7 @@
     "lastUsed": "上次使用"
   },
   "subscription": {
+    "copySupportEmail": "复制支持邮箱地址",
     "syncPausedTooltip": "同步已暂停 — 需要有效订阅",
     "syncPausedTitle": "同步已暂停",
     "syncPausedDescription": "同步需要有效订阅。您的本地数据和待同步的更改会保留。",

--- a/apps/frontend/src/pages/layouts/navigation/connect-nav-item.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/connect-nav-item.tsx
@@ -21,13 +21,16 @@ export function ConnectNavItem({ collapsed }: ConnectNavItemProps) {
   const { status, lastSyncTime } = useAggregatedSyncStatus();
   const isActive = isPathActive(location.pathname, "/connect");
 
-  const tooltipContent = lastSyncTime
-    ? t("common:layout.connect_last_synced", {
-        time: formatDistanceToNow(new Date(lastSyncTime), localizationSettings, {
-          addSuffix: true,
-        }),
-      })
-    : t("common:connect");
+  const tooltipContent =
+    status === "subscription_required"
+      ? t("connect:subscription.syncPausedTooltip")
+      : lastSyncTime
+        ? t("common:layout.connect_last_synced", {
+            time: formatDistanceToNow(new Date(lastSyncTime), localizationSettings, {
+              addSuffix: true,
+            }),
+          })
+        : t("common:connect");
 
   return (
     <Tooltip>
@@ -42,7 +45,12 @@ export function ConnectNavItem({ collapsed }: ConnectNavItemProps) {
         >
           <Link
             to="/connect"
-            title={t("common:connect")}
+            title={tooltipContent}
+            aria-label={
+              status === "subscription_required"
+                ? `${t("common:connect")}: ${tooltipContent}`
+                : undefined
+            }
             aria-current={isActive ? "page" : undefined}
           >
             <span aria-hidden="true">

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -457,6 +457,9 @@ async fn run_post_login_device_bootstrap(state: Arc<AppState>) -> PostLoginBoots
     match decision {
         PostLoginDeviceBootstrapDecision::StartBackground => {}
         PostLoginDeviceBootstrapDecision::Skip(reason) => {
+            if matches!(reason, PostLoginBootstrapReason::AlreadyRunning) {
+                state.device_sync_runtime.notify_sync_work_available();
+            }
             return PostLoginBootstrapSyncResult::skipped(reason);
         }
     }
@@ -569,6 +572,11 @@ async fn sync_broker_connections(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<SyncConnectionsResponse>> {
     ensure_connect_sync_enabled()?;
+    if !has_broker_sync(&state).await.map_err(ApiError::Internal)? {
+        return Err(ApiError::Forbidden(
+            "An active broker-sync subscription is required.".to_string(),
+        ));
+    }
     info!("[Connect] Syncing broker connections...");
 
     let client = create_connect_client(&state).await?;
@@ -603,6 +611,11 @@ async fn sync_broker_accounts(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<SyncAccountsResponse>> {
     ensure_connect_sync_enabled()?;
+    if !has_broker_sync(&state).await.map_err(ApiError::Internal)? {
+        return Err(ApiError::Forbidden(
+            "An active broker-sync subscription is required.".to_string(),
+        ));
+    }
     info!("[Connect] Syncing broker accounts...");
 
     let client = create_connect_client(&state).await?;
@@ -634,6 +647,11 @@ async fn sync_broker_activities(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<SyncActivitiesResponse>> {
     ensure_connect_sync_enabled()?;
+    if !has_broker_sync(&state).await.map_err(ApiError::Internal)? {
+        return Err(ApiError::Forbidden(
+            "An active broker-sync subscription is required.".to_string(),
+        ));
+    }
     info!("[Connect] Running activities-only broker sync");
     let result = perform_broker_activities_only_sync(&state)
         .await
@@ -702,6 +720,22 @@ pub async fn has_broker_sync(state: &AppState) -> Result<bool, String> {
         .await
         .map_err(|e| e.to_string())?;
     client.has_broker_sync().await.map_err(|e| e.to_string())
+}
+
+pub async fn has_device_sync(state: &AppState) -> Result<bool, String> {
+    create_connect_client(state)
+        .await
+        .map_err(|err| err.to_string())?
+        .has_device_sync()
+        .await
+        .map_err(|err| err.to_string())
+}
+
+pub async fn ensure_device_sync_subscription(state: &AppState) -> Result<(), String> {
+    if !has_device_sync(state).await? {
+        return Err("Device sync is paused: an active subscription is required.".to_string());
+    }
+    Ok(())
 }
 
 /// Core broker sync logic - syncs connections, accounts, and activities from cloud to local DB.

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -33,7 +33,7 @@ use wealthfolio_connect::{
     ConnectApiClient, PostLoginBootstrapReason, PostLoginBootstrapResult,
     PostLoginBootstrapSyncResult, PostLoginBrokerBootstrapDecision, SyncConfig, SyncOrchestrator,
     SyncProgressPayload, SyncProgressReporter, SyncResult, TokenLifecycleConfig,
-    TokenLifecycleError, CLOUD_ACCESS_TOKEN_KEY, CLOUD_REFRESH_TOKEN_KEY,
+    TokenLifecycleError, CLOUD_REFRESH_TOKEN_KEY,
 };
 #[cfg(feature = "device-sync")]
 use wealthfolio_device_sync::{EnableSyncResult, SyncState, SyncStateResult};
@@ -365,12 +365,10 @@ async fn store_sync_session(
 ) -> ApiResult<Json<()>> {
     ensure_cloud_sync_enabled()?;
     state
-        .secret_store
-        .set_secret(CLOUD_REFRESH_TOKEN_KEY, &body.refresh_token)
-        .map_err(|e| ApiError::Internal(format!("Failed to store refresh token: {}", e)))?;
-    // Best-effort cleanup for legacy versions that stored access tokens at rest.
-    let _ = state.secret_store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
-    state.token_lifecycle.clear_cache().await;
+        .token_lifecycle
+        .store_session(state.secret_store.as_ref(), &body.refresh_token)
+        .await
+        .map_err(map_token_lifecycle_error)?;
 
     Ok(Json(()))
 }
@@ -484,19 +482,29 @@ async fn clear_sync_session(State(state): State<Arc<AppState>>) -> ApiResult<Jso
     ensure_cloud_sync_enabled()?;
     info!("[Connect] Clearing sync session");
 
-    let _ = state.secret_store.delete_secret(CLOUD_REFRESH_TOKEN_KEY);
-    let _ = state.secret_store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
-
-    state.token_lifecycle.clear_cache().await;
-    #[cfg(feature = "device-sync")]
-    device_sync_engine::clear_min_snapshot_created_at_from_store();
-    let _ = state
-        .app_sync_repository
-        .clear_all_min_snapshot_created_at()
-        .await;
-
+    disconnect_cloud_session(&state)
+        .await
+        .map_err(ApiError::Internal)?;
     info!("[Connect] Sync session cleared");
     Ok(Json(()))
+}
+
+async fn disconnect_cloud_session(state: &AppState) -> Result<(), String> {
+    state
+        .token_lifecycle
+        .clear_session_with(state.secret_store.as_ref(), || async {
+            #[cfg(feature = "device-sync")]
+            device_sync_engine::clear_min_snapshot_created_at_from_store();
+            let _ = state
+                .app_sync_repository
+                .clear_all_min_snapshot_created_at()
+                .await;
+            #[cfg(feature = "device-sync")]
+            state.device_sync_runtime.ensure_background_stopped().await;
+        })
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
 }
 
 async fn get_sync_session_status(
@@ -504,10 +512,9 @@ async fn get_sync_session_status(
 ) -> ApiResult<Json<SyncSessionStatus>> {
     ensure_cloud_sync_enabled()?;
     let is_configured = state
-        .secret_store
-        .get_secret(CLOUD_REFRESH_TOKEN_KEY)
-        .map(|t| t.is_some())
-        .unwrap_or(false);
+        .token_lifecycle
+        .is_session_configured(state.secret_store.as_ref())
+        .map_err(map_token_lifecycle_error)?;
 
     Ok(Json(SyncSessionStatus { is_configured }))
 }

--- a/apps/server/src/api/device_sync_engine.rs
+++ b/apps/server/src/api/device_sync_engine.rs
@@ -20,6 +20,7 @@ use wealthfolio_device_sync::{
     DeviceSyncClient, ReconcileReadyStateResponse, SyncPullResponse, SyncPushRequest,
     SyncPushResponse, SyncState,
 };
+use wealthfolio_storage_sqlite::sync::{SqliteSyncEngineDbPorts, SyncTableRowCount};
 
 fn transport_err_from_sync(e: wealthfolio_device_sync::DeviceSyncError) -> TransportError {
     TransportError {
@@ -32,7 +33,6 @@ fn transport_err_from_sync(e: wealthfolio_device_sync::DeviceSyncError) -> Trans
         },
     }
 }
-use wealthfolio_storage_sqlite::sync::{SqliteSyncEngineDbPorts, SyncTableRowCount};
 
 const SYNC_IDENTITY_KEY: &str = "sync_identity";
 const DEVICE_ID_KEY: &str = "sync_device_id";
@@ -636,6 +636,17 @@ impl SyncTransport for ServerEnginePorts {
 
 #[async_trait]
 impl CredentialStore for ServerEnginePorts {
+    fn has_cloud_session(&self) -> Result<bool, String> {
+        self.state
+            .token_lifecycle
+            .is_session_configured(self.state.secret_store.as_ref())
+            .map_err(|err| err.to_string())
+    }
+
+    async fn is_sync_allowed(&self) -> Result<bool, String> {
+        crate::api::connect::has_device_sync(&self.state).await
+    }
+
     fn get_sync_identity(&self) -> Option<SyncIdentity> {
         get_sync_identity_from_store(&self.state)
     }
@@ -908,6 +919,13 @@ pub async fn reconcile_ready_state(
 
 pub async fn ensure_background_engine_started(state: Arc<AppState>) -> Result<(), String> {
     ensure_device_sync_enabled()?;
+    let has_session = state
+        .token_lifecycle
+        .is_session_configured(state.secret_store.as_ref())
+        .map_err(|err| err.to_string())?;
+    if !has_session {
+        return Ok(());
+    }
     let Some(identity) = get_sync_identity_from_store(&state) else {
         return Ok(());
     };
@@ -1036,6 +1054,7 @@ async fn snapshot_satisfies_freshness_gate(
 pub async fn sync_bootstrap_snapshot_if_needed(
     state: Arc<AppState>,
 ) -> Result<SyncBootstrapResult, String> {
+    crate::api::connect::ensure_device_sync_subscription(&state).await?;
     ensure_device_sync_enabled()?;
     let identity = get_sync_identity_from_store(&state)
         .ok_or_else(|| "No sync identity configured. Please enable sync first.".to_string())?;
@@ -1346,6 +1365,7 @@ pub async fn sync_bootstrap_snapshot_if_needed(
 pub async fn generate_snapshot_now(
     state: Arc<AppState>,
 ) -> Result<SyncSnapshotUploadResult, String> {
+    crate::api::connect::ensure_device_sync_subscription(&state).await?;
     ensure_device_sync_enabled()?;
     state
         .device_sync_runtime

--- a/apps/tauri/capabilities/ios.json
+++ b/apps/tauri/capabilities/ios.json
@@ -1,6 +1,6 @@
 {
   "identifier": "ios-mobile-share-capability",
-  "description": "iOS mobile share permission",
+  "description": "iOS mobile share and web authentication permissions",
   "local": true,
   "windows": [
     "main"
@@ -9,6 +9,8 @@
     "iOS"
   ],
   "permissions": [
-    "mobile-share:default"
+    "mobile-share:default",
+    "web-auth:default",
+    "web-auth:allow-authenticate"
   ]
 }

--- a/apps/tauri/capabilities/mobile.json
+++ b/apps/tauri/capabilities/mobile.json
@@ -43,8 +43,6 @@
     "haptics:allow-notification-feedback",
     "haptics:allow-selection-feedback",
     "haptics:allow-vibrate",
-    "web-auth:default",
-    "web-auth:allow-authenticate",
     "barcode-scanner:allow-scan",
     "barcode-scanner:allow-cancel",
     "barcode-scanner:allow-check-permissions",

--- a/apps/tauri/src/commands/device_sync/engine.rs
+++ b/apps/tauri/src/commands/device_sync/engine.rs
@@ -13,6 +13,7 @@ use wealthfolio_device_sync::engine::{
 use wealthfolio_device_sync::{
     ReconcileReadyStateResponse, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncState,
 };
+use wealthfolio_storage_sqlite::sync::SqliteSyncEngineDbPorts;
 
 fn transport_err_from_sync(e: wealthfolio_device_sync::DeviceSyncError) -> TransportError {
     TransportError {
@@ -34,7 +35,6 @@ fn transport_err_permanent(message: String) -> TransportError {
         details: None,
     }
 }
-use wealthfolio_storage_sqlite::sync::SqliteSyncEngineDbPorts;
 
 use super::{
     create_client, decrypt_sync_payload, encrypt_sync_payload, get_sync_identity_from_store,
@@ -241,6 +241,14 @@ impl SyncTransport for TauriEnginePorts {
 
 #[async_trait]
 impl CredentialStore for TauriEnginePorts {
+    fn has_cloud_session(&self) -> Result<bool, String> {
+        self.context.connect_service().is_session_configured()
+    }
+
+    async fn is_sync_allowed(&self) -> Result<bool, String> {
+        self.context.connect_service().has_device_sync().await
+    }
+
     fn get_sync_identity(&self) -> Option<SyncIdentity> {
         get_sync_identity_from_store().map(|identity| SyncIdentity {
             device_id: identity.device_id,
@@ -326,6 +334,10 @@ pub(super) async fn run_sync_cycle(
 }
 
 pub async fn ensure_background_engine_started(context: Arc<ServiceContext>) -> Result<(), String> {
+    let has_session = context.connect_service().is_session_configured()?;
+    if !has_session {
+        return Ok(());
+    }
     let Some(identity) = get_sync_identity_from_store() else {
         return Ok(());
     };

--- a/apps/tauri/src/commands/device_sync/snapshot.rs
+++ b/apps/tauri/src/commands/device_sync/snapshot.rs
@@ -246,6 +246,10 @@ pub async fn sync_bootstrap_snapshot_if_needed(
     handle: AppHandle,
     context: &Arc<ServiceContext>,
 ) -> Result<SyncBootstrapResult, String> {
+    context
+        .connect_service()
+        .ensure_device_sync_subscription()
+        .await?;
     let identity = get_sync_identity_from_store()
         .ok_or_else(|| "No sync identity configured. Please enable sync first.".to_string())?;
     let device_id = identity
@@ -580,6 +584,10 @@ pub async fn generate_snapshot_now_internal(
     handle: Option<&AppHandle>,
     context: Arc<ServiceContext>,
 ) -> Result<SyncSnapshotUploadResult, String> {
+    context
+        .connect_service()
+        .ensure_device_sync_subscription()
+        .await?;
     context
         .device_sync_runtime()
         .snapshot_upload_cancelled

--- a/apps/tauri/src/commands/wealthfolio_connect.rs
+++ b/apps/tauri/src/commands/wealthfolio_connect.rs
@@ -203,6 +203,9 @@ async fn run_post_login_device_bootstrap(
     match decision {
         PostLoginDeviceBootstrapDecision::StartBackground => {}
         PostLoginDeviceBootstrapDecision::Skip(reason) => {
+            if matches!(reason, PostLoginBootstrapReason::AlreadyRunning) {
+                context.device_sync_runtime().notify_sync_work_available();
+            }
             return PostLoginBootstrapSyncResult::skipped(reason);
         }
     }

--- a/apps/tauri/src/commands/wealthfolio_connect.rs
+++ b/apps/tauri/src/commands/wealthfolio_connect.rs
@@ -250,7 +250,6 @@ pub fn get_sync_session_status(
 }
 
 /// Clear explicit logout credentials and stop the worker in one transition.
-
 async fn disconnect_cloud_session(context: &ServiceContext) -> Result<(), String> {
     context
         .connect_service()

--- a/apps/tauri/src/commands/wealthfolio_connect.rs
+++ b/apps/tauri/src/commands/wealthfolio_connect.rs
@@ -26,7 +26,6 @@ use wealthfolio_core::secrets::SecretStore;
 use wealthfolio_device_sync::SyncState;
 
 // Storage keys (without prefix - the SecretStore adds "wealthfolio_" prefix)
-const SYNC_ACCESS_TOKEN_KEY: &str = "sync_access_token";
 const SYNC_REFRESH_TOKEN_KEY: &str = "sync_refresh_token";
 
 #[cfg(feature = "device-sync")]
@@ -80,25 +79,17 @@ pub async fn store_sync_session(
     refresh_token: Option<String>,
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<(), String> {
-    match refresh_token.as_deref().map(str::trim) {
-        Some(token) if !token.is_empty() => {
-            if let Err(e) = KeyringSecretStore.set_secret(SYNC_REFRESH_TOKEN_KEY, token) {
-                error!("Failed to store refresh token in keyring: {}", e);
-                return Err(format!("Failed to store refresh token: {}", e));
-            }
-            // Best-effort cleanup for legacy versions that stored access tokens at rest.
-            let _ = KeyringSecretStore.delete_secret(SYNC_ACCESS_TOKEN_KEY);
-            debug!("Refresh token stored successfully");
-        }
-        _ => {
-            if let Err(e) = KeyringSecretStore.delete_secret(SYNC_REFRESH_TOKEN_KEY) {
-                error!("Failed to delete refresh token from keyring: {}", e);
-                // Don't fail the whole operation if we can't delete
-            }
+    match refresh_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
+        Some(token) => state.connect_service().store_session(token).await?,
+        None => {
+            disconnect_cloud_session(&state).await?;
         }
     }
 
-    state.connect_service().clear_cached_token().await;
     Ok(())
 }
 
@@ -237,34 +228,44 @@ async fn run_post_login_device_bootstrap(
 
 #[tauri::command]
 pub async fn clear_sync_session(state: State<'_, Arc<ServiceContext>>) -> Result<(), String> {
-    // Best-effort cleanup for legacy installs that persisted the access token.
-    let _ = KeyringSecretStore.delete_secret(SYNC_ACCESS_TOKEN_KEY);
-    let refresh_result = KeyringSecretStore.delete_secret(SYNC_REFRESH_TOKEN_KEY);
+    disconnect_cloud_session(&state).await
+}
 
-    // Report refresh-token errors but don't fail on legacy access-token cleanup.
-    let mut errors = Vec::new();
-    if let Err(e) = refresh_result {
-        error!("Failed to delete refresh token from keyring: {}", e);
-        errors.push(format!("refresh_token: {}", e));
-    }
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncSessionStatus {
+    pub is_configured: bool,
+}
 
-    state.connect_service().clear_cached_token().await;
-    #[cfg(feature = "device-sync")]
-    clear_min_snapshot_created_at_from_store();
-    let _ = state
-        .app_sync_repository()
-        .clear_all_min_snapshot_created_at()
-        .await;
+#[tauri::command]
+pub fn get_sync_session_status(
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<SyncSessionStatus, String> {
+    Ok(SyncSessionStatus {
+        is_configured: state.connect_service().is_session_configured()?,
+    })
+}
 
-    if errors.is_empty() {
-        debug!("Sync session cleared from keyring");
-        Ok(())
-    } else {
-        Err(format!(
-            "Failed to clear some tokens: {}",
-            errors.join(", ")
-        ))
-    }
+/// Clear explicit logout credentials and stop the worker in one transition.
+
+async fn disconnect_cloud_session(context: &ServiceContext) -> Result<(), String> {
+    context
+        .connect_service()
+        .clear_session_with(|| async {
+            #[cfg(feature = "device-sync")]
+            clear_min_snapshot_created_at_from_store();
+            let _ = context
+                .app_sync_repository()
+                .clear_all_min_snapshot_created_at()
+                .await;
+            #[cfg(feature = "device-sync")]
+            context
+                .device_sync_runtime()
+                .ensure_background_stopped()
+                .await;
+        })
+        .await
+        .map(|_| ())
 }
 
 #[derive(Serialize)]

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -698,6 +698,8 @@ pub fn run() {
             #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
             commands::wealthfolio_connect::clear_sync_session,
             #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
+            commands::wealthfolio_connect::get_sync_session_status,
+            #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
             commands::wealthfolio_connect::restore_sync_session,
             #[cfg(feature = "connect-sync")]
             commands::brokers_sync::sync_broker_data,

--- a/apps/tauri/src/services/connect_service.rs
+++ b/apps/tauri/src/services/connect_service.rs
@@ -90,8 +90,28 @@ impl ConnectService {
         .map_err(|err| err.to_string())
     }
 
-    pub async fn clear_cached_token(&self) {
-        self.token_lifecycle.clear_cache().await;
+    pub fn is_session_configured(&self) -> Result<bool, String> {
+        self.token_lifecycle
+            .is_session_configured(self.secret_store.as_ref())
+            .map_err(|err| err.to_string())
+    }
+
+    pub async fn store_session(&self, token: &str) -> Result<(), String> {
+        self.token_lifecycle
+            .store_session(self.secret_store.as_ref(), token)
+            .await
+            .map_err(|err| err.to_string())
+    }
+
+    pub async fn clear_session_with<F, Fut>(&self, after_clear: F) -> Result<bool, String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        self.token_lifecycle
+            .clear_session_with(self.secret_store.as_ref(), after_clear)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     /// Get an authenticated API client using the stored access token.

--- a/apps/tauri/src/services/connect_service.rs
+++ b/apps/tauri/src/services/connect_service.rs
@@ -134,6 +134,23 @@ impl ConnectService {
         ConnectApiClient::new(&cloud_api_base_url, &access_token).map_err(|e| e.to_string())
     }
 
+    pub async fn has_device_sync(&self) -> Result<bool, String> {
+        let token = self.get_valid_access_token().await?;
+        let url = cloud_api_base_url().ok_or("Cloud sync is disabled")?;
+        ConnectApiClient::new(&url, &token)
+            .map_err(|err| err.to_string())?
+            .has_device_sync()
+            .await
+            .map_err(|err| err.to_string())
+    }
+
+    pub async fn ensure_device_sync_subscription(&self) -> Result<(), String> {
+        if !self.has_device_sync().await? {
+            return Err("Device sync is paused: an active subscription is required.".to_string());
+        }
+        Ok(())
+    }
+
     /// Check if the current user's plan includes broker sync.
     ///
     /// Returns `Ok(true)` only when the user has an active subscription

--- a/crates/connect/src/client.rs
+++ b/crates/connect/src/client.rs
@@ -147,6 +147,10 @@ pub struct ConnectApiClient {
     auth_header: HeaderValue,
 }
 
+fn subscription_allows_sync(status: Option<&str>) -> bool {
+    matches!(status, Some("active" | "trialing" | "past_due"))
+}
+
 impl ConnectApiClient {
     /// Create a new Connect API client.
     ///
@@ -410,6 +414,15 @@ impl ConnectApiClient {
         self.get("/api/v1/subscription/plans").await
     }
 
+    /// Every paid plan includes device sync. Unknown/inactive subscriptions deny access.
+    pub async fn has_device_sync(&self) -> Result<bool> {
+        let info = self.get_user_info().await?;
+        Ok(info
+            .team
+            .as_ref()
+            .is_some_and(|team| subscription_allows_sync(team.subscription_status.as_deref())))
+    }
+
     /// Check if the current user's plan includes broker sync.
     ///
     /// Returns true when the user has an active subscription AND their plan
@@ -425,10 +438,7 @@ impl ConnectApiClient {
             }
         };
 
-        let is_active = matches!(
-            team.subscription_status.as_deref(),
-            Some("active") | Some("trialing")
-        );
+        let is_active = subscription_allows_sync(team.subscription_status.as_deref());
         if !is_active {
             debug!("[ConnectApi] No active subscription, broker sync not available");
             return Ok(false);
@@ -773,6 +783,61 @@ mod tests {
         assert!(error.contains("temporary failure"));
         assert!(error.contains(&format!("clientRequestId={}", client_request_id)));
         assert!(error.contains("requestId=server-req-123"));
+        handle.join().expect("server thread");
+    }
+
+    #[test]
+    fn subscription_status_gates_sync_without_affecting_authentication() {
+        for status in ["active", "trialing", "past_due"] {
+            assert!(subscription_allows_sync(Some(status)));
+        }
+        for status in [
+            None,
+            Some("canceled"),
+            Some("unpaid"),
+            Some("incomplete"),
+            Some("incomplete_expired"),
+            Some("paused"),
+            Some("unknown"),
+        ] {
+            assert!(!subscription_allows_sync(status));
+        }
+    }
+
+    #[tokio::test]
+    async fn device_sync_requires_subscription_but_accepts_basic_plan() {
+        for (body, allowed) in [
+            (r#"{"id":"user-1","team":null}"#, false),
+            (
+                r#"{"id":"user-1","team":{"id":"team-1","plan":"basic","subscriptionStatus":null}}"#,
+                false,
+            ),
+            (
+                r#"{"id":"user-1","team":{"id":"team-1","plan":"basic","subscriptionStatus":"canceled"}}"#,
+                false,
+            ),
+            (
+                r#"{"id":"user-1","team":{"id":"team-1","plan":"basic","subscriptionStatus":"active"}}"#,
+                true,
+            ),
+        ] {
+            let (base_url, _captured, handle) = start_one_request_server(200, body, None);
+            let client = ConnectApiClient::new(&base_url, "test-token").unwrap();
+            assert_eq!(client.has_device_sync().await.unwrap(), allowed);
+            handle.join().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn broker_sync_allows_past_due_grace_period() {
+        let (base_url, _captured, handle) = start_one_request_server(
+            200,
+            r#"{"id":"user-1","team":{"id":"team-1","plan":"essentials","subscriptionStatus":"past_due"}}"#,
+            None,
+        );
+        let client = ConnectApiClient::new(&base_url, "test-token").unwrap();
+
+        assert!(client.has_broker_sync().await.unwrap());
         handle.join().expect("server thread");
     }
 

--- a/crates/connect/src/token_lifecycle.rs
+++ b/crates/connect/src/token_lifecycle.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::{engine::general_purpose, Engine as _};
@@ -43,6 +44,7 @@ impl TokenLifecycleConfig {
 pub struct TokenLifecycleState {
     cache: RwLock<Option<CachedAccessToken>>,
     refresh_lock: Mutex<()>,
+    terminated: AtomicBool,
 }
 
 impl TokenLifecycleState {
@@ -50,7 +52,74 @@ impl TokenLifecycleState {
         Self {
             cache: RwLock::new(None),
             refresh_lock: Mutex::new(()),
+            terminated: AtomicBool::new(false),
         }
+    }
+
+    pub fn is_session_configured(
+        &self,
+        store: &dyn SecretStore,
+    ) -> Result<bool, TokenLifecycleError> {
+        if self.terminated.load(Ordering::SeqCst) {
+            return Ok(false);
+        }
+        store
+            .get_secret(CLOUD_REFRESH_TOKEN_KEY)
+            .map(|token| token.is_some_and(|token| !token.trim().is_empty()))
+            .map_err(|err| TokenLifecycleError::Internal(err.to_string()))
+    }
+
+    /// Explicit login and logout share the refresh lock, preventing token resurrection.
+    pub async fn store_session(
+        &self,
+        store: &dyn SecretStore,
+        token: &str,
+    ) -> Result<(), TokenLifecycleError> {
+        let _guard = self.refresh_lock.lock().await;
+        store
+            .set_secret(CLOUD_REFRESH_TOKEN_KEY, token)
+            .map_err(|err| TokenLifecycleError::Internal(err.to_string()))?;
+        self.terminated.store(false, Ordering::SeqCst);
+        self.clear_cache().await;
+        let _ = store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
+        Ok(())
+    }
+
+    /// Explicit logout removes persistent credentials and stops future refreshes.
+    pub async fn clear_session(
+        &self,
+        store: &dyn SecretStore,
+    ) -> Result<bool, TokenLifecycleError> {
+        self.clear_session_with(store, || async {}).await
+    }
+
+    /// Keep worker shutdown in the same transition as credential cleanup so a
+    /// replacement login cannot start a worker that the old logout then aborts.
+    pub async fn clear_session_with<F, Fut>(
+        &self,
+        store: &dyn SecretStore,
+        after_clear: F,
+    ) -> Result<bool, TokenLifecycleError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let _guard = self.refresh_lock.lock().await;
+        let result = self.clear_session_locked(store).await;
+        after_clear().await;
+        result.map(|_| true)
+    }
+
+    async fn clear_session_locked(
+        &self,
+        store: &dyn SecretStore,
+    ) -> Result<(), TokenLifecycleError> {
+        self.terminated.store(true, Ordering::SeqCst);
+        self.clear_cache().await;
+        let _ = store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
+        store
+            .delete_secret(CLOUD_REFRESH_TOKEN_KEY)
+            .map_err(|err| TokenLifecycleError::Internal(err.to_string()))
     }
 
     pub async fn clear_cache(&self) {
@@ -107,11 +176,12 @@ pub async fn ensure_valid_access_token(
     state: &TokenLifecycleState,
     config: Option<&TokenLifecycleConfig>,
 ) -> Result<String, TokenLifecycleError> {
-    if let Some(token) = read_cached_token(state).await {
-        return Ok(token);
-    }
-
     let _refresh_guard = state.refresh_lock.lock().await;
+    if state.terminated.load(Ordering::SeqCst) {
+        return Err(TokenLifecycleError::Unauthorized(
+            "Cloud session has ended. Please sign in again.".to_string(),
+        ));
+    }
 
     if let Some(token) = read_cached_token(state).await {
         return Ok(token);
@@ -165,9 +235,7 @@ pub async fn ensure_valid_access_token(
         }
         Err(err) => {
             if err.is_session_invalid() {
-                let _ = secret_store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
-                let _ = secret_store.delete_secret(CLOUD_REFRESH_TOKEN_KEY);
-                state.clear_cache().await;
+                state.clear_session_locked(secret_store).await?;
                 return Err(TokenLifecycleError::Unauthorized(format!(
                     "Session expired. Please sign in again. ({})",
                     err.message
@@ -426,5 +494,134 @@ mod tests {
             fallback_refresh_error_message(400, "non-json response: invalid refresh token");
 
         assert!(is_session_invalid(400, "", &message));
+    }
+    #[derive(Default)]
+    struct MemorySecrets(std::sync::Mutex<std::collections::HashMap<String, String>>);
+
+    impl SecretStore for MemorySecrets {
+        fn get_secret(&self, key: &str) -> wealthfolio_core::errors::Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+        fn set_secret(&self, key: &str, value: &str) -> wealthfolio_core::errors::Result<()> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+        fn delete_secret(&self, key: &str) -> wealthfolio_core::errors::Result<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn logout_clears_credentials_even_without_a_ui_listener() {
+        let store = MemorySecrets::default();
+        let state = TokenLifecycleState::new();
+        state.store_session(&store, "account-a").await.unwrap();
+        state.clear_session(&store).await.unwrap();
+        assert!(!state.is_session_configured(&store).unwrap());
+        assert!(!TokenLifecycleState::new()
+            .is_session_configured(&store)
+            .unwrap());
+        assert!(ensure_valid_access_token(&store, &state, None)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn termination_waits_for_refresh_and_removes_rotated_credentials() {
+        use std::io::{Read, Write};
+        use std::sync::Arc;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let config = TokenLifecycleConfig::new(
+            format!("http://{}", listener.local_addr().unwrap()),
+            "test-key".into(),
+        );
+        let (received_tx, received_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 4096];
+            stream.read(&mut request).unwrap();
+            received_tx.send(()).unwrap();
+            release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            let body = r#"{"access_token":"test-access","refresh_token":"rotated-refresh","expires_in":3600}"#;
+            write!(stream, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body).unwrap();
+        });
+        let state = Arc::new(TokenLifecycleState::new());
+        let store = Arc::new(MemorySecrets::default());
+        state
+            .store_session(store.as_ref(), "original-refresh")
+            .await
+            .unwrap();
+        let refresh = tokio::spawn({
+            let state = Arc::clone(&state);
+            let store = Arc::clone(&store);
+            async move { ensure_valid_access_token(store.as_ref(), &state, Some(&config)).await }
+        });
+        received_rx.await.unwrap();
+        let mut terminate = tokio::spawn({
+            let state = Arc::clone(&state);
+            let store = Arc::clone(&store);
+            async move { state.clear_session(store.as_ref()).await }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut terminate)
+                .await
+                .is_err()
+        );
+        release_tx.send(()).unwrap();
+        refresh.await.unwrap().unwrap();
+        terminate.await.unwrap().unwrap();
+        assert!(store.get_secret(CLOUD_REFRESH_TOKEN_KEY).unwrap().is_none());
+        assert!(state.cache.read().await.is_none());
+        assert!(!state.is_session_configured(store.as_ref()).unwrap());
+        server.join().unwrap();
+    }
+    #[tokio::test]
+    async fn replacement_login_waits_until_old_worker_shutdown_finishes() {
+        use std::sync::Arc;
+        let state = Arc::new(TokenLifecycleState::new());
+        let store = Arc::new(MemorySecrets::default());
+        state
+            .store_session(store.as_ref(), "account-a")
+            .await
+            .unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let terminate = tokio::spawn({
+            let state = Arc::clone(&state);
+            let store = Arc::clone(&store);
+            async move {
+                state
+                    .clear_session_with(store.as_ref(), || async {
+                        shutdown_tx.send(()).unwrap();
+                        release_rx.await.unwrap();
+                    })
+                    .await
+            }
+        });
+        shutdown_rx.await.unwrap();
+        let mut login = tokio::spawn({
+            let state = Arc::clone(&state);
+            let store = Arc::clone(&store);
+            async move { state.store_session(store.as_ref(), "account-b").await }
+        });
+        assert!(tokio::time::timeout(Duration::from_millis(20), &mut login)
+            .await
+            .is_err());
+        release_tx.send(()).unwrap();
+        terminate.await.unwrap().unwrap();
+        login.await.unwrap().unwrap();
+        assert_eq!(
+            store
+                .get_secret(CLOUD_REFRESH_TOKEN_KEY)
+                .unwrap()
+                .as_deref(),
+            Some("account-b")
+        );
+        assert!(state.is_session_configured(store.as_ref()).unwrap());
     }
 }

--- a/crates/connect/src/token_lifecycle.rs
+++ b/crates/connect/src/token_lifecycle.rs
@@ -544,7 +544,7 @@ mod tests {
         let server = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut request = [0; 4096];
-            stream.read(&mut request).unwrap();
+            assert!(stream.read(&mut request).unwrap() > 0);
             received_tx.send(()).unwrap();
             release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
             let body = r#"{"access_token":"test-access","refresh_token":"rotated-refresh","expires_in":3600}"#;

--- a/crates/device-sync/Cargo.toml
+++ b/crates/device-sync/Cargo.toml
@@ -37,4 +37,4 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/device-sync/src/engine/mod.rs
+++ b/crates/device-sync/src/engine/mod.rs
@@ -223,6 +223,28 @@ where
         pulled_count: 0,
     };
 
+    match ports.is_sync_allowed().await {
+        Ok(true) => {}
+        Ok(false) => {
+            return ctx
+                .fail(
+                    "subscription_required",
+                    "Device sync is paused: an active subscription is required.".to_string(),
+                    Some(300),
+                )
+                .await
+        }
+        Err(err) => {
+            return ctx
+                .fail(
+                    "subscription_check_error",
+                    format!("Could not verify sync subscription: {}", err),
+                    Some(60),
+                )
+                .await
+        }
+    }
+
     let identity = match ports.get_sync_identity() {
         Some(value) => value,
         None => {
@@ -309,6 +331,11 @@ where
     let reconcile = match ports.get_reconcile_ready_state(&token, &device_id).await {
         Ok(response) => response,
         Err(err) => {
+            if err.is_subscription_blocked() {
+                return ctx
+                    .fail("subscription_required", err.to_string(), Some(300))
+                    .await;
+            }
             return ctx
                 .fail(
                     "reconcile_error",
@@ -567,6 +594,11 @@ where
                 server_cursor = push_response.server_cursor;
             }
             Err(err) => {
+                if err.is_subscription_blocked() {
+                    return ctx
+                        .fail("subscription_required", err.to_string(), Some(300))
+                        .await;
+                }
                 let err_str = err.to_string();
 
                 if err_str.contains("KEY_VERSION_MISMATCH") {
@@ -721,6 +753,11 @@ where
             {
                 Ok(value) => value,
                 Err(err) => {
+                    if err.is_subscription_blocked() {
+                        return ctx
+                            .fail("subscription_required", err.to_string(), Some(300))
+                            .await;
+                    }
                     if err.retry_class == ApiRetryClass::ReauthRequired {
                         warn!("[DeviceSync] Auth error during pull — token may need refresh");
                         return ctx
@@ -1153,8 +1190,13 @@ where
     P: OutboxStore + ReplayStore + Send + Sync,
 {
     let mut delay_ms = DEVICE_SYNC_PERIODIC_INTERVAL_SECS.saturating_mul(1000) + jitter_ms;
+    let mut subscription_paused = false;
 
     if let Ok(engine_status) = ports.get_engine_status().await {
+        subscription_paused = matches!(
+            engine_status.last_cycle_status.as_deref(),
+            Some("subscription_required" | "subscription_check_error")
+        );
         if let Some(next_retry_at) = engine_status.next_retry_at.as_deref() {
             if let Some(wait_ms) = millis_until_rfc3339(next_retry_at) {
                 delay_ms = wait_ms.saturating_add(jitter_ms).max(1_000);
@@ -1162,7 +1204,7 @@ where
         }
     }
 
-    if ports.has_pending_outbox().await.unwrap_or(false) {
+    if !subscription_paused && ports.has_pending_outbox().await.unwrap_or(false) {
         delay_ms = delay_ms.min(2_000 + (jitter_ms % 500));
     }
 
@@ -1245,6 +1287,20 @@ where
     let mut next_prune_at =
         tokio::time::Instant::now() + Duration::from_secs(DEVICE_SYNC_OUTBOX_PRUNE_INTERVAL_SECS);
     loop {
+        // A wake can race logout's startup check. Never keep a worker alive
+        // without a session, even if it was spawned just after shutdown.
+        match ports.has_cloud_session() {
+            Ok(true) => {}
+            Ok(false) => break,
+            Err(err) => {
+                warn!(
+                    "[DeviceSync] Could not read cloud session; retrying: {}",
+                    err
+                );
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                continue;
+            }
+        }
         let identity = ports.get_sync_identity();
         if !sync_identity_can_run_background(identity.clone()) {
             if sync_identity_is_revoked(identity) {
@@ -1316,6 +1372,9 @@ mod tests {
 
     #[derive(Clone)]
     struct TestPorts {
+        has_cloud_session: bool,
+        session_read_results: Arc<std::sync::Mutex<VecDeque<Result<bool, String>>>>,
+        sync_allowed: Result<bool, String>,
         cursor: i64,
         identity: Option<SyncIdentity>,
         sync_state: Result<SyncState, String>,
@@ -1340,6 +1399,9 @@ mod tests {
     impl TestPorts {
         fn new(identity: Option<SyncIdentity>, sync_state: Result<SyncState, String>) -> Self {
             Self {
+                has_cloud_session: true,
+                session_read_results: Arc::new(std::sync::Mutex::new(VecDeque::new())),
+                sync_allowed: Ok(true),
                 cursor: 0,
                 identity,
                 sync_state,
@@ -1498,7 +1560,7 @@ mod tests {
                 last_error: None,
                 consecutive_failures: 0,
                 next_retry_at: None,
-                last_cycle_status: None,
+                last_cycle_status: self.cycle_outcomes.lock().await.last().cloned(),
                 last_cycle_duration_ms: None,
             })
         }
@@ -1585,6 +1647,18 @@ mod tests {
 
     #[async_trait]
     impl CredentialStore for TestPorts {
+        fn has_cloud_session(&self) -> Result<bool, String> {
+            self.session_read_results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(Ok(self.has_cloud_session))
+        }
+
+        async fn is_sync_allowed(&self) -> Result<bool, String> {
+            self.sync_allowed.clone()
+        }
+
         fn get_sync_identity(&self) -> Option<SyncIdentity> {
             self.identity.clone()
         }
@@ -1679,6 +1753,120 @@ mod tests {
             );
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
+    }
+
+    #[tokio::test]
+    async fn inactive_subscription_preserves_pending_changes_and_resumes() {
+        let mut ports = TestPorts::new(Some(ready_identity()), Ok(SyncState::Ready));
+        ports.sync_allowed = Ok(false);
+        ports.pending_outbox.lock().await.push(outbox_event(
+            "event-1",
+            "019cb093-06a8-7534-8677-546317b17957",
+            1,
+        ));
+        let paused = run_sync_cycle(&ports, false).await.unwrap();
+        assert_eq!(paused.status, "subscription_required");
+        assert_eq!(ports.pending_outbox.lock().await.len(), 1);
+        assert!(ports.persisted_trust_states.lock().await.is_empty());
+        assert_eq!(ports.max_active_reconcile_count.load(Ordering::SeqCst), 0);
+        assert!(compute_cycle_delay_ms(&ports, 0).await >= 300_000);
+        ports.sync_allowed = Ok(true);
+        let resumed = run_sync_cycle(&ports, false).await.unwrap();
+        assert_eq!(resumed.status, "ok");
+        assert_eq!(ports.push_batches.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn subscription_denied_during_push_preserves_pending_changes() {
+        let mut ports = TestPorts::new(Some(ready_identity()), Ok(SyncState::Ready));
+        ports.push_error = Some(TransportError {
+            message: "Subscription required".to_string(),
+            retry_class: ApiRetryClass::Permanent,
+            error_code: Some("SUBSCRIPTION_REQUIRED".to_string()),
+            details: None,
+        });
+        ports.pending_outbox.lock().await.push(outbox_event(
+            "event-1",
+            "019cb093-06a8-7534-8677-546317b17957",
+            1,
+        ));
+        assert_eq!(
+            run_sync_cycle(&ports, false).await.unwrap().status,
+            "subscription_required"
+        );
+        assert_eq!(ports.pending_outbox.lock().await.len(), 1);
+        assert!(ports.dead_outbox_batches.lock().await.is_empty());
+        ports.push_error = None;
+        assert_eq!(run_sync_cycle(&ports, false).await.unwrap().status, "ok");
+        assert_eq!(
+            *ports.push_batches.lock().await,
+            vec![vec!["event-1".to_string()], vec!["event-1".to_string()]]
+        );
+    }
+
+    #[tokio::test]
+    async fn subscription_lookup_failure_cannot_push_or_pull() {
+        let mut ports = TestPorts::new(Some(ready_identity()), Ok(SyncState::Ready));
+        ports.sync_allowed = Err("service unavailable".to_string());
+        assert_eq!(
+            run_sync_cycle(&ports, false).await.unwrap().status,
+            "subscription_check_error"
+        );
+        assert!(ports.push_batches.lock().await.is_empty());
+        assert!(ports.applied_events.lock().await.is_empty());
+        assert!(ports.persisted_trust_states.lock().await.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn background_recovers_from_session_read_error_without_a_wake() {
+        let ports = Arc::new(TestPorts::new(Some(ready_identity()), Ok(SyncState::Ready)));
+        ports
+            .session_read_results
+            .lock()
+            .unwrap()
+            .push_back(Err("storage unavailable".into()));
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        tokio::task::yield_now().await;
+        assert!(runtime.is_background_running().await);
+        assert!(ports.cycle_outcomes.lock().await.is_empty());
+        tokio::time::advance(Duration::from_secs(59)).await;
+        assert!(ports.cycle_outcomes.lock().await.is_empty());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        wait_for_cycle_outcomes(&ports, 1, 1_000).await;
+        assert_eq!(ports.cycle_outcomes.lock().await[0], "ok");
+        runtime.ensure_background_stopped().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn background_stops_if_session_is_missing_after_read_error() {
+        let ports = Arc::new(TestPorts::new(Some(ready_identity()), Ok(SyncState::Ready)));
+        ports
+            .session_read_results
+            .lock()
+            .unwrap()
+            .extend([Err("storage unavailable".into()), Ok(false)]);
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(60)).await;
+        wait_for_background_stopped(&runtime, 1_000).await;
+        assert!(ports.cycle_outcomes.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn background_wake_without_session_exits_without_cloud_requests() {
+        let mut ports = TestPorts::new(Some(ready_identity()), Ok(SyncState::Ready));
+        ports.has_cloud_session = false;
+        let ports = Arc::new(ports);
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+        for _ in 0..2 {
+            runtime.ensure_background_started(Arc::clone(&ports)).await;
+            runtime.notify_sync_work_available();
+            wait_for_background_stopped(&runtime, 1_000).await;
+        }
+        assert!(ports.cycle_outcomes.lock().await.is_empty());
+        assert_eq!(ports.max_active_reconcile_count.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]

--- a/crates/device-sync/src/engine/ports.rs
+++ b/crates/device-sync/src/engine/ports.rs
@@ -76,6 +76,14 @@ pub struct TransportError {
     pub details: Option<serde_json::Value>,
 }
 
+impl TransportError {
+    pub fn is_subscription_blocked(&self) -> bool {
+        self.error_code
+            .as_deref()
+            .is_some_and(|code| code.starts_with("SUBSCRIPTION_"))
+    }
+}
+
 impl std::fmt::Display for TransportError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)
@@ -167,6 +175,8 @@ pub trait SyncTransport: Send + Sync {
 
 #[async_trait]
 pub trait CredentialStore: Send + Sync {
+    fn has_cloud_session(&self) -> Result<bool, String>;
+    async fn is_sync_allowed(&self) -> Result<bool, String>;
     fn get_sync_identity(&self) -> Option<SyncIdentity>;
     fn get_access_token(&self) -> Result<String, String>;
     async fn get_sync_state(&self) -> Result<SyncState, String>;

--- a/crates/device-sync/src/error.rs
+++ b/crates/device-sync/src/error.rs
@@ -145,7 +145,7 @@ impl DeviceSyncError {
         match self {
             Self::Api { status, .. } => match *status {
                 401 | 403 => ApiRetryClass::ReauthRequired,
-                408 | 409 | 423 | 425 | 429 => ApiRetryClass::Retryable,
+                402 | 408 | 409 | 423 | 425 | 429 => ApiRetryClass::Retryable,
                 500..=599 => ApiRetryClass::Retryable,
                 _ => ApiRetryClass::Permanent,
             },


### PR DESCRIPTION
## Description

Keep users signed in when their Connect subscription is inactive or missing. Show pricing and an explicit sync-paused message while broker sync, device transfers, and snapshots wait for subscription access. Preserve queued changes when access is denied during a push, and resume without requiring another login.

The change also coordinates backend token storage/logout, retries temporary credential-read and sync-startup failures, and makes Connect navigation consistent across desktop and mobile. Portal controls use external-link icons and the platform browser adapter; icon-only controls have accessible labels and larger mobile touch targets. All new UI text is translated across the 10 supported locales.

## Commit guide

1. Scope web-auth permissions to iOS, avoiding the Android capability mismatch.
2. Serialize backend token persistence, refresh, and logout cleanup.
3. Gate subscription sync and recover from transient failures while preserving sessions and queued events.
4. Show pricing, paused-state explanations, and the subscription warning icon.
5. Unify portal navigation and improve mobile controls and external-link event composition.
6. Translate remaining captions and sync notifications.

## Behavior decisions

- Sync is allowed for active, trialing, and past_due subscriptions. Allowing past_due is a change from the previous active/trialing policy.
- Explicit logout uses Supabase local scope; other sessions remain signed in.
- Subscription lookup failures pause transfers and offer retry; they do not clear authentication.

## Validation

- Independent full review found no additional confirmed actionable regressions.
- Before rebasing: full frontend suite passed (1,996 tests), Rust Connect/device-sync tests passed, web/Tauri builds and desktop/server/iOS simulator/Android ARM64 compile checks passed.
- Translation audit: 370 referenced keys across 10 locales, with no missing values or mismatched interpolation placeholders in Connect scope.
- Rebased onto current main; preserved upstream Traditional Chinese wording when resolving the only conflict.
- After rebasing: workspace type generation and the web production build passed.
- Post-rebase frontend suite: 2,210 passed; two tests timed out (market-data provider form and spending date picker). Both affected files passed on isolated reruns (4 and 6 tests respectively); no application code was changed for these timeouts.
- A local post-rebase Rust rerun was canceled while waiting on another Cargo process's artifact lock. GitHub Frontend Check and Rust Check are running; the successful pre-rebase Rust/native validation is listed above.

Physical-device OAuth, background/resume, secure-storage failure recovery, and logout after backend token rotation still need manual verification.
