### PR TITLE
feat(custom-provider): support unix timestamp (%s) in date placeholders

### DIFF
--- a/apps/frontend/src/pages/settings/market-data/source-config-panel.tsx
+++ b/apps/frontend/src/pages/settings/market-data/source-config-panel.tsx
@@ -43,11 +43,15 @@ const PLACEHOLDERS = [
   "{currency}",
   "{TODAY}",
   "{TODAY:%Y-%m-%d}",
+  "{TODAY:%s}",
   "{FROM}",
   "{FROM:%Y-%m-%d}",
+  "{FROM:%s}",
   "{TO}",
   "{TO:%Y-%m-%d}",
+  "{TO:%s}",
   "{DATE:%Y-%m-%d}",
+  "{DATE:%s}",
 ];
 
 const SOURCE_TYPES: {

--- a/apps/frontend/src/pages/settings/market-data/template-placeholders.test.ts
+++ b/apps/frontend/src/pages/settings/market-data/template-placeholders.test.ts
@@ -15,6 +15,18 @@ describe("template placeholders", () => {
     ).toBe("20240102/04/03/2024/2024/2024-06-15");
   });
 
+  it("expands %s to unix timestamp in seconds", () => {
+    expect(
+      expandTemplatePlaceholders(
+        "{FROM:%s}/{TO:%s}/{TODAY:%s}",
+        { FROM: "2024-01-02", TO: "2024-03-04", TODAY: "2024-01-02" },
+        now,
+      ),
+    ).toBe("1704153600/1709510400/1704153600");
+    const dateValue = expandTemplatePlaceholders("{DATE:%s}", {}, now);
+    expect(dateValue).toBe(String(Math.floor(now.getTime() / 1000)));
+  });
+
   it("keeps unknown placeholders unchanged", () => {
     expect(expandTemplatePlaceholders("{SYMBOL}/{UNKNOWN:%Q}", { SYMBOL: "AAPL" }, now)).toBe(
       "AAPL/{UNKNOWN:%Q}",

--- a/apps/frontend/src/pages/settings/market-data/template-placeholders.ts
+++ b/apps/frontend/src/pages/settings/market-data/template-placeholders.ts
@@ -15,10 +15,11 @@ const DATE_PARTS: Record<string, (date: Date) => string> = {
   Y: (date) => String(date.getUTCFullYear()).padStart(4, "0"),
   m: (date) => String(date.getUTCMonth() + 1).padStart(2, "0"),
   d: (date) => String(date.getUTCDate()).padStart(2, "0"),
+  s: (date) => String(Math.floor(date.getTime() / 1000)),
 };
 
 function formatStrftime(format: string, date: Date): string {
-  return format.replace(/%([Ymd])/g, (match, token: string) => {
+  return format.replace(/%([Ymds])/g, (match, token: string) => {
     return DATE_PARTS[token]?.(date) ?? match;
   });
 }
@@ -29,7 +30,7 @@ function hasUnsupportedStrftimeDirective(format: string): boolean {
   while (!character.done) {
     if (character.value === "%") {
       const directive = characters.next();
-      if (directive.done || !["Y", "m", "d"].includes(directive.value)) return true;
+      if (directive.done || !["Y", "m", "d", "s"].includes(directive.value)) return true;
     }
     character = characters.next();
   }

--- a/crates/core/src/custom_provider/model.rs
+++ b/crates/core/src/custom_provider/model.rs
@@ -90,7 +90,7 @@ fn has_unsupported_date_directive(variable: &str, format: &str) -> bool {
 
     let mut chars = format.chars();
     while let Some(character) = chars.next() {
-        if character == '%' && !matches!(chars.next(), Some('Y' | 'm' | 'd')) {
+        if character == '%' && !matches!(chars.next(), Some('Y' | 'm' | 'd' | 's')) {
             return true;
         }
     }
@@ -108,8 +108,8 @@ pub(crate) enum PrepareRequestError<E> {
 /// Supported variables: `{SYMBOL}`, `{currency}`, `{CURRENCY}`, `{TODAY}`,
 /// `{FROM}`, `{TO}`, `{ISIN}`, `{MIC}`, `{DATE:format}`,
 /// `{FROM:format}`, `{TO:format}`, `{TODAY:format}`. `DATE` accepts any
-/// valid Chrono directive; the date-only variables support `%Y`, `%m`, and
-/// `%d`.
+/// valid Chrono directive; the date-only variables support `%Y`, `%m`, `%d`,
+/// and `%s`.
 pub fn expand_template(
     template: &str,
     ctx: &TemplateContext<'_>,
@@ -166,7 +166,12 @@ pub fn expand_template(
                 };
                 // Parse the ISO date and reformat; fall back to the raw string.
                 match chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
-                    Ok(parsed) => parsed.format(format).to_string(),
+                    Ok(parsed) => parsed
+                        .and_hms_opt(0, 0, 0)
+                        .expect("midnight is always valid")
+                        .and_utc()
+                        .format(format)
+                        .to_string(),
                     Err(_) => date_str.to_string(),
                 }
             })
@@ -571,6 +576,13 @@ mod tests {
         let c = ctx(Some("2024-01-02"), Some("2024-03-04"));
         let out = expand_template("{FROM:%Y%m%d}-{TO:%d/%m/%Y}", &c).unwrap();
         assert_eq!(out, "20240102-04/03/2024");
+    }
+
+    #[test]
+    fn expands_formatted_from_and_to_unix_timestamp() {
+        let c = ctx(Some("2024-01-02"), Some("2024-03-04"));
+        let out = expand_template("{FROM:%s}-{TO:%s}", &c).unwrap();
+        assert_eq!(out, "1704153600-1709510400");
     }
 
     #[test]


### PR DESCRIPTION
## Description

**Problem:** some price APIs [tonapi.io](https://tonapi.io) expect unix timestamps in their date query params instead of formatted dates:

`https://tonapi.io/v2/rates/chart?token=GRAM&currency=usd&start_date=1767225600&end_date=1788998400&points_count=200`

Custom providers had no way to produce those values, date placeholders only supported `%Y` / `%m` / `%d`, so there was no way to emit `start_date` / `end_date` as timestamps.

**Fix:** support `%s` unix timestamp in seconds in custom-provider date placeholders: `{FROM:%s}`, `{TO:%s}`, `{TODAY:%s}`, `{DATE:%s}`:
- `FROM` / `TO` / `TODAY` resolve at `00:00:00 UTC`, `FROM = 2024-01-02` -> `1704153600`

Response-side auto `date_format` already parses bare unix timestamps

## Checklist


- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).


By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).