### PR TITLE
fix: show activity currency on transfer match cards

### DIFF
--- a/apps/frontend/src/pages/activity/components/transfer-match-dialog.test.tsx
+++ b/apps/frontend/src/pages/activity/components/transfer-match-dialog.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { findTransferMatchCandidates } from "@/adapters";
+import { ActivityStatus } from "@/lib/constants";
+import type { Account, Activity } from "@/lib/types";
+import { render, screen, within } from "@/test/render";
+import { TransferMatchDialog } from "./transfer-match-dialog";
+
+vi.mock("@/adapters", () => ({
+  findTransferMatchCandidates: vi.fn(),
+  getTransferPairForActivity: vi.fn(),
+  searchActivities: vi.fn(),
+  logger: { warn: vi.fn() },
+}));
+vi.mock("../hooks/use-activity-mutations", () => ({
+  useActivityMutations: () => ({
+    linkTransferActivitiesMutation: { isPending: false },
+    unlinkTransferActivitiesMutation: { isPending: false },
+    updateActivityMutation: { isPending: false },
+  }),
+}));
+
+const timestamp = "2026-04-01T00:00:00+00:00";
+const account: Account = {
+  id: "synthetic-account",
+  name: "Synthetic account",
+  accountType: "SECURITIES",
+  balance: 0,
+  currency: "USD",
+  isDefault: false,
+  isActive: true,
+  isArchived: false,
+  trackingMode: "TRANSACTIONS",
+  createdAt: new Date(timestamp),
+  updatedAt: new Date(timestamp),
+};
+const activity: Activity = {
+  id: "synthetic-transfer",
+  accountId: account.id,
+  activityType: "TRANSFER_OUT",
+  status: ActivityStatus.POSTED,
+  activityDate: timestamp,
+  amount: "105.31",
+  currency: "CAD",
+  isUserModified: false,
+  needsReview: false,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+};
+
+function renderActivity(overrides: Partial<Activity> = {}) {
+  return render(
+    <TransferMatchDialog
+      open
+      mode="link"
+      sourceActivity={{ ...activity, ...overrides }}
+      accounts={[account, { ...account, id: "candidate-account", name: "Candidate account" }]}
+      onOpenChange={vi.fn()}
+    />,
+  );
+}
+
+describe("transfer activity summary", () => {
+  beforeEach(() => {
+    vi.mocked(findTransferMatchCandidates).mockResolvedValue([]);
+  });
+
+  it("labels cash source and suggested transfers with their activity currency", async () => {
+    vi.mocked(findTransferMatchCandidates).mockResolvedValue([
+      {
+        activity: {
+          ...activity,
+          id: "synthetic-candidate",
+          accountId: "candidate-account",
+          activityType: "TRANSFER_IN",
+        },
+        matchKind: "cash",
+        confidence: "high",
+        score: 100,
+        reasons: ["Same currency"],
+        warnings: [],
+      },
+    ]);
+    renderActivity();
+
+    const reason = await screen.findByText("Same currency");
+    const candidate = reason.closest("button");
+    expect(candidate).not.toBeNull();
+    expect(within(candidate!).getByText("CAD")).toBeInTheDocument();
+    expect(screen.getAllByText("CA$105.31")).toHaveLength(2);
+    expect(screen.getAllByText("CAD", { selector: "span" })).toHaveLength(2);
+    expect(screen.queryByText("USD", { selector: "span" })).not.toBeInTheDocument();
+  });
+
+  it("preserves the security quantity and symbol label", async () => {
+    renderActivity({ assetId: "SYNTHETIC", quantity: "2" });
+    expect(screen.getByText("2 SYNTHETIC")).toBeInTheDocument();
+    await screen.findByText("No matches within 7 days of this activity.");
+  });
+});

--- a/apps/frontend/src/pages/activity/components/transfer-match-dialog.tsx
+++ b/apps/frontend/src/pages/activity/components/transfer-match-dialog.tsx
@@ -337,7 +337,7 @@ function ActivitySummaryRow({
       <div className="text-muted-foreground flex items-center justify-between gap-3 text-xs">
         <span className="min-w-0 truncate">{normalized.notes || symbol}</span>
         <span className="shrink-0">
-          {quantity != null ? `${Math.abs(quantity)} ${symbol}` : normalized.accountCurrency}
+          {quantity != null ? `${Math.abs(quantity)} ${symbol}` : normalized.currency}
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Description

Partial fix for #1701: display the activity currency on cash transfer summary
cards, matching the currency already used to format their amounts. Preserve the
quantity/symbol label for security transfers. This does not address the separate
date/import behavior in the issue and intentionally does not close it.

Add real-dialog component coverage for the source activity, asynchronously loaded
suggested candidate, displayed amounts and security quantity label. Fixtures are
synthetic; only backend adapters and mutations are mocked.

### Validation

- Regression failed before the fix and passes afterward.
- Frozen pnpm10.33.4 install, formatting, lint and workspace type checks passed.
- Web and Tauri frontend builds passed; no Rust/backend change.
- CI-matching Node24.18.1: 263 test files, 2218 tests passed.
- Net-worth layout E2E: 48 passed.

### Upstream validation (September 12)

Addon-sandbox E2E remains incomplete locally: 1 passed / 8 failed. Six failures
are missing pinned Firefox/WebKit binaries; two Chromium failures involve an
inline WOFF2 fixture and duplicate runtime payload behavior. Running the same
build and E2E command with the product change removed produces the same failures.
No unrelated sandbox changes were made. The baseline comparison alone was not
treated as a successful E2E gate.

The upstream [PR Check run](https://github.com/wealthfolio/wealthfolio/actions/runs/34603337468)
has now passed for commit `16611da017d5bef527cd92a31b81997a846a6194`.
The Frontend Check installed all sandbox browsers and passed 2218 unit tests,
48 net-worth E2E tests and all 9 addon-sandbox E2E tests. Rust Check and Build
Status also passed. This resolves the draft's validation gate in upstream CI;
the local environment limitations above remain documented.

AI assistance: implemented, tested and reviewed with OpenAI Codex. This does not
imply manual human review.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
