### PR TITLE
fix(speding-activities): prevent iPhone expense from being zero

### DIFF
--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -1184,7 +1184,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
                 {t("spending:txTab.clearFilters")}
               </Button>
             ) : (
-              <Button onClick={openAddForm}>
+              <Button type="button" onClick={openAddForm}>
                 <Icons.Plus className="mr-2 h-4 w-4" aria-hidden="true" />
                 {t("spending:txTab.addTransaction")}
               </Button>

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -1,97 +1,97 @@
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { toast } from "sonner";
-import { useSearchParams } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import type { DateRange } from "react-day-picker";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
 
 import { createActivity, deleteActivity, updateActivity } from "@/adapters";
-import { generateId } from "@/lib/id";
-import { useAccounts } from "@/hooks/use-accounts";
-import { useIsMobileViewport } from "@/hooks/use-platform";
-import { useVirtualScrollContainer } from "@/hooks/use-virtual-scroll-container";
-import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { InfiniteScrollTrigger } from "@/components/infinite-scroll-trigger";
+import { useAccounts } from "@/hooks/use-accounts";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
+import { useVirtualScrollContainer } from "@/hooks/use-virtual-scroll-container";
+import { generateId } from "@/lib/id";
 import { QueryKeys } from "@/lib/query-keys";
-import { formatDateISO } from "@/lib/utils";
-import type { Account, ActivityDetails, TaxonomyCategory } from "@/lib/types";
 import { useSettingsContext } from "@/lib/settings-provider";
+import type { Account, ActivityDetails, TaxonomyCategory } from "@/lib/types";
+import { formatDateISO } from "@/lib/utils";
 
 import {
-  Button,
-  Checkbox,
-  EmptyPlaceholder,
-  Icons,
-  Skeleton,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+    Button,
+    Checkbox,
+    EmptyPlaceholder,
+    Icons,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
 } from "@wealthfolio/ui";
 
-import { CashActivityForm } from "./cash-activity-form";
+import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
+import { ActivityType } from "@/lib/constants";
 import { ActivityForm } from "@/pages/activity/components/activity-form";
 import { MobileActivityForm } from "@/pages/activity/components/mobile-forms/mobile-activity-form";
 import { TransferMatchDialog } from "@/pages/activity/components/transfer-match-dialog";
-import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
-import { ActivityType } from "@/lib/constants";
-import type { AmountRange } from "./amount-range-filter";
-import { DeleteTransactionsDialog, type DeletePreview } from "./delete-transactions-dialog";
-import { TransactionCard } from "./transaction-card";
-import { SelectionToolbar } from "./selection-toolbar";
-import { TransactionDayHeader, TransactionDayHeading } from "./transaction-day-header";
-import { TransactionRow } from "./transaction-row";
-import { SplitTransactionSheet } from "./split-transaction-sheet";
-import { TransactionsBulkBar } from "./transactions-bulk-bar";
-import { TransactionsFilterBar, type FilterOption } from "./transactions-filter-bar";
-import type { QuickCategorizeScope } from "./quick-categorize-popover";
 import {
-  CASH_ACTIVITY_TYPES,
-  CASH_ACTIVITY_TYPE_LABELS,
-  getEffectiveCashActivityType,
-  isCreditCardAccountType,
-  isSpendingAccountType,
-} from "../lib/constants";
-import { cashActivityFlowMetadata } from "../lib/cash-activity-form-utils";
-import {
-  isTransferCashActivity,
-  stableArr,
-  toRowVM,
-  groupRowsByDay,
-  flattenDayGroups,
-  netSummary,
-  type TransactionDayGroup,
-  type TransactionRowVM,
-} from "../lib/transactions-helpers";
-import { useCashActivitySearch } from "../hooks/use-cash-activity-search";
-import {
-  useAssignActivityCategory,
-  useBulkAssignCategories,
-  useClearActivitySplits,
-  useReplaceActivitySplits,
-  useSetActivityEvent,
-  useUnassignActivityCategory,
+    useAssignActivityCategory,
+    useBulkAssignCategories,
+    useClearActivitySplits,
+    useReplaceActivitySplits,
+    useSetActivityEvent,
+    useUnassignActivityCategory,
 } from "../hooks/use-cash-activities";
+import { useCashActivitySearch } from "../hooks/use-cash-activity-search";
 import { useEventTypes, useSpendingEvents } from "../hooks/use-spending-events";
 import { useSpendingSettings } from "../hooks/use-spending-settings";
+import { cashActivityFlowMetadata } from "../lib/cash-activity-form-utils";
+import {
+    CASH_ACTIVITY_TYPES,
+    CASH_ACTIVITY_TYPE_LABELS,
+    getEffectiveCashActivityType,
+    isCreditCardAccountType,
+    isSpendingAccountType,
+} from "../lib/constants";
 import { invalidateSpendingCaches } from "../lib/invalidation";
+import {
+    flattenDayGroups,
+    groupRowsByDay,
+    isTransferCashActivity,
+    netSummary,
+    stableArr,
+    toRowVM,
+    type TransactionDayGroup,
+    type TransactionRowVM,
+} from "../lib/transactions-helpers";
 import type {
-  CashActivitySearchRequest,
-  CashActivityStatusFilter,
-  NewActivitySplit,
+    CashActivitySearchRequest,
+    CashActivityStatusFilter,
+    NewActivitySplit,
 } from "../types/cash-activity";
+import type { AmountRange } from "./amount-range-filter";
+import { CashActivityForm } from "./cash-activity-form";
+import { DeleteTransactionsDialog, type DeletePreview } from "./delete-transactions-dialog";
+import type { QuickCategorizeScope } from "./quick-categorize-popover";
+import { SelectionToolbar } from "./selection-toolbar";
+import { SplitTransactionSheet } from "./split-transaction-sheet";
+import { TransactionCard } from "./transaction-card";
+import { TransactionDayHeader, TransactionDayHeading } from "./transaction-day-header";
+import { TransactionRow } from "./transaction-row";
+import { TransactionsBulkBar } from "./transactions-bulk-bar";
+import { TransactionsFilterBar, type FilterOption } from "./transactions-filter-bar";
 
 const SPENDING_TAXONOMY = "spending_categories";
 const INCOME_TAXONOMY = "income_sources";

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -2,14 +2,14 @@ import { getAccounts } from "@/adapters";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { SwipablePage, type SwipablePageView } from "@/components/page";
 import {
-  SpendingTransactionsTab,
-  type SpendingTransactionsTabHandle,
+    SpendingTransactionsTab,
+    type SpendingTransactionsTabHandle,
 } from "@/features/spending/components/spending-transactions-tab";
 import { useSpendingSettings } from "@/features/spending/hooks/use-spending-settings";
 import { SyncButton } from "@/features/wealthfolio-connect/components/sync-button";
 import { usePersistentState } from "@/hooks/use-persistent-state";
-import { usePortfolios } from "@/hooks/use-portfolios";
 import { useIsCompactTableViewport, useIsMobileViewport } from "@/hooks/use-platform";
+import { usePortfolios } from "@/hooks/use-portfolios";
 import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import { ActivityType } from "@/lib/constants";
 import { debounce } from "@/lib/debounce";
@@ -32,16 +32,16 @@ import { ActivityPagination } from "./components/activity-pagination";
 import ActivityTable from "./components/activity-table/activity-table";
 import ActivityTableMobile from "./components/activity-table/activity-table-mobile";
 import { ActivityViewControls, type ActivityViewMode } from "./components/activity-view-controls";
-import { NeedsReviewBanner } from "./components/needs-review-banner";
 import { BulkHoldingsModal } from "./components/forms/bulk-holdings-modal";
 import { MobileActivityForm } from "./components/mobile-forms/mobile-activity-form";
+import { NeedsReviewBanner } from "./components/needs-review-banner";
 import { TransferMatchDialog } from "./components/transfer-match-dialog";
 import { useActivityActionDialogs } from "./hooks/use-activity-action-dialogs";
 import { useActivitySearch, type ActivityStatusFilter } from "./hooks/use-activity-search";
 import {
-  clearActivityUrlFilters,
-  resolveActivityTabFromUrlFilters,
-  resolveActivityUrlFilters,
+    clearActivityUrlFilters,
+    resolveActivityTabFromUrlFilters,
+    resolveActivityUrlFilters,
 } from "./utils/url-filters";
 
 interface ActivityDateRangeFilter {

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -603,7 +603,7 @@ const ActivityPage = () => {
           onOpenChange={setShowActionPalette}
           groups={actionPaletteGroups}
           trigger={
-            <Button data-testid="add-activities-button" size="sm">
+            <Button type="button" data-testid="add-activities-button" size="sm">
               <Icons.Plus className="mr-2 h-4 w-4" />
               {t("activity:page.add_activities")}
             </Button>
@@ -672,7 +672,7 @@ const ActivityPage = () => {
           onOpenChange={setShowSpendingActionPalette}
           groups={spendingActionPaletteGroups}
           trigger={
-            <Button data-testid="add-activities-button" size="sm">
+            <Button type="button" data-testid="add-activities-button" size="sm">
               <Icons.Plus className="mr-2 h-4 w-4" />
               {t("activity:page.add_activities")}
             </Button>
@@ -690,6 +690,7 @@ const ActivityPage = () => {
         <Button
           size="icon"
           title={t("common:add")}
+          type="button"
           onClick={() => spendingTabRef.current?.openAddForm()}
         >
           <Icons.Plus className="size-4" />


### PR DESCRIPTION
## Description

### Problem

On iPhone/Safari, opening the Spending transaction form could trigger an implicit form submission. This caused a new expense transaction to be created immediately with an amount of `0` and the form to close.

### Fix

- Explicitly set the transaction creation buttons to `type="button"`.
- Prevent accidental parent-form submissions when opening the transaction form.
- Applied the fix to both mobile and desktop transaction entry points.

### Testing

- ESLint passed for the modified files.
- Verified that the final diff only contains the button type changes.
- The global frontend type-check still reports unrelated pre-existing workspace errors.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).