### PR TITLE
fix: preserve activity currency when editing on mobile

### DIFF
--- a/apps/frontend/src/pages/activity/components/mobile-forms/__tests__/mobile-currency.test.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/__tests__/mobile-currency.test.tsx
@@ -1,0 +1,74 @@
+import { ActivityType } from "@/lib/constants";
+import { render, screen, waitFor } from "@/test/render";
+import userEvent from "@testing-library/user-event";
+import { useRef } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import type { AccountSelectOption } from "../../forms/fields";
+import type { NewActivityFormValues } from "../../forms/schemas";
+import { MobileDetailsStep } from "../mobile-details-step";
+
+vi.mock("@/lib/settings-provider", () => ({
+  useSettingsContext: () => ({ settings: { baseCurrency: "CAD" } }),
+}));
+
+const accounts: AccountSelectOption[] = [
+  { value: "cad-account", label: "CAD account", currency: "CAD" },
+];
+
+function TestForm({
+  currency,
+  options = accounts,
+  onSubmit = vi.fn(),
+}: {
+  currency: string;
+  options?: AccountSelectOption[];
+  onSubmit?: (values: NewActivityFormValues) => void;
+}) {
+  const form = useForm<NewActivityFormValues>({
+    defaultValues: {
+      activityType: ActivityType.DEPOSIT,
+      accountId: "cad-account",
+      activityDate: new Date("2026-09-01T12:00:00Z"),
+      amount: 100,
+      currency,
+    },
+  });
+  const amountWasEdited = useRef(false);
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <MobileDetailsStep
+          accounts={options}
+          activityType={ActivityType.DEPOSIT}
+          isEditing
+          amountWasEdited={amountWasEdited}
+        />
+        <output data-testid="currency">{form.watch("currency")}</output>
+        <button type="submit">Save test activity</button>
+      </form>
+    </FormProvider>
+  );
+}
+
+describe("mobile activity currency backfill", () => {
+  it("preserves a stored activity currency when saving without edits", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm currency="USD" onSubmit={onSubmit} />);
+    await userEvent.setup().click(screen.getByRole("button", { name: "Save test activity" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].currency).toBe("USD");
+  });
+
+  it("preserves the stored currency when account options arrive later", async () => {
+    const { rerender } = render(<TestForm currency="USD" options={[]} />);
+    rerender(<TestForm currency="USD" />);
+    await waitFor(() => expect(screen.getByTestId("currency")).toHaveTextContent("USD"));
+  });
+
+  it("still fills an empty currency when account options arrive later", async () => {
+    const { rerender } = render(<TestForm currency="" options={[]} />);
+    rerender(<TestForm currency="" />);
+    await waitFor(() => expect(screen.getByTestId("currency")).toHaveTextContent("CAD"));
+  });
+});

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -375,7 +375,7 @@ export function MobileDetailsStep({
     const currentCurrency = currency?.trim();
     if (currentCurrency === selected.currency) return;
 
-    const shouldAutoSetCurrency = !getFieldState("currency").isDirty || !currentCurrency;
+    const shouldAutoSetCurrency = !currentCurrency && !getFieldState("currency").isDirty;
     if (!shouldAutoSetCurrency) return;
 
     setValue("currency", selected.currency, {


### PR DESCRIPTION
## Description

Fixes #1715.

The mobile details step treated an untouched currency as eligible for account
currency backfill, including a non-empty currency loaded from an existing
activity. Opening a USD activity in a CAD account therefore replaced USD before
the user made any changes.

Only backfill an empty, untouched currency, matching the desktop AccountSelect
effect. Explicit account selection retains its existing behavior.

Regression tests render the real MobileDetailsStep with React Hook Form and
cover saving the stored currency unchanged, late-arriving account options, and
backfilling an empty currency. The first two fail on the previous condition.

Validation (Node 24.18.1, pnpm 10.33.4):

- `pnpm check`: passed (formatting, lint, workspace types).
- `pnpm test --run`: 266 files / 2234 tests passed on the full rerun. An initial
  run alongside browser tests hit a 5-second timeout in an unchanged spending
  date-picker test; its isolated 6-test suite and the complete rerun passed
  without changing timeouts or tests.
- `pnpm build` and `pnpm build:tauri`: passed.
- Translation checker: 7 tests and 20 namespaces passed.
- `pnpm test:e2e:net-worth`: 48 passed.
- Addon sandbox suite: 9 passed using the pinned Chromium, Firefox and WebKit
  with a fresh Web build on an isolated loopback port.

AI assistance: implemented and validated with OpenAI Codex. No physical-device
or native Android build verification is claimed.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
